### PR TITLE
Emmanuel/hit forced

### DIFF
--- a/Docs/sphinx_doc/Algorithms.rst
+++ b/Docs/sphinx_doc/Algorithms.rst
@@ -1,10 +1,3 @@
-.. highlight:: rst
-
- .. role:: cpp(code)
-    :language: c++
- 
- .. role:: fortran(code)
-    :language: fortran
 
 .. _GettingStarted:
 

--- a/Docs/sphinx_doc/Algorithms.rst
+++ b/Docs/sphinx_doc/Algorithms.rst
@@ -2,6 +2,8 @@
 .. _GettingStarted:
 
 
+.. Warning:: This documentation is a placeholder, and contents should currently be considered a work in progress, out of context, or just plain wrong until this note is removed!
+
 Algorithms
 ==========
 

--- a/Docs/sphinx_doc/Introduction.rst
+++ b/Docs/sphinx_doc/Introduction.rst
@@ -1,5 +1,8 @@
 .. highlight:: rst
 
+.. Warning:: This documentation is a placeholder, and contents should currently be considered a work in progress, out of context, or just plain wrong until this note is removed!
+
+
 Introduction
 ============
 

--- a/Docs/sphinx_doc/conf.py
+++ b/Docs/sphinx_doc/conf.py
@@ -19,7 +19,7 @@
 # import os
 import sys
 # sys.path.insert(0, os.path.abspath('.'))
-sys.path.append("../breathe")
+#sys.path.append("../breathe")
 
 # -- General configuration ------------------------------------------------
 
@@ -30,15 +30,13 @@ sys.path.append("../breathe")
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['breathe',
-              'sphinx.ext.mathjax',
-              'sphinxfortran.fortran_domain']
+extensions = [ 'sphinx.ext.mathjax']
 
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
-breathe_projects = {"PeleC": "../doxygen_output/xml/"}
-breathe_default_project = "PeleC"
+#breathe_projects = {"PeleC": "../doxygen_output/xml/"}
+#breathe_default_project = "PeleC"
 
 fortran_src ='../../Source/Src_2d/'
 #fortran_ext =[' 'F90']

--- a/Docs/sphinx_doc/geometry/amrex_geometry.rst
+++ b/Docs/sphinx_doc/geometry/amrex_geometry.rst
@@ -9,28 +9,9 @@ There are a few key AMReX facilities used to enable the EB capability.
     Preprocessor variable to enable AMReX-EB related operations. In PeleC used to control call of initialization routines for EB geometry (in main.cpp).
 
 
-.. doxygenclass:: amrex::EBFArrayBox
-   :members:
-   :undoc-members:
-
-.. doxygenfunction:: amrex::EBFArrayBox::getEBCellFlagFab
-
-.. doxygenenum:: amrex::FabType
 
 .. _geom:
 
-.. doxygenclass:: amrex::GeometryShop
 
 
-.. f:function:: amrex_ebcellflag_module/get_neighbor_cells
-    :p flag: Flag encoding information about neighbor cells
-    :p nbr: A 3x3x3 (3x3 in 2D) returning 0 if cell is covered
-
-    This returns 1 if the neighbor cell is connected, and 0 if not. There is an alternative version `get_neighbor_cells_real` that returns floating point values.
-
-
-.. f:function:: amrex_ebcellflag_module/is_regular_cell
-    :p flag: Flag encoding information about neighbor cells
-
-    This returns 1 if the cell is a regular cell, and 0 if it is a cut cell. 
 

--- a/Exec/HIT_forced/GNUmakefile
+++ b/Exec/HIT_forced/GNUmakefile
@@ -1,0 +1,35 @@
+PRECISION  = DOUBLE
+PROFILE    = FALSE
+USE_EB     = FALSE
+DEBUG      = FALSE
+
+DIM        = 3 
+
+COMP	   = gcc
+
+USE_MPI    = TRUE
+USE_OMP    = FALSE
+
+#HYP_TYPE = MOL
+
+# define the location of the PELE top directory
+PELE_HOME    := ../../..
+
+# This sets the EOS directory in $(PELE_PHYSICS_HOME)/Eos
+Eos_dir     := GammaLaw
+
+# This sets the network directory in $(PELE_PHYSICS_HOME)/Reactions
+Reactions_dir := Null
+
+# This sets the transport directory in $(PELE_PHYSICS_HOME)/Transport
+Transport_dir := Constant
+
+Bpack   := ./Make.package
+
+include ../Make.PeleC
+
+DEFINES += -DO_HIT_FORCE
+
+ifeq ($(DEBUG), TRUE)
+DEFINES += -DDEBUG
+endif

--- a/Exec/HIT_forced/Make.package
+++ b/Exec/HIT_forced/Make.package
@@ -1,0 +1,4 @@
+f90EXE_sources += probdata.f90
+
+BOXLIB_BASE=EXE
+

--- a/Exec/HIT_forced/Prob_nd.F90
+++ b/Exec/HIT_forced/Prob_nd.F90
@@ -1,0 +1,615 @@
+module pc_prob_module
+
+#include <AMReX_CONSTANTS.H>
+
+  implicit none
+
+  private
+
+  public :: amrex_probinit, pc_initdata, pc_prob_close
+
+contains
+
+  subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(C, name = "amrex_probinit")
+
+    use parallel
+    use probdata_module
+    use bl_error_module
+    use bl_constants_module, only: HALF
+    use network, only: nspec, naux, molec_wt
+    use extern_probin_module, only: const_viscosity, const_bulk_viscosity, const_conductivity, const_diffusivity
+    use eos_module
+
+    implicit none
+
+    integer :: init, namlen
+    integer :: name(namlen)
+    double precision :: problo(3), probhi(3)
+    integer untin,i
+
+    namelist /fortin/ restart, lambda0, reynolds_lambda0, mach_t0, prandtl, &
+                      spectrum_type, mode_start, nmodes, &
+                      force_scale, forcing_time_scale_min, forcing_time_scale_max, &
+                      forcing_time_scale_min, forcing_time_scale_max, &
+                      time_offset, div_free_force
+
+    ! Build "probin" filename -- the name of file containing fortin namelist.
+    integer, parameter :: maxlen = 256
+    character probin*(maxlen)
+
+    ! Local
+    double precision :: twicePi, kxd, kyd, kzd, rn
+    double precision :: thetaTmp, phiTmp
+    double precision :: cosThetaTmp, cosPhiTmp
+    double precision :: sinThetaTmp, sinPhiTmp
+    double precision :: px, py, pz, mp2, Ekh
+    integer :: kx, ky, kz, mode_count, reduced_mode_count
+    integer :: modx, mody, modz, xstep, ystep, zstep
+    integer :: iseed
+    integer :: nxmodes, nymodes, nzmodes
+
+    double precision :: Lmin
+    double precision :: kappa, kappaMax, freqMin, freqMax, freqDiff, pdk
+
+
+    integer, parameter :: out_unit=20
+    type(eos_t) :: eos_state
+    integer(kind=8) :: n
+
+    if (namlen .gt. maxlen) then
+       call bl_error('probin file name too long')
+    end if
+
+    do i = 1, namlen
+       probin(i:i) = char(name(i))
+    end do
+
+    ! set namelist defaults here
+    restart = .false.
+    lambda0 = 0.5_dp_t
+    reynolds_lambda0 = 100.0_dp_t
+    mach_t0 = 0.1_dp_t
+    prandtl = 0.71_dp_t
+
+    div_free_force = 0 
+    spectrum_type          = 0
+    mode_start             = 1
+    nmodes                 = 4
+    force_scale            = 1.0d10
+    forcing_time_scale_min = 0.0
+    forcing_time_scale_max = 0.0
+  
+
+    ! Initial pressure and temperature
+    p0 = 1013250.0d0 ! [erg cm^-3]
+    T0 = 1200.d0
+
+    ! Read namelists
+    untin = 9
+    open(untin,file=probin(1:namlen),form='formatted',status='old')
+    read(untin,fortin)
+    close(unit=untin)
+
+    ! set local variable defaults
+    Lx = probhi(1) - problo(1)
+    Ly = probhi(2) - problo(2)
+    Lz = probhi(3) - problo(3)
+
+    ! Define the molecular weight for air
+    molec_wt = 28.97
+
+    ! Wavelength associated to Taylor length scale
+    k0 = 2.d0/lambda0
+
+    ! Set the equation of state variables
+    call build(eos_state)
+    eos_state % p = p0
+    eos_state % T = T0
+    eos_state % massfrac    = 0.d0
+    eos_state % massfrac(1) = 1.0d0
+    call eos_tp(eos_state)
+
+    ! Initial density, velocity, and material properties
+    rho0  = eos_state % rho
+    eint0 = eos_state % e
+    urms0 = mach_t0 * eos_state % cs / sqrt(3.d0)
+    tau  = lambda0 / urms0
+    const_bulk_viscosity = 0.d0
+    const_diffusivity = 0.d0
+    const_viscosity = rho0 * urms0 * lambda0 / reynolds_lambda0
+    const_conductivity = const_viscosity * eos_state % cp / prandtl
+
+    ! Write this out to file (might be useful for postprocessing)
+     if ( parallel_ioprocessor() ) then
+       open(unit=out_unit,file="ic.txt",action="write",status="replace")
+       write(out_unit,*)"lambda0, k0, rho0, urms0, tau, p0, T0, mu, k, c_s0, Reynolds, Mach, Prandtl"
+       write(out_unit,*) lambda0, "," , k0, "," , eos_state % rho, "," , urms0, "," , tau, "," , &
+            eos_state % p, "," , eos_state % T, "," , const_viscosity, "," , &
+            const_conductivity, "," , eos_state % cs, "," , &
+            reynolds_lambda0, "," , mach_t0, "," , prandtl
+       close(out_unit)
+    endif
+
+
+    if ( parallel_ioprocessor() ) then
+       write (*,*) "Initialising random number generator..."
+    end if
+
+    twicePi = two*Pi
+
+    if (blrandseed.gt.0) then
+       call blutilinitrand(blrandseed)
+       call blutilrand(rn)
+       call blutilinitrand(blrandseed)
+       if ( parallel_ioprocessor() ) then
+          write (*,*) "blrandseed = ",blrandseed
+          write (*,*) "first random number = ",rn
+       endif
+    else
+       call blutilinitrand(111397)
+    endif
+
+    if ( parallel_ioprocessor() ) then
+       write(*,*) "Lx = ",Lx
+       write(*,*) "Ly = ",Ly
+       write(*,*) "Lz = ",Lz
+    endif
+
+    Lmin = min(Lx,Ly,Lz)
+    kappaMax = dfloat(nmodes)/Lmin + 1.0d-8
+    nxmodes = nmodes*int(0.5+Lx/Lmin)
+    nymodes = nmodes*int(0.5+Ly/Lmin)
+    nzmodes = nmodes*int(0.5+Lz/Lmin)
+    if ( parallel_ioprocessor() ) then 
+      write(*,*) "Lmin = ",Lmin
+      write(*,*) "kappaMax = ",kappaMax
+      write(*,*) "nxmodes = ",nxmodes
+      write(*,*) "nymodes = ",nymodes
+      write(*,*) "nzmodes = ",nzmodes
+    endif
+
+    allocate(FTX(1:nxmodes, 1:nymodes, 1:nzmodes))
+    allocate(FTY(1:nxmodes, 1:nymodes, 1:nzmodes))
+    allocate(FTZ(1:nxmodes, 1:nymodes, 1:nzmodes))
+    allocate(TAT(1:nxmodes, 1:nymodes, 1:nzmodes))
+    allocate(TAP(1:nxmodes, 1:nymodes, 1:nzmodes))
+
+    allocate(FPX(1:nxmodes, 1:nymodes, 1:nzmodes))
+    allocate(FPY(1:nxmodes, 1:nymodes, 1:nzmodes))
+    allocate(FPZ(1:nxmodes, 1:nymodes, 1:nzmodes))
+    allocate(FAX(1:nxmodes, 1:nymodes, 1:nzmodes))
+    allocate(FAY(1:nxmodes, 1:nymodes, 1:nzmodes))
+    allocate(FAZ(1:nxmodes, 1:nymodes, 1:nzmodes))
+
+    allocate(FPXX(1:nxmodes, 1:nymodes, 1:nzmodes))
+    allocate(FPYX(1:nxmodes, 1:nymodes, 1:nzmodes))
+    allocate(FPZX(1:nxmodes, 1:nymodes, 1:nzmodes))
+    allocate(FPXY(1:nxmodes, 1:nymodes, 1:nzmodes))
+    allocate(FPYY(1:nxmodes, 1:nymodes, 1:nzmodes))
+    allocate(FPZY(1:nxmodes, 1:nymodes, 1:nzmodes))
+    allocate(FPXZ(1:nxmodes, 1:nymodes, 1:nzmodes))
+    allocate(FPYZ(1:nxmodes, 1:nymodes, 1:nzmodes))
+    allocate(FPZZ(1:nxmodes, 1:nymodes, 1:nzmodes))
+
+
+    if (forcing_time_scale_min.eq.zero) then
+      forcing_time_scale_min = half
+    endif
+    if (forcing_time_scale_max.eq.zero) then
+       forcing_time_scale_max = one
+    endif
+
+    freqMin = one/forcing_time_scale_max
+    freqMax = one/forcing_time_scale_min
+    freqDiff= freqMax-freqMin
+
+    if ( parallel_ioprocessor() ) then
+       write(*,*) "forcing_time_scale_min = ",forcing_time_scale_min
+       write(*,*) "forcing_time_scale_max = ",forcing_time_scale_max
+       write(*,*) "freqMin = ",freqMin
+       write(*,*) "freqMax = ",freqMax
+       write(*,*) "freqDiff = ",freqDiff
+    endif
+
+    mode_count = 0
+
+    xstep = int(Lx/Lmin+0.5)
+    ystep = int(Ly/Lmin+0.5)
+    zstep = int(Lz/Lmin+0.5)
+    if ( parallel_ioprocessor() ) then
+      write (*,*) "Mode step ",xstep, ystep, zstep
+    endif
+
+    do kz = mode_start*zstep, nzmodes, zstep
+       kzd = dfloat(kz)
+       do ky = mode_start*ystep, nymodes, ystep
+          kyd = dfloat(ky)
+          do kx = mode_start*xstep, nxmodes, xstep
+             kxd = dfloat(kx)
+
+             kappa = sqrt( (kxd*kxd)/(Lx*Lx) + (kyd*kyd)/(Ly*Ly) + (kzd*kzd)/(Lz*Lz) )
+
+             if (kappa.le.kappaMax) then
+                call blutilrand(rn)
+                FTX(kx,ky,kz) = (freqMin + freqDiff*rn)*twicePi
+                call blutilrand(rn)
+                FTY(kx,ky,kz) = (freqMin + freqDiff*rn)*twicePi
+                call blutilrand(rn)
+                FTZ(kx,ky,kz) = (freqMin + freqDiff*rn)*twicePi
+!     Translation angles, theta=0..2Pi and phi=0..Pi
+                call blutilrand(rn)
+                TAT(kx,ky,kz) = rn*twicePi
+                call blutilrand(rn)
+                TAP(kx,ky,kz) = rn*Pi
+!     Phases
+                call blutilrand(rn)
+                FPX(kx,ky,kz) = rn*twicePi
+                call blutilrand(rn)
+                FPY(kx,ky,kz) = rn*twicePi
+                call blutilrand(rn)
+                FPZ(kx,ky,kz) = rn*twicePi
+                if (div_free_force.eq.1) then
+                  call blutilrand(rn)
+                  FPXX(kx,ky,kz) = rn*twicePi
+                  call blutilrand(rn)
+                  FPYX(kx,ky,kz) = rn*twicePi
+                  call blutilrand(rn)
+                  FPZX(kx,ky,kz) = rn*twicePi
+                  call blutilrand(rn)
+                  FPXY(kx,ky,kz) = rn*twicePi
+                  call blutilrand(rn)
+                  FPYY(kx,ky,kz) = rn*twicePi
+                  call blutilrand(rn)
+                  FPZY(kx,ky,kz) = rn*twicePi
+                  call blutilrand(rn)
+                  FPXZ(kx,ky,kz) = rn*twicePi
+                  call blutilrand(rn)
+                  FPYZ(kx,ky,kz) = rn*twicePi
+                  call blutilrand(rn)
+                  FPZZ(kx,ky,kz) = rn*twicePi
+                endif
+!     Amplitudes (alpha)
+                call blutilrand(rn)
+                thetaTmp      = rn*twicePi
+                cosThetaTmp   = cos(thetaTmp)
+                sinThetaTmp   = sin(thetaTmp)
+                call blutilrand(rn)
+                phiTmp        = rn*Pi
+                cosPhiTmp     = cos(phiTmp)
+                sinPhiTmp     = sin(phiTmp)
+
+                px = cosThetaTmp * sinPhiTmp
+                py = sinThetaTmp * sinPhiTmp
+                pz =               cosPhiTmp
+
+                mp2           = px*px + py*py + pz*pz
+                if (kappa .lt. 0.000001) then
+                  if ( parallel_ioprocessor() ) then
+                     write(*,*) "ZERO AMPLITUDE MODE ",kx,ky,kz
+                  endif
+                  FAX(kx,ky,kz) = zero
+                  FAY(kx,ky,kz) = zero
+                  FAZ(kx,ky,kz) = zero
+                else
+!     Count modes that contribute
+                   mode_count = mode_count + 1
+!     Set amplitudes
+                   if (spectrum_type.eq.1) then
+                       Ekh        = one / kappa
+                   else if (spectrum_type.eq.2) then
+                       Ekh        = one / (kappa*kappa)
+                   else
+                       Ekh        = one
+                   endif
+
+                   if (div_free_force.eq.1) then
+                       Ekh = Ekh / kappa
+                   endif
+
+                   if (moderate_zero_modes.eq.1) then
+                           if (kx.eq.0) Ekh = Ekh / two
+                           if (ky.eq.0) Ekh = Ekh / two
+                           if (kz.eq.0) Ekh = Ekh / two
+                   endif
+
+                   if (force_scale.gt.zero) then
+                           FAX(kx,ky,kz) = force_scale * px * Ekh / mp2
+                           FAY(kx,ky,kz) = force_scale * py * Ekh / mp2
+                           FAZ(kx,ky,kz) = force_scale * pz * Ekh / mp2
+                   else
+                           FAX(kx,ky,kz) = px * Ekh / mp2
+                           FAY(kx,ky,kz) = py * Ekh / mp2
+                           FAZ(kx,ky,kz) = pz * Ekh / mp2
+                   endif
+
+                   if ( parallel_ioprocessor() ) then 
+                           write (*,*) "Mode"
+                           write (*,*) "kappa = ",kx,ky,kz,kappa, sqrt(FAX(kx,ky,kz)**2+FAY(kx,ky,kz)**2+FAZ(kx,ky,kz)**2)
+                           write (*,*) "Amplitudes - A"
+                           write (*,*) FAX(kx,ky,kz), FAY(kx,ky,kz), FAZ(kx,ky,kz)
+                           write (*,*) "Frequencies"
+                           write (*,*) FTX(kx,ky,kz), FTY(kx,ky,kz), FTZ(kx,ky,kz)
+                    endif
+
+                endif
+             endif
+
+
+          enddo
+       enddo
+    enddo
+
+
+!    Now let's break symmetry, have to assume high aspect ratio in z for now
+    reduced_mode_count = 0
+    do kz = 1, zstep - 1
+      kzd = dfloat(kz)
+      do ky = mode_start, nymodes
+         kyd = dfloat(ky)
+         do kx = mode_start, nxmodes
+            kxd = dfloat(kx)
+
+            kappa = sqrt( (kxd*kxd)/(Lx*Lx) + (kyd*kyd)/(Ly*Ly) + (kzd*kzd)/(Lz*Lz) )
+            if (kappa.le.kappaMax) then
+                call blutilrand(rn)
+                FTX(kx,ky,kz) = (freqMin + freqDiff*rn)*twicePi
+                call blutilrand(rn)
+                FTY(kx,ky,kz) = (freqMin + freqDiff*rn)*twicePi
+                call blutilrand(rn)
+                FTZ(kx,ky,kz) = (freqMin + freqDiff*rn)*twicePi
+!     Translation angles, theta=0..2Pi and phi=0..Pi
+                call blutilrand(rn)
+                TAT(kx,ky,kz) = rn*twicePi
+                call blutilrand(rn)
+                TAP(kx,ky,kz) = rn*Pi
+!     Phases
+                call blutilrand(rn)
+                FPX(kx,ky,kz) = rn*twicePi
+                call blutilrand(rn)
+                FPY(kx,ky,kz) = rn*twicePi
+                call blutilrand(rn)
+                FPZ(kx,ky,kz) = rn*twicePi
+                if (div_free_force.eq.1) then
+                   call blutilrand(rn)
+                   FPXX(kx,ky,kz) = rn*twicePi
+                   call blutilrand(rn)
+                   FPYX(kx,ky,kz) = rn*twicePi
+                   call blutilrand(rn)
+                   FPZX(kx,ky,kz) = rn*twicePi
+                   call blutilrand(rn)
+                   FPXY(kx,ky,kz) = rn*twicePi
+                   call blutilrand(rn)
+                   FPYY(kx,ky,kz) = rn*twicePi
+                   call blutilrand(rn)
+                   FPZY(kx,ky,kz) = rn*twicePi
+                   call blutilrand(rn)
+                   FPXZ(kx,ky,kz) = rn*twicePi
+                   call blutilrand(rn)
+                   FPYZ(kx,ky,kz) = rn*twicePi
+                   call blutilrand(rn)
+                   FPZZ(kx,ky,kz) = rn*twicePi
+                endif
+!     Amplitudes (alpha)
+                call blutilrand(rn)
+                thetaTmp      = rn*twicePi
+                cosThetaTmp   = cos(thetaTmp)
+                sinThetaTmp   = sin(thetaTmp)
+                call blutilrand(rn)
+                phiTmp        = rn*Pi
+                cosPhiTmp     = cos(phiTmp)
+                sinPhiTmp     = sin(phiTmp)
+
+                px = cosThetaTmp * sinPhiTmp
+                py = sinThetaTmp * sinPhiTmp
+                pz =               cosPhiTmp
+
+                mp2           = px*px + py*py + pz*pz
+                if (kappa .lt. 0.000001) then
+                   if ( parallel_ioprocessor() ) then  
+                      write(*,*) "ZERO AMPLITUDE MODE ",kx,ky,kz
+                   endif
+                   FAX(kx,ky,kz) = zero
+                   FAY(kx,ky,kz) = zero
+                   FAZ(kx,ky,kz) = zero
+                else
+!     Count modes that contribute
+                  reduced_mode_count = reduced_mode_count + 1
+!     Set amplitudes
+                  if (spectrum_type.eq.1) then
+                    Ekh        = one / kappa
+                  else if (spectrum_type.eq.2) then
+                    Ekh        = one / (kappa*kappa)
+                  else
+                    Ekh        = one
+                  endif
+         
+                  if (div_free_force.eq.1) then
+                    Ekh = Ekh / kappa
+                  endif
+
+                  if (moderate_zero_modes.eq.1) then
+                    if (kx.eq.0) Ekh = Ekh / two
+                    if (ky.eq.0) Ekh = Ekh / two
+                    if (kz.eq.0) Ekh = Ekh / two
+                  endif
+                  if (force_scale.gt.zero) then
+                    FAX(kx,ky,kz) = forcing_epsilon * force_scale * px * Ekh / mp2
+                    FAY(kx,ky,kz) = forcing_epsilon * force_scale * py * Ekh / mp2
+                    FAZ(kx,ky,kz) = forcing_epsilon * force_scale * pz * Ekh / mp2
+                  else
+                    FAX(kx,ky,kz) = forcing_epsilon * px * Ekh / mp2
+                    FAY(kx,ky,kz) = forcing_epsilon * py * Ekh / mp2
+                    FAZ(kx,ky,kz) = forcing_epsilon * pz * Ekh / mp2
+                  endif
+
+                  if ( parallel_ioprocessor() ) then       
+                     write (*,*) "Mode"
+                     write (*,*) "kappa = ",kx,ky,kz,kappa, sqrt(FAX(kx,ky,kz)**2+FAY(kx,ky,kz)**2+FAZ(kx,ky,kz)**2)
+                     write (*,*) "Amplitudes - B"
+                     write (*,*) FAX(kx,ky,kz), FAY(kx,ky,kz), FAZ(kx,ky,kz)
+                     write (*,*) "Frequencies"
+                     write (*,*) FTX(kx,ky,kz), FTY(kx,ky,kz), FTZ(kx,ky,kz)
+                  endif
+                endif
+            endif
+
+
+          enddo
+       enddo
+    enddo
+
+    if ( parallel_ioprocessor() ) then
+       write(*,*) "mode_count = ",mode_count
+       write(*,*) "reduced_mode_count = ",reduced_mode_count
+       if (spectrum_type.eq.1) then
+          write (*,*) "Spectrum type 1"
+       else if (spectrum_type.eq.2) then
+          write (*,*) "Spectrum type 2"
+       else
+          write (*,*) "Spectrum type OTHER"
+       endif
+    endif
+
+
+  end subroutine amrex_probinit
+
+
+  ! ::: -----------------------------------------------------------
+  ! ::: This routine is called at problem setup time and is used
+  ! ::: to initialize data on each grid.
+  ! :::
+  ! ::: NOTE:  all arrays have one cell of ghost zones surrounding
+  ! :::        the grid interior.  Values in these cells need not
+  ! :::        be set here.
+  ! :::
+  ! ::: INPUTS/OUTPUTS:
+  ! :::
+  ! ::: level     => amr level of grid
+  ! ::: time      => time at which to init data
+  ! ::: lo,hi     => index limits of grid interior (cell centered)
+  ! ::: nstate    => number of state components.  You should know
+  ! :::		   this already!
+  ! ::: state     <=  Scalar array
+  ! ::: delta     => cell size
+  ! ::: xlo,xhi   => physical locations of lower left and upper
+  ! :::              right hand corner of grid.  (does not include
+  ! :::		   ghost region).
+  ! ::: -----------------------------------------------------------
+  subroutine pc_initdata(level,time,lo,hi,nvar, &
+       state,state_lo,state_hi, &
+       delta,xlo,xhi) bind(C, name = "pc_initdata")
+
+    use probdata_module
+    use network, only: nspec, naux, molec_wt
+    use eos_type_module
+    use meth_params_module, only : URHO, UMX, UMY, UMZ, &
+         UEDEN, UEINT, UFS, UTEMP
+    use bl_constants_module, only: ZERO, HALF, M_PI
+    use eos_module
+
+    implicit none
+
+    integer :: level, nvar
+    integer :: lo(3), hi(3)
+    integer :: state_lo(3),state_hi(3)
+    double precision :: xlo(3), xhi(3), time, delta(3)
+    double precision :: state(state_lo(1):state_hi(1), &
+         state_lo(2):state_hi(2), &
+         state_lo(3):state_hi(3),nvar)
+
+    type(eos_t) :: eos_state
+    integer :: i, j, k
+    double precision :: x, y, z
+    double precision :: uinterp, vinterp, winterp
+
+    ! Define the molecular weight for air
+    molec_wt = 28.97
+
+    ! Set the equation of state variables
+    call build(eos_state)
+    eos_state % p = p0
+    eos_state % T = T0
+    eos_state % massfrac    = 0.d0
+    eos_state % massfrac(1) = 1.0d0
+
+    call eos_tp(eos_state)
+
+    ! Uniform density, temperature, pressure (internal energy)
+    state(:,:,:,URHO)            = rho0
+    do i = 1,nspec
+       state(:,:,:,UFS+i-1)      = rho0 * eos_state % massfrac(i)
+    enddo
+    state(:,:,:,UTEMP)           = T0
+    state(:,:,:,UEINT)           = rho0 * eint0
+
+    ! Fill in the velocities and energy.
+    do k = lo(3), hi(3)
+       z = xlo(3) + delta(3)*(dble(k-lo(3)) + HALF)
+
+       do j = lo(2), hi(2)
+          y = xlo(2) + delta(2)*(dble(j-lo(2)) + HALF)
+
+          do i = lo(1), hi(1)
+             x = xlo(1) + delta(1)*(dble(i-lo(1)) + HALF)
+
+             uinterp = 0.0d0
+             vinterp = 0.0d0
+             winterp = 0.0d0
+
+             state(i,j,k,UMX)   = state(i,j,k,URHO) * uinterp
+             state(i,j,k,UMY)   = state(i,j,k,URHO) * vinterp
+             state(i,j,k,UMZ)   = state(i,j,k,URHO) * winterp
+             state(i,j,k,UEDEN) = state(i,j,k,UEINT) + HALF * state(i,j,k,URHO) * (uinterp**2 + vinterp**2 + winterp**2)
+          enddo
+       enddo
+    enddo
+
+  end subroutine pc_initdata
+
+  subroutine pc_prob_close() &
+       bind(C, name="pc_prob_close")
+
+  end subroutine pc_prob_close
+
+
+
+  ! ::: -----------------------------------------------------------
+  ! ::: Calculate the Taylor length scale in x-direction.
+  ! :::    lambda = <u^2>/<(du/dx)^2>
+  ! :::
+  ! ::: INPUTS/OUTPUTS:
+  ! :::
+  ! ::: u(n,n,n) => input velocity array
+  ! ::: x(n,n,n) => input coordinate array
+  ! ::: n        => size of array
+  ! ::: lambda  <=> lambda
+  ! ::: -----------------------------------------------------------
+  subroutine calculate_taylor_microscale(u, x, n, lambda)
+
+    implicit none
+
+    double precision, intent(in) :: u(n,n,n)
+    double precision, intent(in) :: x(n,n,n)
+    integer, intent(in) :: n
+    double precision, intent(out) :: lambda
+
+    ! Local variables
+    integer :: i
+    double precision :: dudx2 = 0, u2 = 0
+
+    ! Square of velocity
+    u2 = sum(u(:,:,:)*u(:,:,:))
+
+    ! Calculate the gradients. Assume periodicity for the edges.
+    do i = 2, n-1
+       dudx2 = dudx2 + sum((u(i+1,:,:) - u(i-1,:,:))**2 / (x(i+1,:,:) - x(i-1,:,:))**2)
+    enddo
+    dudx2 = dudx2 + sum((u(2,:,:) - u(n,:,:))**2 / (x(2,:,:) - x(n,:,:))**2)
+    dudx2 = dudx2 + sum((u(1,:,:) - u(n-1,:,:))**2 / (x(1,:,:) - x(n-1,:,:))**2)
+
+    lambda = sqrt(u2/dudx2)
+
+    return
+  end subroutine calculate_taylor_microscale
+
+end module pc_prob_module

--- a/Exec/HIT_forced/forcing_src_nd.F90
+++ b/Exec/HIT_forced/forcing_src_nd.F90
@@ -1,0 +1,248 @@
+module forcing_src_module
+
+#include <AMReX_CONSTANTS.H>
+
+  implicit none
+
+  private
+
+  public :: pc_forcing_src
+
+contains
+
+  subroutine pc_forcing_src(lo,hi, &
+                            old_state,os_lo,os_hi, &
+                            new_state,ns_lo,ns_hi, &
+                            src,src_lo,src_hi,problo,dx,xlo,xhi, &
+                            time,dt) bind(C, name = "pc_forcing_src")
+
+    use bl_constants_module, only: ZERO, HALF
+    use meth_params_module, only : NVAR, URHO, UMX, UMY, UMZ
+    use prob_params_module, only: dim
+    use probdata_module
+
+    implicit none
+
+    integer,          intent(in   ) :: lo(3),hi(3)
+    integer,          intent(in   ) :: os_lo(3),os_hi(3)
+    integer,          intent(in   ) :: ns_lo(3),ns_hi(3)
+    integer,          intent(in   ) :: src_lo(3),src_hi(3)
+    double precision, intent(in   ) :: xlo(3), xhi(3)
+    double precision, intent(in   ) :: old_state(os_lo(1):os_hi(1),os_lo(2):os_hi(2),os_lo(3):os_hi(3),NVAR)
+    double precision, intent(in   ) :: new_state(ns_lo(1):ns_hi(1),ns_lo(2):ns_hi(2),ns_lo(3):ns_hi(3),NVAR)
+    double precision, intent(inout) :: src(src_lo(1):src_hi(1),src_lo(2):src_hi(2),src_lo(3):src_hi(3),NVAR)
+    double precision, intent(in   ) :: problo(3),dx(3),time,dt
+
+    ! local
+    integer :: i,j,k
+    integer :: kx, ky, kz
+    integer :: modx, mody, modz, xstep, ystep, zstep
+    integer :: nxmodes, nymodes, nzmodes
+    double precision :: f1, f2, f3
+    double precision :: HLx, HLy, HLz, hx, hy, hz 
+    double precision :: infl_time, kappa, kappaMax
+    double precision :: kxd, kyd, kzd
+    double precision :: Lmin, twicePi, xT, x, y, z
+
+
+!write(*,*) 'DEBUG ENTERING FORCING'
+
+
+
+    src(lo(1):hi(1),lo(2):hi(2),lo(3):hi(3),:) = ZERO
+
+!     Homogeneous Isotropic Turbulence
+    twicePi=two*Pi
+
+!     Adjust z offset for probtype 15
+    if (time_offset.gt.zero) then
+      infl_time = time + time_offset
+    else
+      infl_time = time
+    endif
+
+    Lmin = min(Lx,Ly,Lz)
+
+    kappaMax = dfloat(nmodes)/Lmin + 1.0d-8
+    nxmodes = nmodes*int(0.5+Lx/Lmin)
+    nymodes = nmodes*int(0.5+Ly/Lmin)
+    nzmodes = nmodes*int(0.5+Lz/Lmin)
+
+    xstep = int(Lx/Lmin+0.5)
+    ystep = int(Ly/Lmin+0.5)
+    zstep = int(Lz/Lmin+0.5)
+
+    HLx = Lx
+    HLy = Ly
+    HLz = Lz
+
+!    write(*,*) 'DEBUG FORCING',lo,hi,xlo
+!    write(*,*) 'DEBUG FORCING 2',infl_time,div_free_force,mode_start,nmodes,nxmodes,nymodes,nzmodes,xstep,ystep,zstep,HLx,HLy,HLz 
+
+!               do kz = mode_start*zstep, nzmodes, zstep
+!                  kzd = dfloat(kz)
+!                  do ky = mode_start*ystep, nymodes, ystep
+!                     kyd = dfloat(ky)
+!                     do kx = mode_start*xstep, nxmodes, xstep
+!                        kxd = dfloat(kx)
+!                        kappa = sqrt( (kxd*kxd)/(Lx*Lx) + (kyd*kyd)/(Ly*Ly) + (kzd*kzd)/(Lz*Lz) )
+!                        if (kappa.le.kappaMax) then
+!                           write (*,*) "Mode"
+!                           write (*,*) "kappa = ",kx,ky,kz,kappa
+!                           write (*,*) "Amplitudes - C"
+!                           write (*,*) FAX(kx,ky,kz), FAY(kx,ky,kz), FAZ(kx,ky,kz)
+!                           write (*,*) "Frequencies"
+!                           write (*,*) FTX(kx,ky,kz), FTY(kx,ky,kz), FTZ(kx,ky,kz)
+!                           write (*,*) "Phases"
+!                           write (*,*) FPX(kx,ky,kz), FPY(kx,ky,kz), FPZ(kx,ky,kz)
+!                           write (*,*) "TAT"
+!                           write (*,*) TAT(kx,ky,kz)
+!                        endif
+!                     enddo
+!                  enddo
+!               enddo
+
+
+!write(*,*) ""
+!write(*,*) "OK UNTIL HERE",infl_time
+!write(*,*) ""
+
+!write(*,*) 'DEBUG lo,hi,xlo',lo,hi,xlo
+
+    do k = lo(3), hi(3)
+       z = xlo(3) + dx(3)*(dble(k-lo(3)) + HALF)
+       do j = lo(2), hi(2)
+          y = xlo(2) + dx(2)*(dble(j-lo(2)) + HALF)
+          do i = lo(1), hi(1)
+             x = xlo(1) + dx(1)*(dble(i-lo(1)) + HALF)
+             f1 = zero
+             f2 = zero
+             f3 = zero
+
+             do kz = mode_start*zstep, nzmodes, zstep
+                kzd = dfloat(kz)
+                do ky = mode_start*ystep, nymodes, ystep
+                   kyd = dfloat(ky)
+                   do kx = mode_start*xstep, nxmodes, xstep
+                      kxd = dfloat(kx)
+                      kappa = sqrt( (kxd*kxd)/(Lx*Lx) + (kyd*kyd)/(Ly*Ly) + (kzd*kzd)/(Lz*Lz) )
+                      if (kappa.le.kappaMax) then
+                         xT = cos(FTX(kx,ky,kz)*infl_time+TAT(kx,ky,kz))
+                         if (div_free_force.eq.1) then
+                             f1 = f1 + xT * ( FAZ(kx,ky,kz)*twicePi*(kyd/HLy) &
+                                          * sin(twicePi*kxd*x/HLx+FPZX(kx,ky,kz)) &
+                                          * cos(twicePi*kyd*y/HLy+FPZY(kx,ky,kz)) &
+                                          * sin(twicePi*kzd*z/HLz+FPZZ(kx,ky,kz)) &
+                                         -    FAY(kx,ky,kz)*twicePi*(kzd/HLz) &
+                                          * sin(twicePi*kxd*x/HLx+FPYX(kx,ky,kz)) &
+                                          * sin(twicePi*kyd*y/HLy+FPYY(kx,ky,kz)) &
+                                          * cos(twicePi*kzd*z/HLz+FPYZ(kx,ky,kz)) )
+
+                             f2 = f2 + xT * ( FAX(kx,ky,kz)*twicePi*(kzd/HLz) &
+                                          * sin(twicePi*kxd*x/HLx+FPXX(kx,ky,kz)) &
+                                          * sin(twicePi*kyd*y/HLy+FPXY(kx,ky,kz)) &
+                                          * cos(twicePi*kzd*z/HLz+FPXZ(kx,ky,kz)) &
+                                         -    FAZ(kx,ky,kz)*twicePi*(kxd/HLx) &
+                                          * cos(twicePi*kxd*x/HLx+FPZX(kx,ky,kz)) &
+                                          * sin(twicePi*kyd*y/HLy+FPZY(kx,ky,kz)) &
+                                          * sin(twicePi*kzd*z/HLz+FPZZ(kx,ky,kz)) )
+
+                             f3 = f3 + xT * ( FAY(kx,ky,kz)*twicePi*(kxd/HLx) &
+                                          * cos(twicePi*kxd*x/HLx+FPYX(kx,ky,kz)) &
+                                          * sin(twicePi*kyd*y/HLy+FPYY(kx,ky,kz)) &
+                                          * sin(twicePi*kzd*z/HLz+FPYZ(kx,ky,kz)) &
+                                         -    FAX(kx,ky,kz)*twicePi*(kyd/HLy) &
+                                          * sin(twicePi*kxd*x/HLx+FPXX(kx,ky,kz)) &
+                                          * cos(twicePi*kyd*y/HLy+FPXY(kx,ky,kz)) &
+                                          * sin(twicePi*kzd*z/HLz+FPXZ(kx,ky,kz)) )
+
+                         else
+                             f1 = f1 + xT*FAX(kx,ky,kz)* cos(twicePi*kxd*x/HLx+FPX(kx,ky,kz)) &
+                                                       * sin(twicePi*kyd*y/HLy+FPY(kx,ky,kz)) &
+                                                       * sin(twicePi*kzd*z/HLz+FPZ(kx,ky,kz))
+                             f2 = f2 + xT*FAY(kx,ky,kz)* sin(twicePi*kxd*x/HLx+FPX(kx,ky,kz)) &
+                                                       * cos(twicePi*kyd*y/HLy+FPY(kx,ky,kz)) &
+                                                       * sin(twicePi*kzd*z/HLz+FPZ(kx,ky,kz))
+                             f3 = f3 + xT*FAZ(kx,ky,kz)* sin(twicePi*kxd*x/HLx+FPX(kx,ky,kz)) &
+                                                       * sin(twicePi*kyd*y/HLy+FPY(kx,ky,kz)) &
+                                                       * cos(twicePi*kzd*z/HLz+FPZ(kx,ky,kz))
+
+             !          write(*,*) 'DEBUG F1, F2, F3',kx,ky,kz,kappa,xT,f1,f2,f3
+             !          write(*,*) 'DEBUG x,y,z',x,y,z,kxd,kyd,kzd
+                         endif
+                      endif
+                   enddo
+                enddo
+             enddo
+
+
+             do kz = 1, zstep - 1
+                kzd = dfloat(kz)
+                do ky = mode_start, nymodes
+                   kyd = dfloat(ky)
+                   do kx = mode_start, nxmodes
+                      kxd = dfloat(kx)
+                      kappa = sqrt( (kxd*kxd)/(Lx*Lx) + (kyd*kyd)/(Ly*Ly) + (kzd*kzd)/(Lz*Lz) )
+                      if (kappa.le.kappaMax) then
+                       write(*,*) 'COUCOU'
+                         xT = cos(FTX(kx,ky,kz)*infl_time+TAT(kx,ky,kz))
+                         if (div_free_force.eq.1) then
+                             f1 = f1 + xT * ( FAZ(kx,ky,kz)*twicePi*(kyd/HLy) &
+                                          * sin(twicePi*kxd*x/HLx+FPZX(kx,ky,kz)) &
+                                          * cos(twicePi*kyd*y/HLy+FPZY(kx,ky,kz)) &
+                                          * sin(twicePi*kzd*z/HLz+FPZZ(kx,ky,kz)) &
+                                         -    FAY(kx,ky,kz)*twicePi*(kzd/HLz) &
+                                          * sin(twicePi*kxd*x/HLx+FPYX(kx,ky,kz)) &
+                                          * sin(twicePi*kyd*y/HLy+FPYY(kx,ky,kz)) &
+                                          * cos(twicePi*kzd*z/HLz+FPYZ(kx,ky,kz)) )
+
+                             f2 = f2 + xT * ( FAX(kx,ky,kz)*twicePi*(kzd/HLz) &
+                                          * sin(twicePi*kxd*x/HLx+FPXX(kx,ky,kz)) &
+                                          * sin(twicePi*kyd*y/HLy+FPXY(kx,ky,kz)) &
+                                          * cos(twicePi*kzd*z/HLz+FPXZ(kx,ky,kz)) &
+                                         -    FAZ(kx,ky,kz)*twicePi*(kxd/HLx) &
+                                          * cos(twicePi*kxd*x/HLx+FPZX(kx,ky,kz)) &
+                                          * sin(twicePi*kyd*y/HLy+FPZY(kx,ky,kz)) &
+                                          * sin(twicePi*kzd*z/HLz+FPZZ(kx,ky,kz)) )
+
+                             f3 = f3 + xT * ( FAY(kx,ky,kz)*twicePi*(kxd/HLx) &
+                                          * cos(twicePi*kxd*x/HLx+FPYX(kx,ky,kz)) &
+                                          * sin(twicePi*kyd*y/HLy+FPYY(kx,ky,kz)) &
+                                          * sin(twicePi*kzd*z/HLz+FPYZ(kx,ky,kz)) &
+                                         -    FAX(kx,ky,kz)*twicePi*(kyd/HLy) & 
+                                          * sin(twicePi*kxd*x/HLx+FPXX(kx,ky,kz)) &
+                                          * cos(twicePi*kyd*y/HLy+FPXY(kx,ky,kz)) &
+                                          * sin(twicePi*kzd*z/HLz+FPXZ(kx,ky,kz)) )
+
+                         else
+                             f1 = f1 + xT*FAX(kx,ky,kz)* cos(twicePi*kxd*x/Lx+FPX(kx,ky,kz)) &
+                                                       * sin(twicePi*kyd*y/Ly+FPY(kx,ky,kz)) &
+                                                       * sin(twicePi*kzd*z/Lz+FPZ(kx,ky,kz))
+                             f2 = f2 + xT*FAY(kx,ky,kz)* sin(twicePi*kxd*x/Lx+FPX(kx,ky,kz)) &
+                                                       * cos(twicePi*kyd*y/Ly+FPY(kx,ky,kz)) &
+                                                       * sin(twicePi*kzd*z/Lz+FPZ(kx,ky,kz))
+                             f3 = f3 + xT*FAZ(kx,ky,kz)* sin(twicePi*kxd*x/Lx+FPX(kx,ky,kz)) &
+                                                       * sin(twicePi*kyd*y/Ly+FPY(kx,ky,kz)) &
+                                                       * cos(twicePi*kzd*z/Lz+FPZ(kx,ky,kz))
+!write(*,*) 'DEBUG F1, F2, F3',kx,ky,kz,kappa,xT,f1,f2,f3
+                          endif
+                      endif
+                   enddo
+                enddo
+             enddo
+
+             src(i,j,k,UMX) = f1*new_state(i,j,k,URHO)
+             src(i,j,k,UMY) = f2*new_state(i,j,k,URHO)
+             src(i,j,k,UMZ) = f3*new_state(i,j,k,URHO)
+
+!write(*,*) "DEBUG",i,j,k,src(i,j,k,UMX),src(i,j,k,UMY),src(i,j,k,UMZ)
+
+          end do
+       end do
+    end do
+
+
+
+  end subroutine pc_forcing_src
+
+end module forcing_src_module

--- a/Exec/HIT_forced/inputs_3d
+++ b/Exec/HIT_forced/inputs_3d
@@ -1,0 +1,62 @@
+# ------------------  INPUTS TO MAIN PROGRAM  -------------------
+max_step = 1000
+stop_time = 6
+
+# PROBLEM SIZE & GEOMETRY
+geometry.is_periodic = 1 1 1
+geometry.coord_sys   = 0  # 0 => cart, 1 => RZ  2=>spherical
+geometry.prob_lo     =   0.0  0.0  0.0
+geometry.prob_hi     =   6.283185307179586232  6.283185307179586232  6.283185307179586232
+amr.n_cell           =  32 32 32
+#amr.n_cell           =  256 256 256
+
+# >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
+# 0 = Interior           3 = Symmetry
+# 1 = Inflow             4 = SlipWall
+# 2 = Outflow            5 = NoSlipWall
+# >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
+pelec.lo_bc       =  0   0   0
+pelec.hi_bc       =  0   0   0
+
+# WHICH PHYSICS
+pelec.do_hydro = 1
+pelec.diffuse_vel = 1
+pelec.diffuse_temp = 1
+pelec.do_react = 0
+pelec.do_grav = 0
+pelec.allow_negative_energy = 0
+pelec.add_forcing_src = 1 
+
+# TIME STEP CONTROL
+pelec.cfl            = 0.9     # cfl number for hyperbolic system
+pelec.init_shrink    = 0.3     # scale back initial timestep
+pelec.change_max     = 1.1     # max time step growth
+pelec.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
+# DIAGNOSTICS & VERBOSITY
+pelec.sum_interval   = 1       # timesteps between computing mass
+pelec.v              = 1       # verbosity in Castro.cpp
+amr.v                = 1       # verbosity in Amr.cpp
+#amr.data_log         = datlog
+#amr.grid_log        = grdlog  # name of grid logging file
+
+# REFINEMENT / REGRIDDING 
+amr.max_level       = 0       # maximum level number allowed
+amr.ref_ratio       = 2 2 2 2 # refinement ratio
+amr.regrid_int      = 2 2 2 2 # how often to regrid
+amr.blocking_factor = 4      # block factor in grid generation
+amr.max_grid_size   = 64
+amr.n_error_buf     = 2 2 2 2 # number of buffer cells in error est
+
+# CHECKPOINT FILES
+amr.check_file      = chk        # root name of checkpoint file
+amr.check_int       = 100        # number of timesteps between checkpoints
+
+# PLOTFILES
+amr.plot_file       = plt        # root name of plotfile
+amr.plot_int        = 10
+amr.plot_vars  =  density Temp
+amr.derive_plot_vars = x_velocity y_velocity z_velocity magvel magvort pressure MachNumber forcing forcex forcey forcez
+
+#PROBIN FILENAME
+amr.probin_file = probin

--- a/Exec/HIT_forced/probdata.f90
+++ b/Exec/HIT_forced/probdata.f90
@@ -1,0 +1,24 @@
+module probdata_module
+
+  ! HIT parameters
+  logical, save            :: restart
+  double precision, save   :: lambda0, reynolds_lambda0, mach_t0, prandtl
+  double precision, save   :: Lx, Ly, Lz
+  double precision, save   :: Linput
+  double precision, save   :: k0, rho0, urms0, tau, p0, T0, eint0
+
+  integer, save :: spectrum_type, mode_start, nmodes
+  double precision, save   :: turb_scale, force_scale, forcing_time_scale_min, forcing_time_scale_max
+  double precision, save :: time_offset
+
+  integer, save :: div_free_force
+
+  integer, parameter :: blrandseed = 0
+  integer, parameter :: moderate_zero_modes = 0
+  double precision, parameter :: forcing_epsilon = 1.0d-4
+
+  double precision, save, dimension(:,:,:), allocatable :: FTX, FTY, FTZ, TAT, TAP, &
+                                                FPX, FPY, FPZ, FAX, FAY, FAZ, &
+                                                FPXX, FPYX, FPZX, FPXY, FPYY, FPZY, FPXZ, FPYZ, FPZZ
+
+end module probdata_module

--- a/Exec/HIT_forced/probin
+++ b/Exec/HIT_forced/probin
@@ -1,0 +1,33 @@
+&fortin
+
+ lambda0 = 0.5
+ reynolds_lambda0 = 100.0d0
+ mach_t0 = 0.6
+ prandtl = 0.71
+
+ div_free_force = 0
+ spectrum_type          = 1 
+ mode_start             = 1
+ nmodes                 = 4 
+ force_scale            = 6.80d7  ! to get M=0.6
+ forcing_time_scale_min = 0.08
+ forcing_time_scale_max = 0.3
+
+ time_offset = 0.0d0
+ 
+/
+
+&tagging
+
+  denerr = 1.d20
+  dengrad = 0.01
+  max_denerr_lev = 5
+  max_dengrad_lev = 5
+
+  presserr = 1.d20
+  pressgrad = 1.d20
+  max_presserr_lev = 5
+  max_pressgrad_lev = 5
+
+/
+

--- a/Exec/HIT_forced/solution_varfield_average.py
+++ b/Exec/HIT_forced/solution_varfield_average.py
@@ -1,0 +1,36 @@
+import yt
+import argparse
+
+
+parser = argparse.ArgumentParser(
+            description = 'Post Processing script to take field average of a variable.'
+            )
+parser.add_argument(
+            'plotfile',
+            type = str,
+            help = 'First argument must be the name of the plotfile.'
+            )
+parser.add_argument(
+            'name_var',
+            type = str,
+            help = 'Name of the variable: x_velocity, MachNumber, Temp, density, ...'
+            )
+args = parser.parse_args()
+# Remove Trailing Slashes
+args.plotfile = '/'.join(list(filter(lambda x: len(x), args.plotfile.split('/'))))
+
+#print("{}".format(args))
+
+
+ds = yt.load(args.plotfile)  # load data
+
+field = args.name_var  # The field to average
+weight = "cell_mass"  # The weight for the average
+
+ad = ds.all_data()  # This is a region describing the entire box,
+                    # but note it doesn't read anything in yet!
+
+# We now use our 'quantities' call to get the average quantity
+average_value = ad.quantities.weighted_average_quantity(field, weight)
+
+print("Average %s (weighted by %s) is %0.3e %s" % (field, weight, average_value, average_value.units))

--- a/README.rst
+++ b/README.rst
@@ -22,12 +22,12 @@ To build `PeleC` and run a sample 2D flame problem:
 2. Set the environment variable, PELE_PHYSICS_HOME, and clone a copy of `PelePhysics` there. You should be placed in the `development` branch ::
 
     export PELE_PHYSICS_HOME=<location for PelePhysics>
-    git clone git@code.ornl.gov:Pele/PelePhysics.git ${PELE_PHYSICS_HOME}
+    git clone git@github.com:AMReX-Combustion/PelePhysics.git ${PELE_PHYSICS_HOME}
 
 3. Set the environment variable, PELEC_HOME, and clone a copy of `PeleC` there. You should be placed in the `development` branch ::
 
     export PELEC_HOME=<location for PeleC>
-    git clone git@code.ornl.gov:Pele/PeleC.git ${PELEC_HOME}
+    git clone git@github.com:AMReX-Combustion/PeleC.git ${PELEC_HOME}
 
 4. Move to an example build folder, build an executable, run a test case ::
 
@@ -75,7 +75,7 @@ To add a new feature to PeleC, the procedure is:
 
 3a. Check the pipeline status and make sure the regression tests passed
 
-4.  Submit a merge request through code.ornl.gov - be sure you are requesting to merge your branch to the development branch.
+4.  Submit a merge request through git@github.com:AMReX-Combustion/PeleC.git - be sure you are requesting to merge your branch to the development branch.
 
 Documentation
 -------------

--- a/Source/Derive_F.H
+++ b/Source/Derive_F.H
@@ -223,6 +223,44 @@ extern "C"
      const amrex::Real* time, const amrex::Real* dt, const int* bcrec, 
      const int* level, const int* grid_no);
 
+#ifdef DO_HIT_FORCE
+  void pc_derforcing
+    (BL_FORT_FAB_ARG_3D(der),const int* nvar,
+		 const BL_FORT_FAB_ARG_3D(data), const int* ncomp,
+		 const int* lo, const int* hi,
+		 const int* domain_lo, const int* domain_hi,
+		 const amrex::Real* delta, const amrex::Real* xlo,
+		 const amrex::Real* time, const amrex::Real* dt, const int* bcrec, 
+     const int* level, const int* grid_no);
+  
+  void pc_derforcex
+    (BL_FORT_FAB_ARG_3D(der),const int* nvar,
+		 const BL_FORT_FAB_ARG_3D(data), const int* ncomp,
+		 const int* lo, const int* hi,
+		 const int* domain_lo, const int* domain_hi,
+		 const amrex::Real* delta, const amrex::Real* xlo,
+		 const amrex::Real* time, const amrex::Real* dt, const int* bcrec, 
+     const int* level, const int* grid_no);
+    
+  void pc_derforcey
+    (BL_FORT_FAB_ARG_3D(der),const int* nvar,
+		 const BL_FORT_FAB_ARG_3D(data), const int* ncomp,
+		 const int* lo, const int* hi,
+		 const int* domain_lo, const int* domain_hi,
+		 const amrex::Real* delta, const amrex::Real* xlo,
+		 const amrex::Real* time, const amrex::Real* dt, const int* bcrec, 
+     const int* level, const int* grid_no);
+    
+  void pc_derforcez
+    (BL_FORT_FAB_ARG_3D(der),const int* nvar,
+		 const BL_FORT_FAB_ARG_3D(data), const int* ncomp,
+		 const int* lo, const int* hi,
+		 const int* domain_lo, const int* domain_hi,
+		 const amrex::Real* delta, const amrex::Real* xlo,
+		 const amrex::Real* time, const amrex::Real* dt, const int* bcrec, 
+     const int* level, const int* grid_no);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/PeleC_F.H
+++ b/Source/PeleC_F.H
@@ -461,6 +461,7 @@ extern "C"
                       const BL_FORT_FAB_ARG_3D(new_state),
                       BL_FORT_FAB_ARG_3D(forcing_src),
                       const amrex::Real* prob_lo, const amrex::Real* dx,
+                      const amrex::Real* xlo, const amrex::Real* xhi,
                       const amrex::Real* time, const amrex::Real* dt);
 
 #ifdef __cplusplus

--- a/Source/PeleC_advance.cpp
+++ b/Source/PeleC_advance.cpp
@@ -258,8 +258,6 @@ PeleC::do_sdc_advance(Real time,
       SDC), hydro, and the source terms.
   */
 
-  BL_PROFILE("PeleC::do_advance()");
-
   initialize_sdc_advance(time, dt, amr_iteration, amr_ncycle);
 
   if (do_react_load_balance) {

--- a/Source/PeleC_forcing.cpp
+++ b/Source/PeleC_forcing.cpp
@@ -58,7 +58,12 @@ PeleC::fill_forcing_source (Real time, Real dt,
 #endif
   for (MFIter mfi(forcing_src,true); mfi.isValid(); ++mfi)
   {
-    const Box& bx = mfi.growntilebox(ng);
+//    const Box& bx = mfi.growntilebox(ng);
+
+    RealBox gridloc = RealBox(grids[mfi.index()],geom.CellSize(),geom.ProbLo());
+    const Box& bx     = mfi.validbox();
+    const int* lo      = bx.loVect();
+    const int* hi      = bx.hiVect();
 
 #ifdef PELE_USE_EB
     const auto& flag_fab = flags[mfi];
@@ -72,10 +77,12 @@ PeleC::fill_forcing_source (Real time, Real dt,
     const auto& Snfab = state_new[mfi];
     auto& Ffab = forcing_src[mfi];
 
-    pc_forcing_src(ARLIM_3D(bx.loVect()), ARLIM_3D(bx.hiVect()),
+    pc_forcing_src(ARLIM_3D(lo), ARLIM_3D(hi),
                    BL_TO_FORTRAN_3D(Sofab),
                    BL_TO_FORTRAN_3D(Snfab),
                    BL_TO_FORTRAN_3D(Ffab),
-                   ZFILL(prob_lo),ZFILL(dx),&time,&dt);
+                   ZFILL(prob_lo),ZFILL(dx),
+                   ZFILL(gridloc.lo()), ZFILL(gridloc.hi()),
+                   &time,&dt);
   }
 }

--- a/Source/PeleC_setup.cpp
+++ b/Source/PeleC_setup.cpp
@@ -556,6 +556,30 @@ PeleC::variableSetUp ()
     //
     derive_lst.add("logden",IndexType::TheCellType(),1,pc_derlogden,the_same_box);
     derive_lst.addComponent("logden",desc_lst,State_Type,Density,NUM_STATE);
+    
+#ifdef DO_HIT_FORCE
+    //
+    // forcing - used to calculate the rate of injection of energy in probtype 14 (HIT)
+    //
+    derive_lst.add("forcing",IndexType::TheCellType(),1,pc_derforcing,the_same_box);
+    derive_lst.addComponent("forcing",desc_lst,State_Type,Density,1);
+    derive_lst.addComponent("forcing",desc_lst,State_Type,Xmom,BL_SPACEDIM);
+    //
+    // forcex - used to put the forcing term in the plot file
+    //
+    derive_lst.add("forcex",IndexType::TheCellType(),1,pc_derforcex,the_same_box);
+    derive_lst.addComponent("forcex",desc_lst,State_Type,Density,1);
+    //
+    // forcey - used to put the forcing term in the plot file
+    //
+    derive_lst.add("forcey",IndexType::TheCellType(),1,pc_derforcey,the_same_box);
+    derive_lst.addComponent("forcey",desc_lst,State_Type,Density,1);
+    //
+    // forcez - used to put the forcing term in the plot file
+    //
+    derive_lst.add("forcez",IndexType::TheCellType(),1,pc_derforcez,the_same_box);
+    derive_lst.addComponent("forcez",desc_lst,State_Type,Density,1);
+#endif
 
     //
     // Y from rhoY

--- a/Source/Src_nd/Derive_nd.F90
+++ b/Source/Src_nd/Derive_nd.F90
@@ -89,7 +89,7 @@ contains
           enddo
        enddo
     enddo
-
+    
     call destroy(eos_state)
 
   end subroutine pc_deruplusc
@@ -142,8 +142,8 @@ contains
           end do
        end do
     end do
-
-    call build(eos_state)
+    
+    call destroy(eos_state)
 
   end subroutine pc_deruminusc
 
@@ -307,7 +307,7 @@ contains
           enddo
        enddo
     enddo
-
+    
     call destroy(eos_state)
 
   end subroutine pc_derpres
@@ -433,8 +433,8 @@ contains
           enddo
        enddo
     enddo
-
-    call build(eos_state)
+    
+    call destroy(eos_state)
 
   end subroutine pc_dersoundspeed
 
@@ -485,7 +485,7 @@ contains
           enddo
        enddo
     enddo
-
+    
     call destroy(eos_state)
 
   end subroutine pc_dermachnumber
@@ -537,7 +537,7 @@ contains
           enddo
        enddo
     enddo
-
+    
     call destroy(eos_state)
 
   end subroutine pc_derentropy
@@ -610,7 +610,7 @@ contains
           enddo
        enddo
     enddo
-
+    
     call destroy(eos_state)
 
   end subroutine pc_derenuctimescale
@@ -698,7 +698,7 @@ contains
           end do
        end do
     end do
- 
+    
     call destroy(eos_state)
 
   end subroutine pc_dermolefrac
@@ -863,9 +863,642 @@ contains
     end do
 
   end subroutine pc_derdivu
+  
+#ifdef DO_HIT_FORCE
+  subroutine pc_derforcing (forcing,u_lo,u_hi,nd, &
+                            dat,d_lo,d_hi,nc, &
+                            lo,hi,domlo,domhi,delta, &
+                            xlo,time,dt,bc,level,grid_no) &
+                            bind(C, name="pc_derforcing")
+!
+!     This routine will derive the energy being injected by the
+!     forcing term used for generating turbulence in probtype 14
+!     Requires velocity field, time, and the right parameters
+!     for the forcing term, i.e. probin, *somehow*
+!
+
+    use bl_constants_module, only: ZERO, HALF, M_PI, TWO
+    use probdata_module
+
+    implicit none
+      
+    integer          :: lo(3), hi(3)
+    integer          :: u_lo(3), u_hi(3), nd
+    integer          :: d_lo(3), d_hi(3), nc
+    integer          :: domlo(3), domhi(3)
+    integer          :: bc(3,2,nc)
+    double precision :: delta(3), xlo(3), time, dt
+    double precision :: forcing(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),nd)
+    double precision :: dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
+    integer          :: level, grid_no
+
+    ! Local
+    integer          :: i, j, k
+    integer :: kx, ky, kz
+    integer :: modx, mody, modz, xstep, ystep, zstep
+    integer :: nxmodes, nymodes, nzmodes
+    double precision :: f1, f2, f3
+    double precision :: HLx, HLy, HLz, hx, hy, hz
+    double precision :: infl_time, kappa, kappaMax
+    double precision :: kxd, kyd, kzd
+    double precision :: Lmin, twicePi, xT, x, y, z
+    double precision :: u, v, w, zlo
+
+    hx = delta(1)
+    hy = delta(2)
+    hz = delta(3)
+    twicePi=two*M_Pi
+
+!c     Homogeneous Isotropic Turbulence or Inflow
+
+    if (time_offset.gt.zero) then
+      infl_time = time + time_offset
+    else
+      infl_time = time
+    endif
+    zlo = xlo(3)
+
+    Lmin = min(Lx,Ly,Lz)
+    kappaMax = dble(nmodes)/Lmin + 1.0d-8
+    nxmodes = nmodes*int(0.5d0+Lx/Lmin)
+    nymodes = nmodes*int(0.5d0+Ly/Lmin)
+    nzmodes = nmodes*int(0.5d0+Lz/Lmin)
+    xstep = int(Lx/Lmin+0.5d0)
+    ystep = int(Ly/Lmin+0.5d0)
+    zstep = int(Lz/Lmin+0.5d0)
+
+    HLx = Lx
+    HLy = Ly
+    HLz = Lz
+
+    
+    do k = lo(3), hi(3)
+       z = xlo(3) + delta(3)*(dble(k-lo(3)) + HALF)
+       do j = lo(2), hi(2)
+          y = xlo(2) + delta(2)*(dble(j-lo(2)) + HALF)
+          do i = lo(1), hi(1)
+             x = xlo(1) + delta(1)*(dble(i-lo(1)) + HALF)
+             f1 = zero
+             f2 = zero
+             f3 = zero
+  
+             do kz = mode_start*zstep, nzmodes, zstep
+                kzd = dble(kz)
+                do ky = mode_start*ystep, nymodes, ystep
+                   kyd = dble(ky)
+                   do kx = mode_start*xstep, nxmodes, xstep
+                      kxd = dble(kx)
+                      kappa = sqrt( (kxd*kxd)/(Lx*Lx) + (kyd*kyd)/(Ly*Ly) + (kzd*kzd)/(Lz*Lz) )
+                      if (kappa.le.kappaMax) then
+                         xT = cos(FTX(kx,ky,kz)*infl_time+TAT(kx,ky,kz))
+                         if (div_free_force.eq.1) then
+                            f1 = f1 + xT * ( FAZ(kx,ky,kz)*twicePi*(kyd/HLy) &
+                                         * sin(twicePi*kxd*x/HLx+FPZX(kx,ky,kz)) &
+                                         * cos(twicePi*kyd*y/HLy+FPZY(kx,ky,kz)) &
+                                         * sin(twicePi*kzd*z/HLz+FPZZ(kx,ky,kz)) &
+                                        -    FAY(kx,ky,kz)*twicePi*(kzd/HLz) &
+                                         * sin(twicePi*kxd*x/HLx+FPYX(kx,ky,kz)) &
+                                         * sin(twicePi*kyd*y/HLy+FPYY(kx,ky,kz)) &
+                                         * cos(twicePi*kzd*z/HLz+FPYZ(kx,ky,kz)) )
+                            f2 = f2 + xT * ( FAX(kx,ky,kz)*twicePi*(kzd/HLz) &
+                                         * sin(twicePi*kxd*x/HLx+FPXX(kx,ky,kz)) &
+                                         * sin(twicePi*kyd*y/HLy+FPXY(kx,ky,kz)) &
+                                         * cos(twicePi*kzd*z/HLz+FPXZ(kx,ky,kz)) &
+                                        -    FAZ(kx,ky,kz)*twicePi*(kxd/HLx) &
+                                         * cos(twicePi*kxd*x/HLx+FPZX(kx,ky,kz)) &
+                                         * sin(twicePi*kyd*y/HLy+FPZY(kx,ky,kz)) &
+                                         * sin(twicePi*kzd*z/HLz+FPZZ(kx,ky,kz)) )
+                            f3 = f3 + xT * ( FAY(kx,ky,kz)*twicePi*(kxd/HLx) &
+                                         * cos(twicePi*kxd*x/HLx+FPYX(kx,ky,kz)) &
+                                         * sin(twicePi*kyd*y/HLy+FPYY(kx,ky,kz)) &
+                                         * sin(twicePi*kzd*z/HLz+FPYZ(kx,ky,kz)) &
+                                        -    FAX(kx,ky,kz)*twicePi*(kyd/HLy) &
+                                         * sin(twicePi*kxd*x/HLx+FPXX(kx,ky,kz)) &
+                                         * cos(twicePi*kyd*y/HLy+FPXY(kx,ky,kz)) &
+                                         * sin(twicePi*kzd*z/HLz+FPXZ(kx,ky,kz)) )
+                         else
+                            f1 = f1 + xT*FAX(kx,ky,kz)* cos(twicePi*kxd*x/HLx+FPX(kx,ky,kz)) &
+                                                      * sin(twicePi*kyd*y/HLy+FPY(kx,ky,kz)) &
+                                                      * sin(twicePi*kzd*z/HLz+FPZ(kx,ky,kz))
+                            f2 = f2 + xT*FAY(kx,ky,kz)* sin(twicePi*kxd*x/HLx+FPX(kx,ky,kz)) &
+                                                      * cos(twicePi*kyd*y/HLy+FPY(kx,ky,kz)) &
+                                                      * sin(twicePi*kzd*z/HLz+FPZ(kx,ky,kz))
+                            f3 = f3 + xT*FAZ(kx,ky,kz)* sin(twicePi*kxd*x/HLx+FPX(kx,ky,kz)) &
+                                                      * sin(twicePi*kyd*y/HLy+FPY(kx,ky,kz)) &
+                                                      * cos(twicePi*kzd*z/HLz+FPZ(kx,ky,kz))
+                         endif
+                      endif
+                   enddo
+                enddo
+             enddo
+                  
+             do kz = 1, zstep - 1
+                kzd = dble(kz)
+                do ky = mode_start, nymodes
+                   kyd = dble(ky)
+                   do kx = mode_start, nxmodes
+                      kxd = dble(kx)
+                      kappa = sqrt( (kxd*kxd)/(Lx*Lx) + (kyd*kyd)/(Ly*Ly) + (kzd*kzd)/(Lz*Lz) )
+                      if (kappa.le.kappaMax) then
+                         xT = cos(FTX(kx,ky,kz)*infl_time+TAT(kx,ky,kz))
+                         if (div_free_force.eq.1) then
+                            f1 = f1 + xT * ( FAZ(kx,ky,kz)*twicePi*(kyd/HLy) &
+                                         * sin(twicePi*kxd*x/HLx+FPZX(kx,ky,kz)) &
+                                         * cos(twicePi*kyd*y/HLy+FPZY(kx,ky,kz)) &
+                                         * sin(twicePi*kzd*z/HLz+FPZZ(kx,ky,kz)) &
+                                        -    FAY(kx,ky,kz)*twicePi*(kzd/HLz) &
+                                         * sin(twicePi*kxd*x/HLx+FPYX(kx,ky,kz)) &
+                                         * sin(twicePi*kyd*y/HLy+FPYY(kx,ky,kz)) &
+                                         * cos(twicePi*kzd*z/HLz+FPYZ(kx,ky,kz)) )
+                            f2 = f2 + xT * ( FAX(kx,ky,kz)*twicePi*(kzd/HLz) &
+                                         * sin(twicePi*kxd*x/HLx+FPXX(kx,ky,kz)) &
+                                         * sin(twicePi*kyd*y/HLy+FPXY(kx,ky,kz)) &
+                                         * cos(twicePi*kzd*z/HLz+FPXZ(kx,ky,kz)) &
+                                        -    FAZ(kx,ky,kz)*twicePi*(kxd/HLx) &
+                                         * cos(twicePi*kxd*x/HLx+FPZX(kx,ky,kz)) &
+                                         * sin(twicePi*kyd*y/HLy+FPZY(kx,ky,kz)) &
+                                         * sin(twicePi*kzd*z/HLz+FPZZ(kx,ky,kz)) )
+                            f3 = f3 + xT * ( FAY(kx,ky,kz)*twicePi*(kxd/HLx) &
+                                         * cos(twicePi*kxd*x/HLx+FPYX(kx,ky,kz)) &
+                                         * sin(twicePi*kyd*y/HLy+FPYY(kx,ky,kz)) &
+                                         * sin(twicePi*kzd*z/HLz+FPYZ(kx,ky,kz)) &
+                                        -    FAX(kx,ky,kz)*twicePi*(kyd/HLy) &
+                                         * sin(twicePi*kxd*x/HLx+FPXX(kx,ky,kz)) &
+                                         * cos(twicePi*kyd*y/HLy+FPXY(kx,ky,kz)) &
+                                         * sin(twicePi*kzd*z/HLz+FPXZ(kx,ky,kz)) )
+                         else
+                            f1 = f1 + xT*FAX(kx,ky,kz) * cos(twicePi*kxd*x/HLx+FPX(kx,ky,kz)) &
+                                                       * sin(twicePi*kyd*y/HLy+FPY(kx,ky,kz)) &
+                                                       * sin(twicePi*kzd*z/HLz+FPZ(kx,ky,kz))
+                            f2 = f2 + xT*FAY(kx,ky,kz) * sin(twicePi*kxd*x/HLx+FPX(kx,ky,kz)) &
+                                                       * cos(twicePi*kyd*y/HLy+FPY(kx,ky,kz)) &
+                                                       * sin(twicePi*kzd*z/HLz+FPZ(kx,ky,kz))
+                            f3 = f3 + xT*FAZ(kx,ky,kz) * sin(twicePi*kxd*x/HLx+FPX(kx,ky,kz)) &
+                                                       * sin(twicePi*kyd*y/HLy+FPY(kx,ky,kz)) &
+                                                       * cos(twicePi*kzd*z/HLz+FPZ(kx,ky,kz))
+                         endif
+                      endif
+                   enddo
+                enddo
+             enddo
+
+             u   = dat(i,j,k,2)
+             v   = dat(i,j,k,3)
+             w   = dat(i,j,k,4)
+                  
+             forcing(i,j,k,1) = dat(i,j,k,1) * ( u*f1 + v*f2 + w*f3 )
+                  
+          end do
+       end do
+    end do
 
 
+  end subroutine pc_derforcing
 
+  subroutine pc_derforcex (forcing,u_lo,u_hi,nd, &
+                            dat,d_lo,d_hi,nc, &
+                            lo,hi,domlo,domhi,delta, &
+                            xlo,time,dt,bc,level,grid_no) &
+                            bind(C, name="pc_derforcex")
+!
+!     This routine will derive the energy being injected by the
+!     forcing term used for generating turbulence in probtype 14
+!     Requires velocity field, time, and the right parameters
+!     for the forcing term, i.e. probin, *somehow*
+!
+
+    use bl_constants_module, only: ZERO, HALF, M_PI, TWO
+    use probdata_module
+
+    implicit none
+      
+    integer          :: lo(3), hi(3)
+    integer          :: u_lo(3), u_hi(3), nd
+    integer          :: d_lo(3), d_hi(3), nc
+    integer          :: domlo(3), domhi(3)
+    integer          :: bc(3,2,nc)
+    double precision :: delta(3), xlo(3), time, dt
+    double precision :: forcing(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),nd)
+    double precision :: dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
+    integer          :: level, grid_no
+
+    ! Local
+    integer          :: i, j, k
+    integer :: kx, ky, kz
+    integer :: xstep, ystep, zstep
+    integer :: nxmodes, nymodes, nzmodes
+    double precision :: f1
+    double precision :: HLx, HLy, HLz
+    double precision :: infl_time, kappa, kappaMax
+    double precision :: kxd, kyd, kzd
+    double precision :: Lmin, twicePi, xT, x, y, z
+    double precision :: zlo
+
+    twicePi=two*M_Pi
+
+!c     Homogeneous Isotropic Turbulence or Inflow
+
+    if (time_offset.gt.zero) then
+      infl_time = time + time_offset
+    else
+      infl_time = time
+    endif
+    zlo = xlo(3)
+
+    Lmin = min(Lx,Ly,Lz)
+    kappaMax = dble(nmodes)/Lmin + 1.0d-8
+    nxmodes = nmodes*int(0.5d0+Lx/Lmin)
+    nymodes = nmodes*int(0.5d0+Ly/Lmin)
+    nzmodes = nmodes*int(0.5d0+Lz/Lmin)
+    xstep = int(Lx/Lmin+0.5d0)
+    ystep = int(Ly/Lmin+0.5d0)
+    zstep = int(Lz/Lmin+0.5d0)
+
+    HLx = Lx
+    HLy = Ly
+    HLz = Lz
+    
+    forcing(lo(1):hi(1),lo(2):hi(2),lo(3):hi(3),:) = ZERO
+
+    !write(*,*) 'DEBUG ENTERING DERIVE X'
+               !    do kz = mode_start*zstep, nzmodes, zstep
+               !   kzd = dfloat(kz)
+               !   do ky = mode_start*ystep, nymodes, ystep
+               !      kyd = dfloat(ky)
+               !      do kx = mode_start*xstep, nxmodes, xstep
+               !         kxd = dfloat(kx)
+               !         kappa = sqrt( (kxd*kxd)/(Lx*Lx) + (kyd*kyd)/(Ly*Ly) + (kzd*kzd)/(Lz*Lz) )
+               !         if (kappa.le.kappaMax) then
+               !            write (*,*) "Mode"
+               !            write (*,*) "kappa = ",kx,ky,kz,kappa
+               !            write (*,*) "Amplitudes - C"
+               !            write (*,*) FAX(kx,ky,kz), FAY(kx,ky,kz), FAZ(kx,ky,kz)
+               !            write (*,*) "Frequencies"
+               !            write (*,*) FTX(kx,ky,kz), FTY(kx,ky,kz), FTZ(kx,ky,kz)
+               !            write (*,*) "Phases"
+               !            write (*,*) FPX(kx,ky,kz), FPY(kx,ky,kz), FPZ(kx,ky,kz)
+               !            write (*,*) "TAT"
+               !            write (*,*) TAT(kx,ky,kz)
+               !         endif
+               !      enddo
+               !   enddo
+               !enddo
+
+    
+    
+    do k = lo(3), hi(3)
+       z = xlo(3) + delta(3)*(dble(k-lo(3)) + HALF)
+       do j = lo(2), hi(2)
+          y = xlo(2) + delta(2)*(dble(j-lo(2)) + HALF)
+          do i = lo(1), hi(1)
+             x = xlo(1) + delta(1)*(dble(i-lo(1)) + HALF)
+             f1 = zero
+
+             do kz = mode_start*zstep, nzmodes, zstep
+                kzd = dble(kz)
+                do ky = mode_start*ystep, nymodes, ystep
+                   kyd = dble(ky)
+                   do kx = mode_start*xstep, nxmodes, xstep
+                      kxd = dble(kx)
+                      kappa = sqrt( (kxd*kxd)/(Lx*Lx) + (kyd*kyd)/(Ly*Ly) + (kzd*kzd)/(Lz*Lz) )
+                      if (kappa.le.kappaMax) then
+                         xT = cos(FTX(kx,ky,kz)*infl_time+TAT(kx,ky,kz))
+                         !write(*,*) 'DEBUG 1',i,j,k,kx,ky,kz,FTX(kx,ky,kz),infl_time,TAT(kx,ky,kz),xT
+                         if (div_free_force.eq.1) then
+                            f1 = f1 + xT * ( FAZ(kx,ky,kz)*twicePi*(kyd/HLy) &
+                                         * sin(twicePi*kxd*x/HLx+FPZX(kx,ky,kz)) &
+                                         * cos(twicePi*kyd*y/HLy+FPZY(kx,ky,kz)) &
+                                         * sin(twicePi*kzd*z/HLz+FPZZ(kx,ky,kz)) &
+                                        -    FAY(kx,ky,kz)*twicePi*(kzd/HLz) &
+                                         * sin(twicePi*kxd*x/HLx+FPYX(kx,ky,kz)) &
+                                         * sin(twicePi*kyd*y/HLy+FPYY(kx,ky,kz)) &
+                                         * cos(twicePi*kzd*z/HLz+FPYZ(kx,ky,kz)) )
+                         else
+
+                            f1 = f1 + xT*FAX(kx,ky,kz)* cos(twicePi*kxd*x/HLx+FPX(kx,ky,kz)) &
+                                                      * sin(twicePi*kyd*y/HLy+FPY(kx,ky,kz)) &
+                                                      * sin(twicePi*kzd*z/HLz+FPZ(kx,ky,kz))
+                         endif
+                      endif
+                   enddo
+                enddo
+             enddo
+                  
+             do kz = 1, zstep - 1
+                kzd = dble(kz)
+                do ky = mode_start, nymodes
+                   kyd = dble(ky)
+                   do kx = mode_start, nxmodes
+                      kxd = dble(kx)
+                      kappa = sqrt( (kxd*kxd)/(Lx*Lx) + (kyd*kyd)/(Ly*Ly) + (kzd*kzd)/(Lz*Lz) )
+                      if (kappa.le.kappaMax) then
+                         xT = cos(FTX(kx,ky,kz)*infl_time+TAT(kx,ky,kz))
+                         if (div_free_force.eq.1) then
+                            f1 = f1 + xT * ( FAZ(kx,ky,kz)*twicePi*(kyd/HLy) &
+                                         * sin(twicePi*kxd*x/HLx+FPZX(kx,ky,kz)) &
+                                         * cos(twicePi*kyd*y/HLy+FPZY(kx,ky,kz)) &
+                                         * sin(twicePi*kzd*z/HLz+FPZZ(kx,ky,kz)) &
+                                        -    FAY(kx,ky,kz)*twicePi*(kzd/HLz) &
+                                         * sin(twicePi*kxd*x/HLx+FPYX(kx,ky,kz)) &
+                                         * sin(twicePi*kyd*y/HLy+FPYY(kx,ky,kz)) &
+                                         * cos(twicePi*kzd*z/HLz+FPYZ(kx,ky,kz)) )
+                         else
+                            f1 = f1 + xT*FAX(kx,ky,kz) * cos(twicePi*kxd*x/HLx+FPX(kx,ky,kz)) &
+                                                       * sin(twicePi*kyd*y/HLy+FPY(kx,ky,kz)) &
+                                                       * sin(twicePi*kzd*z/HLz+FPZ(kx,ky,kz))
+                         endif
+                      endif
+                   enddo
+                enddo
+             enddo
+                   !write(*,*) 'DEBUG TOTO',i,j,k,x,y,z,f1
+             forcing(i,j,k,1) = dat(i,j,k,1) * f1
+                  
+          end do
+       end do
+    end do
+
+
+  end subroutine pc_derforcex
+  
+  subroutine pc_derforcey (forcing,u_lo,u_hi,nd, &
+                            dat,d_lo,d_hi,nc, &
+                            lo,hi,domlo,domhi,delta, &
+                            xlo,time,dt,bc,level,grid_no) &
+                            bind(C, name="pc_derforcey")
+!
+!     This routine will derive the energy being injected by the
+!     forcing term used for generating turbulence in probtype 14
+!     Requires velocity field, time, and the right parameters
+!     for the forcing term, i.e. probin, *somehow*
+!
+
+    use bl_constants_module, only: ZERO, HALF, M_PI, TWO
+    use probdata_module
+
+    implicit none
+      
+    integer          :: lo(3), hi(3)
+    integer          :: u_lo(3), u_hi(3), nd
+    integer          :: d_lo(3), d_hi(3), nc
+    integer          :: domlo(3), domhi(3)
+    integer          :: bc(3,2,nc)
+    double precision :: delta(3), xlo(3), time, dt
+    double precision :: forcing(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),nd)
+    double precision :: dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
+    integer          :: level, grid_no
+
+    ! Local
+    integer          :: i, j, k
+    integer :: kx, ky, kz
+    integer :: xstep, ystep, zstep
+    integer :: nxmodes, nymodes, nzmodes
+    double precision :: f2
+    double precision :: HLx, HLy, HLz
+    double precision :: infl_time, kappa, kappaMax
+    double precision :: kxd, kyd, kzd
+    double precision :: Lmin, twicePi, xT, x, y, z
+    double precision :: zlo
+
+    twicePi=two*M_Pi
+    forcing(lo(1):hi(1),lo(2):hi(2),lo(3):hi(3),:) = ZERO
+
+!c     Homogeneous Isotropic Turbulence or Inflow
+
+    if (time_offset.gt.zero) then
+      infl_time = time + time_offset
+    else
+      infl_time = time
+    endif
+    zlo = xlo(3)
+
+    Lmin = min(Lx,Ly,Lz)
+    kappaMax = dble(nmodes)/Lmin + 1.0d-8
+    nxmodes = nmodes*int(0.5d0+Lx/Lmin)
+    nymodes = nmodes*int(0.5d0+Ly/Lmin)
+    nzmodes = nmodes*int(0.5d0+Lz/Lmin)
+    xstep = int(Lx/Lmin+0.5d0)
+    ystep = int(Ly/Lmin+0.5d0)
+    zstep = int(Lz/Lmin+0.5d0)
+
+    HLx = Lx
+    HLy = Ly
+    HLz = Lz
+
+    
+    do k = lo(3), hi(3)
+       z = xlo(3) + delta(3)*(dble(k-lo(3)) + HALF)
+       do j = lo(2), hi(2)
+          y = xlo(2) + delta(2)*(dble(j-lo(2)) + HALF)
+          do i = lo(1), hi(1)
+             x = xlo(1) + delta(1)*(dble(i-lo(1)) + HALF)
+             f2 = zero
+  
+             do kz = mode_start*zstep, nzmodes, zstep
+                kzd = dble(kz)
+                do ky = mode_start*ystep, nymodes, ystep
+                   kyd = dble(ky)
+                   do kx = mode_start*xstep, nxmodes, xstep
+                      kxd = dble(kx)
+                      kappa = sqrt( (kxd*kxd)/(Lx*Lx) + (kyd*kyd)/(Ly*Ly) + (kzd*kzd)/(Lz*Lz) )
+                      if (kappa.le.kappaMax) then
+                         xT = cos(FTX(kx,ky,kz)*infl_time+TAT(kx,ky,kz))
+                         if (div_free_force.eq.1) then
+                            f2 = f2 + xT * ( FAX(kx,ky,kz)*twicePi*(kzd/HLz) &
+                                         * sin(twicePi*kxd*x/HLx+FPXX(kx,ky,kz)) &
+                                         * sin(twicePi*kyd*y/HLy+FPXY(kx,ky,kz)) &
+                                         * cos(twicePi*kzd*z/HLz+FPXZ(kx,ky,kz)) &
+                                        -    FAZ(kx,ky,kz)*twicePi*(kxd/HLx) &
+                                         * cos(twicePi*kxd*x/HLx+FPZX(kx,ky,kz)) &
+                                         * sin(twicePi*kyd*y/HLy+FPZY(kx,ky,kz)) &
+                                         * sin(twicePi*kzd*z/HLz+FPZZ(kx,ky,kz)) )
+                         else
+                            f2 = f2 + xT*FAY(kx,ky,kz)* sin(twicePi*kxd*x/HLx+FPX(kx,ky,kz)) &
+                                                      * cos(twicePi*kyd*y/HLy+FPY(kx,ky,kz)) &
+                                                      * sin(twicePi*kzd*z/HLz+FPZ(kx,ky,kz))
+                         endif
+                      endif
+                   enddo
+                enddo
+             enddo
+                  
+             do kz = 1, zstep - 1
+                kzd = dble(kz)
+                do ky = mode_start, nymodes
+                   kyd = dble(ky)
+                   do kx = mode_start, nxmodes
+                      kxd = dble(kx)
+                      kappa = sqrt( (kxd*kxd)/(Lx*Lx) + (kyd*kyd)/(Ly*Ly) + (kzd*kzd)/(Lz*Lz) )
+                      if (kappa.le.kappaMax) then
+                         xT = cos(FTX(kx,ky,kz)*infl_time+TAT(kx,ky,kz))
+                         if (div_free_force.eq.1) then
+                            f2 = f2 + xT * ( FAX(kx,ky,kz)*twicePi*(kzd/HLz) &
+                                         * sin(twicePi*kxd*x/HLx+FPXX(kx,ky,kz)) &
+                                         * sin(twicePi*kyd*y/HLy+FPXY(kx,ky,kz)) &
+                                         * cos(twicePi*kzd*z/HLz+FPXZ(kx,ky,kz)) &
+                                        -    FAZ(kx,ky,kz)*twicePi*(kxd/HLx) &
+                                         * cos(twicePi*kxd*x/HLx+FPZX(kx,ky,kz)) &
+                                         * sin(twicePi*kyd*y/HLy+FPZY(kx,ky,kz)) &
+                                         * sin(twicePi*kzd*z/HLz+FPZZ(kx,ky,kz)) )
+                         else
+                            f2 = f2 + xT*FAY(kx,ky,kz) * sin(twicePi*kxd*x/HLx+FPX(kx,ky,kz)) &
+                                                       * cos(twicePi*kyd*y/HLy+FPY(kx,ky,kz)) &
+                                                       * sin(twicePi*kzd*z/HLz+FPZ(kx,ky,kz))
+                         endif
+                      endif
+                   enddo
+                enddo
+             enddo
+                
+             forcing(i,j,k,1) = dat(i,j,k,1) * f2
+                  
+          end do
+       end do
+    end do
+
+
+  end subroutine pc_derforcey
+  
+  subroutine pc_derforcez (forcing,u_lo,u_hi,nd, &
+                            dat,d_lo,d_hi,nc, &
+                            lo,hi,domlo,domhi,delta, &
+                            xlo,time,dt,bc,level,grid_no) &
+                            bind(C, name="pc_derforcez")
+!
+!     This routine will derive the energy being injected by the
+!     forcing term used for generating turbulence in probtype 14
+!     Requires velocity field, time, and the right parameters
+!     for the forcing term, i.e. probin, *somehow*
+!
+
+    use bl_constants_module, only: ZERO, HALF, M_PI, TWO
+    use probdata_module
+
+    implicit none
+      
+    integer          :: lo(3), hi(3)
+    integer          :: u_lo(3), u_hi(3), nd
+    integer          :: d_lo(3), d_hi(3), nc
+    integer          :: domlo(3), domhi(3)
+    integer          :: bc(3,2,nc)
+    double precision :: delta(3), xlo(3), time, dt
+    double precision :: forcing(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),nd)
+    double precision :: dat(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
+    integer          :: level, grid_no
+
+    ! Local
+    integer          :: i, j, k
+    integer :: kx, ky, kz
+    integer :: xstep, ystep, zstep
+    integer :: nxmodes, nymodes, nzmodes
+    double precision :: f3
+    double precision :: HLx, HLy, HLz
+    double precision :: infl_time, kappa, kappaMax
+    double precision :: kxd, kyd, kzd
+    double precision :: Lmin, twicePi, xT, x, y, z
+    double precision :: zlo
+
+    twicePi=two*M_Pi
+    forcing(lo(1):hi(1),lo(2):hi(2),lo(3):hi(3),:) = ZERO
+
+!c     Homogeneous Isotropic Turbulence or Inflow
+
+    if (time_offset.gt.zero) then
+      infl_time = time + time_offset
+    else
+      infl_time = time
+    endif
+    zlo = xlo(3)
+
+    Lmin = min(Lx,Ly,Lz)
+    kappaMax = dble(nmodes)/Lmin + 1.0d-8
+    nxmodes = nmodes*int(0.5d0+Lx/Lmin)
+    nymodes = nmodes*int(0.5d0+Ly/Lmin)
+    nzmodes = nmodes*int(0.5d0+Lz/Lmin)
+    xstep = int(Lx/Lmin+0.5d0)
+    ystep = int(Ly/Lmin+0.5d0)
+    zstep = int(Lz/Lmin+0.5d0)
+
+    HLx = Lx
+    HLy = Ly
+    HLz = Lz
+
+    
+    do k = lo(3), hi(3)
+       z = xlo(3) + delta(3)*(dble(k-lo(3)) + HALF)
+       do j = lo(2), hi(2)
+          y = xlo(2) + delta(2)*(dble(j-lo(2)) + HALF)
+          do i = lo(1), hi(1)
+             x = xlo(1) + delta(1)*(dble(i-lo(1)) + HALF)
+             f3 = zero
+  
+             do kz = mode_start*zstep, nzmodes, zstep
+                kzd = dble(kz)
+                do ky = mode_start*ystep, nymodes, ystep
+                   kyd = dble(ky)
+                   do kx = mode_start*xstep, nxmodes, xstep
+                      kxd = dble(kx)
+                      kappa = sqrt( (kxd*kxd)/(Lx*Lx) + (kyd*kyd)/(Ly*Ly) + (kzd*kzd)/(Lz*Lz) )
+                      if (kappa.le.kappaMax) then
+                         xT = cos(FTX(kx,ky,kz)*infl_time+TAT(kx,ky,kz))
+                         if (div_free_force.eq.1) then
+                            f3 = f3 + xT * ( FAY(kx,ky,kz)*twicePi*(kxd/HLx) &
+                                         * cos(twicePi*kxd*x/HLx+FPYX(kx,ky,kz)) &
+                                         * sin(twicePi*kyd*y/HLy+FPYY(kx,ky,kz)) &
+                                         * sin(twicePi*kzd*z/HLz+FPYZ(kx,ky,kz)) &
+                                        -    FAX(kx,ky,kz)*twicePi*(kyd/HLy) &
+                                         * sin(twicePi*kxd*x/HLx+FPXX(kx,ky,kz)) &
+                                         * cos(twicePi*kyd*y/HLy+FPXY(kx,ky,kz)) &
+                                         * sin(twicePi*kzd*z/HLz+FPXZ(kx,ky,kz)) )
+                         else
+                            f3 = f3 + xT*FAZ(kx,ky,kz)* sin(twicePi*kxd*x/HLx+FPX(kx,ky,kz)) &
+                                                      * sin(twicePi*kyd*y/HLy+FPY(kx,ky,kz)) &
+                                                      * cos(twicePi*kzd*z/HLz+FPZ(kx,ky,kz))
+                         endif
+                      endif
+                   enddo
+                enddo
+             enddo
+                  
+             do kz = 1, zstep - 1
+                kzd = dble(kz)
+                do ky = mode_start, nymodes
+                   kyd = dble(ky)
+                   do kx = mode_start, nxmodes
+                      kxd = dble(kx)
+                      kappa = sqrt( (kxd*kxd)/(Lx*Lx) + (kyd*kyd)/(Ly*Ly) + (kzd*kzd)/(Lz*Lz) )
+                      if (kappa.le.kappaMax) then
+                         xT = cos(FTX(kx,ky,kz)*infl_time+TAT(kx,ky,kz))
+                         if (div_free_force.eq.1) then
+                            f3 = f3 + xT * ( FAY(kx,ky,kz)*twicePi*(kxd/HLx) &
+                                         * cos(twicePi*kxd*x/HLx+FPYX(kx,ky,kz)) &
+                                         * sin(twicePi*kyd*y/HLy+FPYY(kx,ky,kz)) &
+                                         * sin(twicePi*kzd*z/HLz+FPYZ(kx,ky,kz)) &
+                                        -    FAX(kx,ky,kz)*twicePi*(kyd/HLy) &
+                                         * sin(twicePi*kxd*x/HLx+FPXX(kx,ky,kz)) &
+                                         * cos(twicePi*kyd*y/HLy+FPXY(kx,ky,kz)) &
+                                         * sin(twicePi*kzd*z/HLz+FPXZ(kx,ky,kz)) )
+                         else
+                            f3 = f3 + xT*FAZ(kx,ky,kz) * sin(twicePi*kxd*x/HLx+FPX(kx,ky,kz)) &
+                                                       * sin(twicePi*kyd*y/HLy+FPY(kx,ky,kz)) &
+                                                       * cos(twicePi*kzd*z/HLz+FPZ(kx,ky,kz))
+                         endif
+                      endif
+                   enddo
+                enddo
+             enddo
+                 
+             forcing(i,j,k,1) = dat(i,j,k,1) * f3
+                  
+          end do
+       end do
+    end do
+
+
+  end subroutine pc_derforcez
+
+#endif
+  
   subroutine pc_derkineng(kineng,k_lo,k_hi,nk, &
                           dat,d_lo,d_hi,nc, &
                           lo,hi,domlo,domhi,delta, &

--- a/Source/Src_nd/Make.package
+++ b/Source/Src_nd/Make.package
@@ -11,7 +11,7 @@ f90EXE_sources += interpolate.f90
 
 f90EXE_sources += sums_nd.f90
 F90EXE_sources += timestep.F90
-f90EXE_sources += Derive_nd.f90
+F90EXE_sources += Derive_nd.F90
 F90EXE_sources += problem_derive_nd.F90
 f90EXE_sources += riemann_util.f90
 

--- a/Source/Src_nd/forcing_src_nd.F90
+++ b/Source/Src_nd/forcing_src_nd.F90
@@ -10,10 +10,11 @@ module forcing_src_module
 
 contains
 
-  subroutine pc_forcing_src(lo,hi,&
-                            old_state,os_lo,os_hi,&
-                            new_state,ns_lo,ns_hi,&
-                            src,src_lo,src_hi,problo,dx,time,dt) bind(C, name = "pc_forcing_src")
+  subroutine pc_forcing_src(lo,hi, &
+                            old_state,os_lo,os_hi, &
+                            new_state,ns_lo,ns_hi, &
+                            src,src_lo,src_hi,problo,dx,xlo,xhi, &
+                            time,dt) bind(C, name = "pc_forcing_src")
 
     use bl_constants_module, only: ZERO
     use meth_params_module, only : NVAR, URHO, UMX, UMY, UMZ
@@ -25,6 +26,7 @@ contains
     integer,          intent(in   ) :: os_lo(3),os_hi(3)
     integer,          intent(in   ) :: ns_lo(3),ns_hi(3)
     integer,          intent(in   ) :: src_lo(3),src_hi(3)
+    double precision, intent(in   ) :: xlo(3), xhi(3)
     double precision, intent(in   ) :: old_state(os_lo(1):os_hi(1),os_lo(2):os_hi(2),os_lo(3):os_hi(3),NVAR)
     double precision, intent(in   ) :: new_state(ns_lo(1):ns_hi(1),ns_lo(2):ns_hi(2),ns_lo(3):ns_hi(3),NVAR)
     double precision, intent(inout) :: src(src_lo(1):src_hi(1),src_lo(2):src_hi(2),src_lo(3):src_hi(3),NVAR)


### PR DESCRIPTION
This branch adds the forced HIT test case.
It's basically the test case from Aspden et al. CAMCOS 2008 that was in IAMR, and cleaned to work in PeleC. A few routines have been added to Derive_nd. The major change is that Derive_nd is now F90 and no longer f90, because there is a flag (DO_HIT_FORCE) to add at compilation time to compile all of the "forcing" routines.