### PR TITLE
Changes in PeleC to build against AMReX development branch. 

### DIFF
--- a/CMake/amrex_sources.cmake
+++ b/CMake/amrex_sources.cmake
@@ -27,87 +27,205 @@ function(get_amrex_sources)
    )
    set(AMREX_SOURCE_DIR "${CMAKE_SOURCE_DIR}/Submodules/AMReX/Src/Base")
    add_sources(GlobalSourceList
+     # Utility classes ---------------------------------------------------------
+     ${AMREX_SOURCE_DIR}/AMReX_ccse-mpi.H
+     ${AMREX_SOURCE_DIR}/AMReX_Array.H
+     ${AMREX_SOURCE_DIR}/AMReX_Vector.H
+     ${AMREX_SOURCE_DIR}/AMReX_Tuple.H
      ${AMREX_SOURCE_DIR}/AMReX.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_Arena.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_BArena.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_BCRec.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_BCUtil.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_BLBackTrace.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_BLProfiler.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_BLProfiler_F.F90
-     ${AMREX_SOURCE_DIR}/AMReX_BLutil_F.F90
-     ${AMREX_SOURCE_DIR}/AMReX_BaseFab.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_BaseUmap_nd.f90
-     ${AMREX_SOURCE_DIR}/AMReX_Box.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_BoxArray.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_BoxDomain.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_BoxIterator.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_BoxList.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_CArena.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_CoordSys.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_CudaAllocators.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_CudaAsyncArray.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_CudaAsyncFab.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_CudaAsyncFabImpl.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_CudaDevice.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_CudaElixir.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_CudaLaunch.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_CudaUtility.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_DArena.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_DistributionMapping.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_FArrayBox.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_FILCC_${AMREX_DIM}D.F90
-     ${AMREX_SOURCE_DIR}/AMReX_FPC.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_FabAllocator.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_FabArrayBase.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_FabConv.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_ForkJoin.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_Geometry.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_GpuControl.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_IArrayBox.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_IndexType.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_IntConv.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_IntVect.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_Lazy.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_MFCopyDescriptor.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_MFIter.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_Machine.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_MemPool.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_MemProfiler.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_MultiFab.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_MultiFabUtil.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_MultiFabUtil_Perilla.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_NFiles.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_Orientation.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_ParallelContext.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_ParallelDescriptor.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_ParallelDescriptor_F.F90
-     ${AMREX_SOURCE_DIR}/AMReX_ParmParse.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_Periodicity.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_PhysBCFunct.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_PlotFileDataImpl.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_PlotFileUtil.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_RealBox.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_RealVect.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_TinyProfiler.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_Utility.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_VectorIO.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_VisMF.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_acc_mod.F90
-     ${AMREX_SOURCE_DIR}/AMReX_bc_types_mod.F90
-     ${AMREX_SOURCE_DIR}/AMReX_constants_mod.f90
      ${AMREX_SOURCE_DIR}/AMReX_error_fi.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_error_mod.F90
-     ${AMREX_SOURCE_DIR}/AMReX_filcc_mod.F90
-     ${AMREX_SOURCE_DIR}/AMReX_fort_mod.F90
-     ${AMREX_SOURCE_DIR}/AMReX_iMultiFab.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_io_mod.F90
-     ${AMREX_SOURCE_DIR}/AMReX_mempool_mod.F90
-     ${AMREX_SOURCE_DIR}/AMReX_omp_mod.F90
+     ${AMREX_SOURCE_DIR}/AMReX.H
+     ${AMREX_SOURCE_DIR}/AMReX_Exception.H
+     ${AMREX_SOURCE_DIR}/AMReX.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_error_fi.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_Extension.H
+     ${AMREX_SOURCE_DIR}/AMReX_IndexSequence.H
+     ${AMREX_SOURCE_DIR}/AMReX_ParmParse.cpp
      ${AMREX_SOURCE_DIR}/AMReX_parmparse_fi.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_parmparse_mod.F90
+     ${AMREX_SOURCE_DIR}/AMReX_ParmParse.H
+     ${AMREX_SOURCE_DIR}/AMReX_Utility.H
+     ${AMREX_SOURCE_DIR}/AMReX_Utility.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_BLassert.H
+     ${AMREX_SOURCE_DIR}/AMReX_ArrayLim.H
+     ${AMREX_SOURCE_DIR}/AMReX_REAL.H
+     ${AMREX_SOURCE_DIR}/AMReX_CONSTANTS.H
+     ${AMREX_SOURCE_DIR}/AMReX_SPACE.H
+     ${AMREX_SOURCE_DIR}/AMReX_DistributionMapping.H
+     ${AMREX_SOURCE_DIR}/AMReX_DistributionMapping.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_ParallelDescriptor.H
+     ${AMREX_SOURCE_DIR}/AMReX_ParallelDescriptor.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_ParallelReduce.H
+     ${AMREX_SOURCE_DIR}/AMReX_ForkJoin.H
+     ${AMREX_SOURCE_DIR}/AMReX_ForkJoin.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_ParallelContext.H
+     ${AMREX_SOURCE_DIR}/AMReX_ParallelContext.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_VisMF.H
+     ${AMREX_SOURCE_DIR}/AMReX_VisMF.cpp 
+     ${AMREX_SOURCE_DIR}/AMReX_Arena.H
+     ${AMREX_SOURCE_DIR}/AMReX_Arena.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_BArena.H
+     ${AMREX_SOURCE_DIR}/AMReX_BArena.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_CArena.H
+     ${AMREX_SOURCE_DIR}/AMReX_CArena.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_DArena.H
+     ${AMREX_SOURCE_DIR}/AMReX_DArena.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_EArena.H
+     ${AMREX_SOURCE_DIR}/AMReX_EArena.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_FabAllocator.H
+     ${AMREX_SOURCE_DIR}/AMReX_FabAllocator.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_BLProfiler.H
+     ${AMREX_SOURCE_DIR}/AMReX_BLBackTrace.H
+     ${AMREX_SOURCE_DIR}/AMReX_BLFort.H
+     ${AMREX_SOURCE_DIR}/AMReX_NFiles.H
+     ${AMREX_SOURCE_DIR}/AMReX_NFiles.cpp  
+     ${AMREX_SOURCE_DIR}/AMReX_parstream.H
      ${AMREX_SOURCE_DIR}/AMReX_parstream.cpp
+     # I/O stuff  --------------------------------------------------------------
+     ${AMREX_SOURCE_DIR}/AMReX_FabConv.H  
+     ${AMREX_SOURCE_DIR}/AMReX_FabConv.cpp  
+     ${AMREX_SOURCE_DIR}/AMReX_FPC.H
+     ${AMREX_SOURCE_DIR}/AMReX_FPC.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_VectorIO.H
+     ${AMREX_SOURCE_DIR}/AMReX_VectorIO.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_Print.H
+     ${AMREX_SOURCE_DIR}/AMReX_IntConv.H
+     ${AMREX_SOURCE_DIR}/AMReX_IntConv.cpp
+     # Index space -------------------------------------------------------------
+     ${AMREX_SOURCE_DIR}/AMReX_Box.H
+     ${AMREX_SOURCE_DIR}/AMReX_Box.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_BoxIterator.H 
+     ${AMREX_SOURCE_DIR}/AMReX_BoxIterator.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_IntVect.H
+     ${AMREX_SOURCE_DIR}/AMReX_IntVect.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_IndexType.H
+     ${AMREX_SOURCE_DIR}/AMReX_IndexType.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_Orientation.H 
+     ${AMREX_SOURCE_DIR}/AMReX_Orientation.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_Periodicity.H 
+     ${AMREX_SOURCE_DIR}/AMReX_Periodicity.cpp
+     # Real space --------------------------------------------------------------
+     ${AMREX_SOURCE_DIR}/AMReX_RealBox.H
+     ${AMREX_SOURCE_DIR}/AMReX_RealBox.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_RealVect.H
+     ${AMREX_SOURCE_DIR}/AMReX_RealVect.cpp
+     # Unions of rectangle -----------------------------------------------------
+     ${AMREX_SOURCE_DIR}/AMReX_BoxList.H
+     ${AMREX_SOURCE_DIR}/AMReX_BoxList.cpp 
+     ${AMREX_SOURCE_DIR}/AMReX_BoxArray.H 
+     ${AMREX_SOURCE_DIR}/AMReX_BoxArray.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_BoxDomain.H
+     ${AMREX_SOURCE_DIR}/AMReX_BoxDomain.cpp
+     # Fortran array data ------------------------------------------------------
+     ${AMREX_SOURCE_DIR}/AMReX_FArrayBox.H
+     ${AMREX_SOURCE_DIR}/AMReX_FArrayBox.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_IArrayBox.H
+     ${AMREX_SOURCE_DIR}/AMReX_IArrayBox.cpp 
+     ${AMREX_SOURCE_DIR}/AMReX_BaseFab.H
+     ${AMREX_SOURCE_DIR}/AMReX_BaseFab.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_MakeType.H
+     ${AMREX_SOURCE_DIR}/AMReX_TypeTraits.H
+     ${AMREX_SOURCE_DIR}/AMReX_FabFactory.H
+     ${AMREX_SOURCE_DIR}/AMReX_BaseFabUtility.H
+     # Fortran data defined on unions of rectangles ----------------------------
+     ${AMREX_SOURCE_DIR}/AMReX_MultiFab.cpp 
+     ${AMREX_SOURCE_DIR}/AMReX_MultiFab.H
+     ${AMREX_SOURCE_DIR}/AMReX_MFCopyDescriptor.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_MFCopyDescriptor.H
+     ${AMREX_SOURCE_DIR}/AMReX_iMultiFab.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_iMultiFab.H
+     ${AMREX_SOURCE_DIR}/AMReX_FabArrayBase.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_FabArrayBase.H 
+     ${AMREX_SOURCE_DIR}/AMReX_MFIter.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_MFIter.H
+     ${AMREX_SOURCE_DIR}/AMReX_FabArray.H
+     ${AMREX_SOURCE_DIR}/AMReX_FACopyDescriptor.H
+     ${AMREX_SOURCE_DIR}/AMReX_FabArrayCommI.H
+     ${AMREX_SOURCE_DIR}/AMReX_FabArrayUtility.H
+     ${AMREX_SOURCE_DIR}/AMReX_LayoutData.H
+     # Geometry / Coordinate system routines -----------------------------------
+     ${AMREX_SOURCE_DIR}/AMReX_CoordSys.cpp 
+     ${AMREX_SOURCE_DIR}/AMReX_CoordSys.H
+     ${AMREX_SOURCE_DIR}/AMReX_Geometry.cpp 
+     ${AMREX_SOURCE_DIR}/AMReX_Geometry.H
+     ${AMREX_SOURCE_DIR}/AMReX_MultiFabUtil.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_MultiFabUtil.H
+     # Boundary-related --------------------------------------------------------
+     ${AMREX_SOURCE_DIR}/AMReX_BCRec.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_BCRec.H 
+     ${AMREX_SOURCE_DIR}/AMReX_PhysBCFunct.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_PhysBCFunct.H 
+     ${AMREX_SOURCE_DIR}/AMReX_BCUtil.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_BCUtil.H
+     ${AMREX_SOURCE_DIR}/AMReX_BC_TYPES.H 
+     # Plotfile ----------------------------------------------------------------
+     ${AMREX_SOURCE_DIR}/AMReX_PlotFileUtil.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_PlotFileUtil.H
+     ${AMREX_SOURCE_DIR}/AMReX_PlotFileDataImpl.H
+     ${AMREX_SOURCE_DIR}/AMReX_PlotFileDataImpl.cpp
+     # Fortran interface routines.
+     # In GNUMake system, this is included only if BL_NO_FORT=FALSE ------------
+     ${AMREX_SOURCE_DIR}/AMReX_COORDSYS_${AMREX_DIM}D_C.H
+     ${AMREX_SOURCE_DIR}/AMReX_COORDSYS_C.H
+     ${AMREX_SOURCE_DIR}/AMReX_filcc_f.H
+     ${AMREX_SOURCE_DIR}/AMReX_BLutil_F.F90
+     ${AMREX_SOURCE_DIR}/AMReX_BLProfiler_F.F90
+     ${AMREX_SOURCE_DIR}/AMReX_FILCC_${AMREX_DIM}D.F90
+     ${AMREX_SOURCE_DIR}/AMReX_MultiFabUtil_${AMREX_DIM}D_C.H
+     ${AMREX_SOURCE_DIR}/AMReX_MultiFabUtil_nd_C.H
+     ${AMREX_SOURCE_DIR}/AMReX_MultiFabUtil_C.H
+     ${AMREX_SOURCE_DIR}/AMReX_FilCC_${AMREX_DIM}D_C.H
+     ${AMREX_SOURCE_DIR}/AMReX_FilCC_C.H
+     ${AMREX_SOURCE_DIR}/AMReX_filcc_mod.F90
+     ${AMREX_SOURCE_DIR}/AMReX_omp_mod.F90
+     ${AMREX_SOURCE_DIR}/AMReX_acc_mod.F90
+     ${AMREX_SOURCE_DIR}/AMReX_fort_mod.F90
+     ${AMREX_SOURCE_DIR}/AMReX_constants_mod.f90
+     ${AMREX_SOURCE_DIR}/AMReX_error_mod.F90
+     ${AMREX_SOURCE_DIR}/AMReX_parmparse_mod.F90
      ${AMREX_SOURCE_DIR}/AMReX_string_mod.F90
+     ${AMREX_SOURCE_DIR}/AMReX_bc_types_mod.F90
+     ${AMREX_SOURCE_DIR}/AMReX_ParallelDescriptor_F.F90
+     ${AMREX_SOURCE_DIR}/AMReX_io_mod.F90
+     # GPU --------------------------------------------------------------------
+     ${AMREX_SOURCE_DIR}/AMReX_Gpu.H
+     ${AMREX_SOURCE_DIR}/AMReX_GpuQualifiers.H
+     ${AMREX_SOURCE_DIR}/AMReX_GpuControl.H
+     ${AMREX_SOURCE_DIR}/AMReX_GpuControl.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_GpuLaunch.H
+     ${AMREX_SOURCE_DIR}/AMReX_GpuError.H
+     # CUDA --------------------------------------------------------------------
+     ${AMREX_SOURCE_DIR}/AMReX_CudaAllocators.H
+     ${AMREX_SOURCE_DIR}/AMReX_CudaAllocators.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_CudaRange.H
+     ${AMREX_SOURCE_DIR}/AMReX_CudaMemory.H
+     ${AMREX_SOURCE_DIR}/AMReX_CudaAllocators.H
+     ${AMREX_SOURCE_DIR}/AMReX_CudaLaunch.H
+     ${AMREX_SOURCE_DIR}/AMReX_CudaLaunch.cpp 
+     ${AMREX_SOURCE_DIR}/AMReX_CudaContainers.H
+     ${AMREX_SOURCE_DIR}/AMReX_CudaReduce.H
+     ${AMREX_SOURCE_DIR}/AMReX_GpuDevice.H
+     ${AMREX_SOURCE_DIR}/AMReX_GpuDevice.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_GpuUtility.H
+     ${AMREX_SOURCE_DIR}/AMReX_GpuUtility.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_GpuAsyncFab.H
+     ${AMREX_SOURCE_DIR}/AMReX_GpuAsyncFab.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_GpuAsyncFabImpl.H
+     ${AMREX_SOURCE_DIR}/AMReX_GpuAsyncFabImpl.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_GpuAsyncArray.H
+     ${AMREX_SOURCE_DIR}/AMReX_GpuAsyncArray.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_CudaElixir.H
+     ${AMREX_SOURCE_DIR}/AMReX_CudaElixir.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_CudaGraph.H
+     # Machine model -----------------------------------------------------------
+     ${AMREX_SOURCE_DIR}/AMReX_Machine.H
+     ${AMREX_SOURCE_DIR}/AMReX_Machine.cpp
+     # Memory pool -------------------------------------------------------------
+     ${AMREX_SOURCE_DIR}/AMReX_MemPool.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_MemPool.H
+     ${AMREX_SOURCE_DIR}/AMReX_mempool_mod.F90 # if BL_NO_FORT = FALSE
+     # Profiling ---------------------------------------------------------------
+     ${AMREX_SOURCE_DIR}/AMReX_BLProfiler.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_BLBackTrace.cpp 
    )
    set(AMREX_SOURCE_DIR "${CMAKE_SOURCE_DIR}/Submodules/AMReX/Src/F_Interfaces/AmrCore")
    add_sources(GlobalSourceList

--- a/CMake/plot_tool_sources.cmake
+++ b/CMake/plot_tool_sources.cmake
@@ -1,81 +1,83 @@
 function(get_plot_tool_sources PLOT_TOOL_NAME)
    set(AMREX_SOURCE_DIR "${CMAKE_SOURCE_DIR}/Submodules/AMReX/Src/Base")
    add_sources(GlobalPlotToolSourceList
-     ${AMREX_SOURCE_DIR}/AMReX.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_error_fi.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_ParmParse.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_parmparse_fi.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_Utility.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_DistributionMapping.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_ParallelDescriptor.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_ForkJoin.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_ParallelContext.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_VisMF.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_Arena.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_BArena.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_CArena.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_DArena.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_EArena.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_FabAllocator.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_NFiles.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_parstream.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_GpuControl.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_CudaDevice.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_CudaLaunch.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_CudaUtility.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_CudaAllocators.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_CudaAsyncFab.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_CudaAsyncFabImpl.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_CudaAsyncArray.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_CudaElixir.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_FabConv.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_FPC.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_IntConv.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_VectorIO.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_Box.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_BoxIterator.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_IntVect.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_IndexType.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_Orientation.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_Periodicity.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_RealBox.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_RealVect.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_BoxList.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_BoxArray.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_BoxDomain.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_FArrayBox.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_IArrayBox.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_BaseFab.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_MultiFab.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_MFCopyDescriptor.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_iMultiFab.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_FabArrayBase.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_MFIter.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_CoordSys.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_Geometry.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_MultiFabUtil.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_MultiFabUtil_Perilla.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_BCRec.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_PhysBCFunct.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_BCUtil.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_PlotFileUtil.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_PlotFileDataImpl.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_BLProfiler.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_BLBackTrace.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_MemPool.cpp
+     # CPP
      ${AMREX_SOURCE_DIR}/AMReX_Machine.cpp
-     ${AMREX_SOURCE_DIR}/AMReX_fort_mod.F90
+     ${AMREX_SOURCE_DIR}/AMReX_MemPool.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_BLBackTrace.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_BLProfiler.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_PlotFileDataImpl.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_PlotFileUtil.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_BCUtil.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_PhysBCFunct.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_BCRec.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_MultiFabUtil_Perilla.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_MultiFabUtil.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_Geometry.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_CoordSys.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_MFIter.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_FabArrayBase.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_iMultiFab.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_MFCopyDescriptor.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_MultiFab.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_BaseFab.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_IArrayBox.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_FArrayBox.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_BoxDomain.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_BoxArray.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_BoxList.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_RealVect.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_RealBox.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_Periodicity.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_Orientation.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_IndexType.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_IntVect.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_BoxIterator.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_Box.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_VectorIO.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_IntConv.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_FPC.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_FabConv.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_CudaElixir.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_GpuAsyncArray.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_GpuAsyncFabImpl.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_GpuAsyncFab.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_CudaAllocators.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_GpuUtility.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_CudaLaunch.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_GpuDevice.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_GpuControl.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_parstream.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_NFiles.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_FabAllocator.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_EArena.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_DArena.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_CArena.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_BArena.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_Arena.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_VisMF.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_ParallelContext.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_ForkJoin.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_ParallelDescriptor.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_DistributionMapping.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_Utility.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_parmparse_fi.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_ParmParse.cpp
+     ${AMREX_SOURCE_DIR}/AMReX_error_fi.cpp
+     ${AMREX_SOURCE_DIR}/AMReX.cpp
+     # Fortran
      ${AMREX_SOURCE_DIR}/AMReX_constants_mod.f90
-     ${AMREX_SOURCE_DIR}/AMReX_bc_types_mod.F90
-     ${AMREX_SOURCE_DIR}/AMReX_filcc_mod.F90
      ${AMREX_SOURCE_DIR}/AMReX_FILCC_3D.F90
      ${AMREX_SOURCE_DIR}/AMReX_BLutil_F.F90
      ${AMREX_SOURCE_DIR}/AMReX_BLProfiler_F.F90
+     ${AMREX_SOURCE_DIR}/AMReX_filcc_mod.F90
      ${AMREX_SOURCE_DIR}/AMReX_omp_mod.F90
      ${AMREX_SOURCE_DIR}/AMReX_acc_mod.F90
-     ${AMREX_SOURCE_DIR}/AMReX_string_mod.F90
+     ${AMREX_SOURCE_DIR}/AMReX_fort_mod.F90
      ${AMREX_SOURCE_DIR}/AMReX_error_mod.F90
      ${AMREX_SOURCE_DIR}/AMReX_parmparse_mod.F90
+     ${AMREX_SOURCE_DIR}/AMReX_string_mod.F90
+     ${AMREX_SOURCE_DIR}/AMReX_bc_types_mod.F90
      ${AMREX_SOURCE_DIR}/AMReX_io_mod.F90
      ${AMREX_SOURCE_DIR}/AMReX_ParallelDescriptor_F.F90
      ${AMREX_SOURCE_DIR}/AMReX_mempool_mod.F90

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -280,14 +280,14 @@ PeleC::read_params ()
   // Check phys_bc against possible periodic geometry
   // if periodic, must have internal BC marked.
   //
-  if (Geometry::isAnyPeriodic())
+  if (DefaultGeometry().isAnyPeriodic())
   {
     //
     // Do idiot check.  Periodic means interior in those directions.
     //
     for (int dir = 0; dir<BL_SPACEDIM; dir++)
     {
-      if (Geometry::isPeriodic(dir))
+      if (DefaultGeometry().isPeriodic(dir))
       {
         if (lo_bc[dir] != Interior)
         {
@@ -330,32 +330,32 @@ PeleC::read_params ()
     }
   }
 
-  if ( Geometry::IsRZ() && (lo_bc[0] != Symmetry) ) {
+  if ( DefaultGeometry().IsRZ() && (lo_bc[0] != Symmetry) ) {
     std::cerr << "ERROR:PeleC::read_params: must set r=0 boundary condition to Symmetry for r-z\n";
     amrex::Error();
   }
 
   // TODO: Any reason to support spherical in PeleC?
 #if (BL_SPACEDIM == 1)
-  if ( Geometry::IsSPHERICAL() )
+  if ( DefaultGeometry().IsSPHERICAL() )
   {
-    if ( (lo_bc[0] != Symmetry) && (Geometry::ProbLo(0) == 0.0) )
+    if ( (lo_bc[0] != Symmetry) && (DefaultGeometry().ProbLo(0) == 0.0) )
     {
       std::cerr << "ERROR:PeleC::read_params: must set r=0 boundary condition to Symmetry for spherical\n";
       amrex::Error();
     }
   }
 #elif (BL_SPACEDIM == 2)
-  if ( Geometry::IsSPHERICAL() )
+  if ( DefaultGeometry().IsSPHERICAL() )
   {
     amrex::Abort("We don't support spherical coordinate systems in 2D");
   }
 #elif (BL_SPACEDIM == 3)
-  if ( Geometry::IsRZ() )
+  if ( DefaultGeometry().IsRZ() )
   {
     amrex::Abort("We don't support cylindrical coordinate systems in 3D");
   }
-  else if ( Geometry::IsSPHERICAL() )
+  else if ( DefaultGeometry().IsSPHERICAL() )
   {
     amrex::Abort("We don't support spherical coordinate systems in 3D");
   }
@@ -408,7 +408,7 @@ PeleC::read_params ()
     amrex::Error();
   }
 
-  if (hybrid_riemann == 1 && (Geometry::IsSPHERICAL() || Geometry::IsRZ() ))
+  if (hybrid_riemann == 1 && (DefaultGeometry().IsSPHERICAL() || DefaultGeometry().IsRZ() ))
   {
     std::cerr << "hybrid_riemann should only be used for Cartesian coordinates\n";
     amrex::Error();
@@ -533,7 +533,7 @@ PeleC::PeleC (Amr&            papa,
 		    level_geom, papa.Geom(level-1),
 		    papa.refRatio(level-1), level, NUM_STATE);
     
-    if (!Geometry::IsCartesian())
+    if (!DefaultGeometry().IsCartesian())
     {
       pres_reg.define(bl, papa.boxArray(level-1),
 		      dm, papa.DistributionMap(level-1),
@@ -580,7 +580,7 @@ PeleC::buildMetrics ()
 
     Real* rad = radius[i].dataPtr();
 
-    if (Geometry::IsCartesian())
+    if (DefaultGeometry().IsCartesian())
     {
       for (int j = 0; j < len; j++)
       {
@@ -1387,7 +1387,7 @@ PeleC::reflux ()
 
   fine_level.flux_reg.Reflux(S_crse, vfrac, S_fine, fine_level.vfrac);
 
-  if (!Geometry::IsCartesian())
+  if (!DefaultGeometry().IsCartesian())
   {
     amrex::Abort("rz not yet compatible with EB");
   }
@@ -1396,7 +1396,7 @@ PeleC::reflux ()
 
   fine_level.flux_reg.Reflux(S_crse);
 
-  if (!Geometry::IsCartesian())
+  if (!DefaultGeometry().IsCartesian())
   {
     MultiFab dr(volume.boxArray(),volume.DistributionMap(),1,volume.nGrow(),
                 MFInfo(),FArrayBoxFactory());

--- a/Source/PeleC_MOL.cpp
+++ b/Source/PeleC_MOL.cpp
@@ -552,7 +552,7 @@ PeleC::getMOLSrcTerm(const amrex::MultiFab& S,
                                 dxDp, dt, vfrac[mfi],
                                 {&((*areafrac[0])[mfi]),
                                     &((*areafrac[1])[mfi]),
-                                    &((*areafrac[2])[mfi])});
+                                    &((*areafrac[2])[mfi])}, RunOn::Cpu);
 #else
             // TODO: EBfluxregisters are designed only for 3D, need for 2D
             Print() << "WARNING:Re redistribution crseadd for EB not implemented\n";
@@ -568,7 +568,7 @@ PeleC::getMOLSrcTerm(const amrex::MultiFab& S,
                                 {&((*areafrac[0])[mfi]),
                                     &((*areafrac[1])[mfi]),
                                     &((*areafrac[2])[mfi])},
-                                dm_as_fine);
+                                dm_as_fine, RunOn::Cpu);
 #else
             // TODO: EBfluxregisters are designed only for 3D, need for 2D
             Print() << "WARNING:Re redistribution fineadd for EB not implemented in 2D\n";

--- a/Source/PeleC_MOL.cpp
+++ b/Source/PeleC_MOL.cpp
@@ -125,7 +125,7 @@ PeleC::getMOLSrcTerm(const amrex::MultiFab& S,
     int flag_nscbc_isAnyPerio = (geom.isAnyPeriodic()) ? 1 : 0; 
     int flag_nscbc_perio[BL_SPACEDIM]; // For 3D, we will know which corners have a periodicity
     for (int d=0; d<BL_SPACEDIM; ++d) {
-        flag_nscbc_perio[d] = (Geometry::isPeriodic(d)) ? 1 : 0;
+        flag_nscbc_perio[d] = (DefaultGeometry().isPeriodic(d)) ? 1 : 0;
     }
 	  const int*  domain_lo = geom.Domain().loVect();
 	  const int*  domain_hi = geom.Domain().hiVect();
@@ -597,13 +597,13 @@ PeleC::getMOLSrcTerm(const amrex::MultiFab& S,
           if (level < parent->finestLevel()) {
             getFluxReg(level+1).CrseAdd(mfi,
                                         {D_DECL(&flux_ec[0], &flux_ec[1], &flux_ec[2])},
-                                        dxDp, dt);
+                                        dxDp, dt, RunOn::Cpu);
           }
 
           if (level > 0) {
             getFluxReg(level).FineAdd(mfi,
                                       {D_DECL(&flux_ec[0], &flux_ec[1], &flux_ec[2])},
-                                      dxDp, dt);
+                                      dxDp, dt, RunOn::Cpu);
           }
         }
 

--- a/Source/PeleC_advance.cpp
+++ b/Source/PeleC_advance.cpp
@@ -32,7 +32,7 @@ PeleC::advance (Real time,
   {
     getFluxReg(level+1).reset();
 
-    if (!Geometry::IsCartesian()) {
+    if (!DefaultGeometry().IsCartesian()) {
       amrex::Abort("Flux registers not r-z compatible yet");
       getPresReg(level+1).reset();
     }

--- a/Source/PeleC_hydro.cpp
+++ b/Source/PeleC_hydro.cpp
@@ -100,7 +100,7 @@ PeleC::construct_hydro_source(const MultiFab& S, Real time, Real dt, int amr_ite
   int flag_nscbc_isAnyPerio = (geom.isAnyPeriodic()) ? 1 : 0; 
   int flag_nscbc_perio[BL_SPACEDIM]; // For 3D, we will know which corners have a periodicity
   for (int d=0; d<BL_SPACEDIM; ++d) {
-        flag_nscbc_perio[d] = (Geometry::isPeriodic(d)) ? 1 : 0;
+        flag_nscbc_perio[d] = (DefaultGeometry().isPeriodic(d)) ? 1 : 0;
     }
 	const int*  domain_lo = geom.Domain().loVect();
 	const int*  domain_hi = geom.Domain().hiVect();
@@ -179,7 +179,7 @@ PeleC::construct_hydro_source(const MultiFab& S, Real time, Real dt, int amr_ite
 		    flux[i].resize(bxtmp,NUM_STATE);
 	    }
 
-	    if (!Geometry::IsCartesian()) {
+	    if (!DefaultGeometry().IsCartesian()) {
 		pradial.resize(amrex::surroundingNodes(bx,0),1);
 	    }
 
@@ -224,9 +224,9 @@ PeleC::construct_hydro_source(const MultiFab& S, Real time, Real dt, int amr_ite
             {
               if (level < finest_level)
               {
-                getFluxReg(level+1).CrseAdd(mfi,{D_DECL(&flux[0],&flux[1],&flux[2])}, dxDp,dt);
+                getFluxReg(level+1).CrseAdd(mfi,{D_DECL(&flux[0],&flux[1],&flux[2])}, dxDp,dt,RunOn::Cpu);
 
-                if (!Geometry::IsCartesian()) {
+                if (!DefaultGeometry().IsCartesian()) {
                     amrex::Abort("Flux registers not r-z compatible yet");
                     //getPresReg(level+1).CrseAdd(mfi,pradial, dx,dt);
                 }
@@ -234,9 +234,9 @@ PeleC::construct_hydro_source(const MultiFab& S, Real time, Real dt, int amr_ite
 
               if (level > 0)
               {
-                getFluxReg(level).FineAdd(mfi, {D_DECL(&flux[0],&flux[1],&flux[2])}, dxDp,dt);
+                getFluxReg(level).FineAdd(mfi, {D_DECL(&flux[0],&flux[1],&flux[2])}, dxDp,dt, RunOn::Cpu);
 
-                if (!Geometry::IsCartesian()) {
+                if (!DefaultGeometry().IsCartesian()) {
                     amrex::Abort("Flux registers not r-z compatible yet");
                     //getPresReg(level).FineAdd(mfi,pradial, dx,dt);
                 }

--- a/Source/PeleC_init_eb.cpp
+++ b/Source/PeleC_init_eb.cpp
@@ -470,8 +470,8 @@ initialize_EB2 (const Geometry& geom, const int required_level, const int max_le
         
     auto polys = EB2::makeUnion(farwall, ramp, pipe, flat_corner);
 
-    Real lenx = Geometry::ProbLength(0);
-    Real leny = Geometry::ProbLength(1);
+    Real lenx = DefaultGeometry().ProbLength(0);
+    Real leny = DefaultGeometry().ProbLength(1);
     auto pr = EB2::translate(EB2::lathe(polys), {lenx*0.5, leny*0.5, 0.});
         
     auto gshop = EB2::makeShop(pr);

--- a/Source/PeleC_io.cpp
+++ b/Source/PeleC_io.cpp
@@ -204,7 +204,7 @@ PeleC::restart (Amr&     papa,
                         geom, papa.Geom(level-1),
                         papa.refRatio(level-1), level, NUM_STATE);
 
-	if (!Geometry::IsCartesian()) {
+	if (!DefaultGeometry().IsCartesian()) {
             pres_reg.define(grids, papa.boxArray(level-1),
                             dmap, papa.DistributionMap(level-1),
                             geom, papa.Geom(level-1),
@@ -747,10 +747,10 @@ PeleC::writePlotFile (const std::string& dir,
         int f_lev = parent->finestLevel();
         os << f_lev << '\n';
         for (i = 0; i < BL_SPACEDIM; i++)
-            os << Geometry::ProbLo(i) << ' ';
+            os << DefaultGeometry().ProbLo(i) << ' ';
         os << '\n';
         for (i = 0; i < BL_SPACEDIM; i++)
-            os << Geometry::ProbHi(i) << ' ';
+            os << DefaultGeometry().ProbHi(i) << ' ';
         os << '\n';
         for (i = 0; i < f_lev; i++)
             os << parent->refRatio(i)[0] << ' ';
@@ -767,7 +767,7 @@ PeleC::writePlotFile (const std::string& dir,
                 os << parent->Geom(i).CellSize()[k] << ' ';
             os << '\n';
         }
-        os << (int) Geometry::Coord() << '\n';
+        os << (int) DefaultGeometry().Coord() << '\n';
         os << "0\n"; // Write bndry data.
 
 	writeJobInfo(dir);
@@ -949,10 +949,10 @@ PeleC::writeSmallPlotFile (const std::string& dir,
         int f_lev = parent->finestLevel();
         os << f_lev << '\n';
         for (i = 0; i < BL_SPACEDIM; i++)
-            os << Geometry::ProbLo(i) << ' ';
+            os << DefaultGeometry().ProbLo(i) << ' ';
         os << '\n';
         for (i = 0; i < BL_SPACEDIM; i++)
-            os << Geometry::ProbHi(i) << ' ';
+            os << DefaultGeometry().ProbHi(i) << ' ';
         os << '\n';
         for (i = 0; i < f_lev; i++)
             os << parent->refRatio(i)[0] << ' ';
@@ -969,7 +969,7 @@ PeleC::writeSmallPlotFile (const std::string& dir,
                 os << parent->Geom(i).CellSize()[k] << ' ';
             os << '\n';
         }
-        os << (int) Geometry::Coord() << '\n';
+        os << (int) DefaultGeometry().Coord() << '\n';
         os << "0\n"; // Write bndry data.
 
         // job_info file with details about the run

--- a/Source/PeleC_setup.cpp
+++ b/Source/PeleC_setup.cpp
@@ -291,7 +291,7 @@ PeleC::variableSetUp ()
 	std::cout << "Using Ghost-Cells Navier-Stokes Characteristic BCs for diffusion: nscbc_diff = " << nscbc_diff << '\n' << '\n' ;
 
   
-    int coord_type = Geometry::Coord();
+    int coord_type = DefaultGeometry().Coord();
 
     // Get the center variable from the inputs and pass it directly to Fortran.
     Vector<Real> center(BL_SPACEDIM, 0.0);
@@ -300,7 +300,7 @@ PeleC::variableSetUp ()
   
     set_problem_params(dm,phys_bc.lo(),phys_bc.hi(),
 		       Interior,UserBC,Inflow,Outflow,Symmetry,SlipWall,NoSlipWall,coord_type,
-		       Geometry::ProbLo(),Geometry::ProbHi(),center.dataPtr());
+		       DefaultGeometry().ProbLo(),DefaultGeometry().ProbHi(),center.dataPtr());
   
     // Read in the parameters for the tagging criteria
     // and store them in the Fortran module.


### PR DESCRIPTION
Changes in PeleC to use the DefaultGeometry() object instead of the now deprocated static variables/functions in the Geometry class. Also changed FineAdd and CrseAdd in flux registers to have the 5th argument RunOn::Cpu.

These changes are in: 
PeleC.cpp 
PeleC_advance.cpp
PeleC_hydro.cpp 
PeleC_setup.cpp 
PeleC_MOL.cpp 
PeleC_io.cpp 