### PR TITLE
Some Make.PeleC modifications

### DIFF
--- a/Exec/Make.PeleC
+++ b/Exec/Make.PeleC
@@ -72,11 +72,11 @@ ifdef Chemistry_Model
   CHEM_HOME = $(PELE_PHYSICS_HOME)/Support/Fuego/Mechanism/Models/$(Chemistry_Model)
   VPATH_LOCATIONS += $(CHEM_HOME)
   Bpack += $(CHEM_HOME)/Make.package
+  Blocs += $(CHEM_HOME)
 
-  CHEM_HOME1 = $(PELE_PHYSICS_HOME)/Support/Fuego/Mechanism/
+  CHEM_HOME1 = $(PELE_PHYSICS_HOME)/Support/Fuego/Mechanism
   VPATH_LOCATIONS += $(CHEM_HOME1)
   Bpack += $(CHEM_HOME1)/Make.package
-  Blocs += $(CHEM_HOME1)
   Blocs += $(CHEM_HOME1)
 endif
 

--- a/Exec/RegTests/PMF/GNUmakefile
+++ b/Exec/RegTests/PMF/GNUmakefile
@@ -6,12 +6,11 @@ PROFILE    = FALSE
 
 DEBUG      = FALSE
 
-DIM        = 1
-DIM        = 2
+DIM        = 3
 
-COMP	   = gcc
+COMP	   = gnu
 
-USE_MPI    = TRUE
+USE_MPI    = FALSE
 
 USE_REACT  = TRUE
 

--- a/Exec/RegTests/PMF/GNUmakefile
+++ b/Exec/RegTests/PMF/GNUmakefile
@@ -6,11 +6,12 @@ PROFILE    = FALSE
 
 DEBUG      = FALSE
 
-DIM        = 3
+DIM        = 1
+DIM        = 2
 
-COMP	   = gnu
+COMP	   = gcc
 
-USE_MPI    = FALSE
+USE_MPI    = TRUE
 
 USE_REACT  = TRUE
 


### PR DESCRIPTION
I think this may be a mistake in `Make.PeleC`. I seem to have needed this change to allow me to compile with .F90 versions of Fuego files. This change doesn't seem to affect the original `.c` versions of Fuego models.