### PR TITLE
Adding the full path to Make.PeleC

### DIFF
--- a/Exec/RegTests/zeroD/GNUmakefile
+++ b/Exec/RegTests/zeroD/GNUmakefile
@@ -39,4 +39,4 @@ Transport_dir := EGLib
 Bpack   := ./Make.package
 Blocs   := .
 
-include ../../Make.PeleC
+include ${PELEC_HOME}/Exec/Make.PeleC


### PR DESCRIPTION
A small change to the zeroD/GNUmakefile to get the full path to Make.PeleC. 