### PR TITLE
Remove AMReX F_interfaces and amrex_parallel_module from PeleC.

### DIFF
--- a/Exec/Make.PeleC
+++ b/Exec/Make.PeleC
@@ -119,10 +119,9 @@ endif
 Bdirs   := Source Source/param_includes Source/Src_nd Source/Src_$(DIM)d Source/TurbInflow
 
 ifeq ($(USE_EB), TRUE)
-  Pdirs := Base EB Amr Boundary AmrCore F_Interfaces/Base
+  Pdirs := Base EB Amr Boundary AmrCore
 else 
-  Pdirs := Base Amr Boundary AmrCore F_Interfaces/Base
-
+  Pdirs := Base Amr Boundary AmrCore
 endif
 
 ifeq ($(USE_PARTICLES), TRUE)

--- a/Exec/RegTests/HIT/Prob_nd.F90
+++ b/Exec/RegTests/HIT/Prob_nd.F90
@@ -10,7 +10,7 @@ contains
 
   subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(C, name = "amrex_probinit")
 
-    use amrex_parallel_module
+    use amrex_paralleldescriptor_module, only: amrex_pd_ioprocessor
     use probdata_module
     use amrex_fort_module
     use amrex_constants_module, only: HALF
@@ -103,7 +103,7 @@ contains
     const_conductivity = const_viscosity * eos_state % cp / prandtl
 
     ! Write this out to file (might be useful for postprocessing)
-    if ( amrex_parallel_ioprocessor() ) then
+    if ( amrex_pd_ioprocessor() ) then
        open(unit=out_unit,file="ic.txt",action="write",status="replace")
        write(out_unit,*)"lambda0, k0, rho0, urms0, tau, p0, T0, gamma, mu, k, c_s0, Reynolds, Mach, Prandtl, u0, v0, w0, forcing"
        write(out_unit,*) lambda0, "," , k0, "," , eos_state % rho, "," , urms0, "," , tau, "," , &
@@ -123,7 +123,7 @@ contains
     ! domain (hence the mod operations in the interpolation).
 
     if (restart) then
-       if ( amrex_parallel_ioprocessor() ) then
+       if ( amrex_pd_ioprocessor() ) then
           write(*,*)"Skipping input file reading and assuming restart."
        endif
     else

--- a/Exec/RegTests/MMS/Prob_nd.F90
+++ b/Exec/RegTests/MMS/Prob_nd.F90
@@ -111,7 +111,7 @@ contains
        state,state_lo,state_hi, &
        delta,xlo,xhi) bind(C, name="pc_initdata")
 
-    use amrex_parallel_module
+    use amrex_paralleldescriptor_module, only: amrex_pd_ioprocessor
     use probdata_module
     use network, only: nspec, naux, molec_wt
     use fundamental_constants_module, only: k_B, n_A
@@ -220,7 +220,7 @@ contains
     call masa_set_param("deltabar",delta(1))
 
     ! Display and check
-    if ( amrex_parallel_ioprocessor() ) then
+    if ( amrex_pd_ioprocessor() ) then
        call masa_display_param()
     endif
     call masa_sanity_check()

--- a/Exec/RegTests/TG/Prob_nd.F90
+++ b/Exec/RegTests/TG/Prob_nd.F90
@@ -82,7 +82,7 @@ contains
        state,state_lo,state_hi, &
        delta,xlo,xhi) bind(C, name="pc_initdata")
 
-     use amrex_parallel_module
+    use amrex_paralleldescriptor_module, only: amrex_pd_ioprocessor
     use probdata_module
     use network, only: nspec, naux, molec_wt
     use eos_type_module
@@ -138,7 +138,7 @@ contains
     state(:,:,:,UTEMP) = T0
 
     ! Write this out to file (might be useful for postprocessing)
-    if ( amrex_parallel_ioprocessor() ) then
+    if ( amrex_pd_ioprocessor() ) then
        open(unit=out_unit,file="ic.txt",action="write",status="replace")
        write(out_unit,*)"L, rho0, v0, p0, T0, gamma, mu, k, c_s0, Reynolds, Mach, Prandtl, omega_x, omega_y, omega_z"
        write(out_unit,*) L, "," , eos_state % rho, "," , v0, "," , eos_state % p, "," , &

--- a/Source/Src_nd/PeleC_nd.F90
+++ b/Source/Src_nd/PeleC_nd.F90
@@ -370,7 +370,6 @@ subroutine set_method_params(dm,Density,Xmom,Eden,Eint,Temp, &
 
   use meth_params_module
   use network, only : nspec, naux
-  use amrex_parallel_module, only : amrex_parallel_init
   use eos_module, only : eos_init, eos_get_small_dens, eos_get_small_temp
   use transport_module, only : transport_init
   use amrex_constants_module, only : ZERO, ONE
@@ -390,8 +389,6 @@ subroutine set_method_params(dm,Density,Xmom,Eden,Eint,Temp, &
   integer :: QLAST
 
   integer :: ioproc
-
-  call amrex_parallel_init()
 
   !---------------------------------------------------------------------
   ! conserved state components


### PR DESCRIPTION
This allows me to build with the Intel compiler.

Please delete the `fix_intel` branches after merge.