### PR TITLE
Consistent Makefiles

### DIFF
--- a/Exec/Make.PeleC
+++ b/Exec/Make.PeleC
@@ -1,7 +1,6 @@
-PELE_HOME         ?= ../
-PELEC_HOME        ?= $(PELE_HOME)
-PELE_PHYSICS_HOME ?= $(PELE_HOME)/Submodules/PelePhysics
-AMREX_HOME        ?= $(PELE_HOME)/Submodules/AMReX
+PELEC_HOME        ?= ../
+PELE_PHYSICS_HOME ?= $(PELEC_HOME)/Submodules/PelePhysics
+AMREX_HOME        ?= $(PELEC_HOME)/Submodules/AMReX
 
 TOP := $(PELEC_HOME)
 

--- a/Exec/RegTests/EB_MMS/GNUmakefile
+++ b/Exec/RegTests/EB_MMS/GNUmakefile
@@ -11,9 +11,6 @@ COMP	   = gcc
 USE_MPI    = FALSE
 USE_OMP    = FALSE
 
-# define the location of the PELE top directory
-PELE_HOME    := ../../..
-
 # This sets the EOS directory in $(PELE_PHYSICS_HOME)/Eos
 Eos_dir     := GammaLaw
 
@@ -34,7 +31,9 @@ endif
 
 Bpack   := ./Make.package
 
-include ../../Make.PeleC
+# define the location of the PELE top directory
+PELEC_HOME    := ../../..
+include $(PELEC_HOME)/Exec/Make.PeleC
 
 ifeq ($(DEBUG), TRUE)
 DEFINES += -DDEBUG

--- a/Exec/RegTests/HIT/GNUmakefile
+++ b/Exec/RegTests/HIT/GNUmakefile
@@ -10,9 +10,6 @@ COMP	   = gcc
 USE_MPI    = FALSE
 USE_OMP    = FALSE
 
-# define the location of the PELE top directory
-PELE_HOME    := ../../..
-
 # This sets the EOS directory in $(PELE_PHYSICS_HOME)/Eos
 Eos_dir     := GammaLaw
 
@@ -24,7 +21,9 @@ Transport_dir := Constant
 
 Bpack   := ./Make.package
 
-include ../../Make.PeleC
+# define the location of the PELE top directory
+PELEC_HOME    := ../../..
+include $(PELEC_HOME)/Exec/Make.PeleC
 
 ifeq ($(DEBUG), TRUE)
 DEFINES += -DDEBUG

--- a/Exec/RegTests/MMS/GNUmakefile
+++ b/Exec/RegTests/MMS/GNUmakefile
@@ -10,9 +10,6 @@ COMP	   = gcc
 USE_MPI    = FALSE
 USE_OMP    = FALSE
 
-# define the location of the PELE top directory
-PELE_HOME    := ../../..
-
 # This sets the EOS directory in $(PELE_PHYSICS_HOME)/Eos
 Eos_dir     := GammaLaw
 
@@ -33,7 +30,9 @@ endif
 
 Bpack   := ./Make.package
 
-include ../../Make.PeleC
+# define the location of the PELE top directory
+PELEC_HOME    := ../../..
+include $(PELEC_HOME)/Exec/Make.PeleC
 
 ifeq ($(DEBUG), TRUE)
 DEFINES += -DDEBUG

--- a/Exec/RegTests/PMF/GNUmakefile
+++ b/Exec/RegTests/PMF/GNUmakefile
@@ -18,9 +18,6 @@ USE_REACT  = TRUE
 
 #HYP_TYPE   = MOL
 
-# define the location of the PELE top directory
-PELE_HOME  := ../../..
-
 # This sets the EOS directory in $(PELE_PHYSICS_HOME)/Eos
 #Eos_dir     := Soave-Redlich-Kwong
 Eos_dir     := Fuego
@@ -39,4 +36,6 @@ Transport_dir := EGLib
 Bpack   := ./Make.package
 Blocs   := .
 
-include ../../Make.PeleC
+# define the location of the PELE top directory
+PELEC_HOME    := ../../..
+include $(PELEC_HOME)/Exec/Make.PeleC

--- a/Exec/RegTests/PMF_NSCBC/GNUmakefile
+++ b/Exec/RegTests/PMF_NSCBC/GNUmakefile
@@ -17,9 +17,6 @@ USE_REACT  = TRUE
 
 #HYP_TYPE   = MOL
 
-# define the location of the PELE top directory
-PELE_HOME  := ../../..
-
 # This sets the EOS directory in $(PELE_PHYSICS_HOME)/Eos
 #Eos_dir     := Soave-Redlich-Kwong
 Eos_dir     := Fuego
@@ -38,4 +35,6 @@ Transport_dir := EGLib
 Bpack   := ./Make.package
 Blocs   := .
 
-include ../../Make.PeleC
+# define the location of the PELE top directory
+PELEC_HOME    := ../../..
+include $(PELEC_HOME)/Exec/Make.PeleC

--- a/Exec/RegTests/Sedov/GNUmakefile
+++ b/Exec/RegTests/Sedov/GNUmakefile
@@ -10,9 +10,6 @@ COMP	   = gcc
 USE_MPI    = TRUE
 USE_OMP    = FALSE
 
-# define the location of the PELE top directory
-PELE_HOME    := ../../..
-
 # This sets the EOS directory in $(PELE_PHYSICS_HOME)/Eos
 Eos_dir     := GammaLaw
 
@@ -25,4 +22,6 @@ Transport_dir := Constant
 Bpack   := ./Make.package
 Blocs   := .
 
-include ../../Make.PeleC
+# define the location of the PELE top directory
+PELEC_HOME    := ../../..
+include $(PELEC_HOME)/Exec/Make.PeleC

--- a/Exec/RegTests/Sod/GNUmakefile
+++ b/Exec/RegTests/Sod/GNUmakefile
@@ -16,9 +16,6 @@ USE_OMP    = FALSE
 
 #HYP_TYPE = MOL
 
-# define the location of the PELE top directory
-PELE_HOME    := ../../..
-
 # This sets the EOS directory in $(PELE_PHYSICS_HOME)/Eos
 Eos_dir     := GammaLaw
 
@@ -31,4 +28,6 @@ Transport_dir := Constant
 Bpack   := ./Make.package
 Blocs   := .
 
-include ../../Make.PeleC
+# define the location of the PELE top directory
+PELEC_HOME    := ../../..
+include $(PELEC_HOME)/Exec/Make.PeleC

--- a/Exec/RegTests/SprayTests/amr_follow/GNUmakefile
+++ b/Exec/RegTests/SprayTests/amr_follow/GNUmakefile
@@ -20,7 +20,7 @@ SPRAY_COMPONENTS = 8
 DEFINES += -DSPRAY_COMPONENTS=$(SPRAY_COMPONENTS)
 
 # define the location of the PELE top directory
-#PELE_HOME    := ../../..
+#PELEC_HOME    := ../../..
 
 # This sets the EOS directory in $(PELE_PHYSICS_HOME)/Eos
 Eos_dir := Fuego
@@ -43,7 +43,9 @@ Transport_dir := EGLib
 Bpack   := ./Make.package 
 Blocs   := .
 
-include ${PELEC_HOME}/Exec/Make.PeleC
+# define the location of the PELE top directory
+PELEC_HOME    := ../../../..
+include $(PELEC_HOME)/Exec/Make.PeleC
 
 ifeq ($(DEBUG), TRUE)
 DEFINES += -DDEBUG

--- a/Exec/RegTests/TG/GNUmakefile
+++ b/Exec/RegTests/TG/GNUmakefile
@@ -10,8 +10,6 @@ COMP	   = gcc
 USE_MPI    = FALSE
 USE_OMP    = FALSE
 
-# define the location of the PELE top directory
-PELE_HOME    := ../../..
 
 # This sets the EOS directory in $(PELE_PHYSICS_HOME)/Eos
 Eos_dir     := GammaLaw
@@ -24,7 +22,9 @@ Transport_dir := Constant
 
 Bpack   := ./Make.package
 
-include ../../Make.PeleC
+# define the location of the PELE top directory
+PELEC_HOME    := ../../..
+include $(PELEC_HOME)/Exec/Make.PeleC
 
 ifeq ($(DEBUG), TRUE)
 DEFINES += -DDEBUG

--- a/Exec/RegTests/zeroD/GNUmakefile
+++ b/Exec/RegTests/zeroD/GNUmakefile
@@ -18,9 +18,6 @@ USE_REACT  = TRUE
 
 #HYP_TYPE   = MOL
 
-# define the location of the PELE top directory
-PELE_HOME  := ../../..
-
 # This sets the EOS directory in $(PELE_PHYSICS_HOME)/Eos
 #Eos_dir     := Soave-Redlich-Kwong
 Eos_dir     := Fuego
@@ -39,4 +36,6 @@ Transport_dir := EGLib
 Bpack   := ./Make.package
 Blocs   := .
 
-include ${PELEC_HOME}/Exec/Make.PeleC
+# define the location of the PELE top directory
+PELEC_HOME    := ../../..
+include $(PELEC_HOME)/Exec/Make.PeleC

--- a/Exec/Tutorials/EB_BackStep/GNUmakefile
+++ b/Exec/Tutorials/EB_BackStep/GNUmakefile
@@ -12,8 +12,6 @@ USE_OMP    = FALSE
 USE_EB = TRUE
 
 HYP_TYPE = MOL
-# define the location of the PELE top directory
-PELE_HOME    := ../../..
 
 # This sets the EOS directory in $(PELE_PHYSICS_HOME)/Eos
 Eos_dir     := GammaLaw
@@ -27,4 +25,6 @@ Transport_dir := Constant
 Bpack   := ./Make.package
 Blocs   := .
 
-include ${PELEC_HOME}/Exec/Make.PeleC
+# define the location of the PELE top directory
+PELEC_HOME := ../../..
+include $(PELEC_HOME)/Exec/Make.PeleC

--- a/Exec/Tutorials/EB_BluffBody/GNUmakefile
+++ b/Exec/Tutorials/EB_BluffBody/GNUmakefile
@@ -12,8 +12,6 @@ USE_OMP    = FALSE
 USE_EB = TRUE
 
 HYP_TYPE = MOL
-# define the location of the PELE top directory
-PELE_HOME    := ../../..
 
 # This sets the EOS directory in $(PELE_PHYSICS_HOME)/Eos
 Eos_dir     := GammaLaw
@@ -27,4 +25,6 @@ Transport_dir := Constant
 Bpack   := ./Make.package
 Blocs   := .
 
-include ../../Make.PeleC
+# define the location of the PELE top directory
+PELEC_HOME := ../../..
+include $(PELEC_HOME)/Exec/Make.PeleC

--- a/Exec/Tutorials/EB_Channel/GNUmakefile
+++ b/Exec/Tutorials/EB_Channel/GNUmakefile
@@ -12,8 +12,6 @@ USE_OMP    = FALSE
 USE_EB = TRUE
 
 HYP_TYPE = MOL
-# define the location of the PELE top directory
-PELE_HOME    := ../../..
 
 # This sets the EOS directory in $(PELE_PHYSICS_HOME)/Eos
 Eos_dir     := GammaLaw
@@ -27,4 +25,6 @@ Transport_dir := Constant
 Bpack   := ./Make.package
 Blocs   := .
 
-include ${PELEC_HOME}/Exec/Make.PeleC
+# define the location of the PELE top directory
+PELEC_HOME := ../../..
+include $(PELEC_HOME)/Exec/Make.PeleC

--- a/Exec/Tutorials/EB_OblqShock/GNUmakefile
+++ b/Exec/Tutorials/EB_OblqShock/GNUmakefile
@@ -12,8 +12,6 @@ USE_OMP    = FALSE
 USE_EB = TRUE
 
 HYP_TYPE = MOL
-# define the location of the PELE top directory
-#PELE_HOME    := ../../..
 
 # This sets the EOS directory in $(PELE_PHYSICS_HOME)/Eos
 Eos_dir     := GammaLaw
@@ -27,4 +25,6 @@ Transport_dir := Constant
 Bpack   := ./Make.package
 Blocs   := .
 
-include ../../Make.PeleC
+# define the location of the PELE top directory
+PELEC_HOME := ../../..
+include $(PELEC_HOME)/Exec/Make.PeleC

--- a/Exec/Tutorials/EB_Sphere/GNUmakefile
+++ b/Exec/Tutorials/EB_Sphere/GNUmakefile
@@ -22,9 +22,6 @@ HYP_TYPE = MOL
 #TINY_PROFILE = TRUE
 #PROFILE = TRUE
 
-# define the location of the PELE top directory
-PELE_HOME    := ../../..
-
 # This sets the EOS directory in $(PELE_PHYSICS_HOME)/Eos
 Eos_dir     := Fuego
 
@@ -41,5 +38,6 @@ Transport_dir := EGLib
 Bpack   := ./Make.package
 Blocs   := .
 
-
-include ../../Make.PeleC
+# define the location of the PELE top directory
+PELEC_HOME := ../../..
+include $(PELEC_HOME)/Exec/Make.PeleC

--- a/Exec/Tutorials/EB_Sphere/GNUmakefile.profile
+++ b/Exec/Tutorials/EB_Sphere/GNUmakefile.profile
@@ -28,9 +28,6 @@ DEBUG = FALSE
 
 HYP_TYPE = MOL
 
-# define the location of the PELE top directory
-PELE_HOME    := ../../..
-
 # This sets the EOS directory in $(PELE_PHYSICS_HOME)/Eos
 Eos_dir     := GammaLaw
 
@@ -43,5 +40,6 @@ Transport_dir := Constant
 Bpack   := ./Make.package
 Blocs   := .
 
-
-include ../Make.PeleC
+# define the location of the PELE top directory
+PELEC_HOME := ../../..
+include $(PELEC_HOME)/Exec/Make.PeleC

--- a/Exec/Tutorials/EB_stube/GNUmakefile
+++ b/Exec/Tutorials/EB_stube/GNUmakefile
@@ -12,8 +12,6 @@ USE_OMP    = FALSE
 USE_EB = TRUE
 
 HYP_TYPE = MOL
-# define the location of the PELE top directory
-PELE_HOME    := ../../..
 
 # This sets the EOS directory in $(PELE_PHYSICS_HOME)/Eos
 Eos_dir     := GammaLaw
@@ -27,4 +25,6 @@ Transport_dir := Constant
 Bpack   := ./Make.package
 Blocs   := .
 
-include ${PELEC_HOME}/Exec/Make.PeleC
+# define the location of the PELE top directory
+PELEC_HOME := ../../..
+include $(PELEC_HOME)/Exec/Make.PeleC

--- a/Exec/UnitTests/HIT_forced/GNUmakefile
+++ b/Exec/UnitTests/HIT_forced/GNUmakefile
@@ -12,9 +12,6 @@ USE_OMP    = FALSE
 
 #HYP_TYPE = MOL
 
-# define the location of the PELE top directory
-PELE_HOME    := ../../..
-
 # This sets the EOS directory in $(PELE_PHYSICS_HOME)/Eos
 Eos_dir     := GammaLaw
 
@@ -26,7 +23,9 @@ Transport_dir := Constant
 
 Bpack   := ./Make.package
 
-include ../../Make.PeleC
+# define the location of the PELE top directory
+PELEC_HOME    := ../../..
+include $(PELEC_HOME)/Exec/Make.PeleC
 
 DEFINES += -DO_HIT_FORCE
 

--- a/Exec/UnitTests/NSCBC_test_cases/1D_Channel_Inflow_Outflow/GNUmakefile
+++ b/Exec/UnitTests/NSCBC_test_cases/1D_Channel_Inflow_Outflow/GNUmakefile
@@ -10,9 +10,6 @@ COMP	   = gcc
 USE_MPI    = TRUE 
 USE_OMP    = FALSE
 
-# define the location of the PELE top directory
-PELE_HOME    := ../../../..
-
 # This sets the EOS directory in $(PELE_PHYSICS_HOME)/Eos
 Eos_dir     := GammaLaw
 
@@ -24,7 +21,9 @@ Transport_dir := Constant
 
 Bpack   := ./Make.package
 
-include ../../../Make.PeleC
+# define the location of the PELE top directory
+PELEC_HOME    := ../../../..
+include $(PELEC_HOME)/Exec/Make.PeleC
 
 ifeq ($(DEBUG), TRUE)
 DEFINES += -DDEBUG

--- a/Exec/UnitTests/NSCBC_test_cases/1D_Explo_Walls_NSCBC/GNUmakefile
+++ b/Exec/UnitTests/NSCBC_test_cases/1D_Explo_Walls_NSCBC/GNUmakefile
@@ -10,9 +10,6 @@ COMP	   = gcc
 USE_MPI    = TRUE 
 USE_OMP    = FALSE
 
-# define the location of the PELE top directory
-PELE_HOME    := ../../../..
-
 # This sets the EOS directory in $(PELE_PHYSICS_HOME)/Eos
 Eos_dir     := GammaLaw
 
@@ -24,7 +21,9 @@ Transport_dir := Constant
 
 Bpack   := ./Make.package
 
-include ../../../Make.PeleC
+# define the location of the PELE top directory
+PELEC_HOME    := ../../../..
+include $(PELEC_HOME)/Exec/Make.PeleC
 
 ifeq ($(DEBUG), TRUE)
 DEFINES += -DDEBUG

--- a/Exec/UnitTests/NSCBC_test_cases/2D_COVO_NSCBC_Inflow_Outflow_X/GNUmakefile
+++ b/Exec/UnitTests/NSCBC_test_cases/2D_COVO_NSCBC_Inflow_Outflow_X/GNUmakefile
@@ -10,9 +10,6 @@ COMP	   = gcc
 USE_MPI    = TRUE 
 USE_OMP    = FALSE
 
-# define the location of the PELE top directory
-PELE_HOME    := ../../../..
-
 # This sets the EOS directory in $(PELE_PHYSICS_HOME)/Eos
 Eos_dir     := GammaLaw
 
@@ -24,7 +21,9 @@ Transport_dir := Constant
 
 Bpack   := ./Make.package
 
-include ../../../Make.PeleC
+# define the location of the PELE top directory
+PELEC_HOME    := ../../../..
+include $(PELEC_HOME)/Exec/Make.PeleC
 
 ifeq ($(DEBUG), TRUE)
 DEFINES += -DDEBUG

--- a/Exec/UnitTests/NSCBC_test_cases/2D_COVO_NSCBC_X/GNUmakefile
+++ b/Exec/UnitTests/NSCBC_test_cases/2D_COVO_NSCBC_X/GNUmakefile
@@ -10,9 +10,6 @@ COMP	   = gcc
 USE_MPI    = TRUE 
 USE_OMP    = FALSE
 
-# define the location of the PELE top directory
-PELE_HOME    := ../../../..
-
 # This sets the EOS directory in $(PELE_PHYSICS_HOME)/Eos
 Eos_dir     := GammaLaw
 
@@ -24,7 +21,9 @@ Transport_dir := Constant
 
 Bpack   := ./Make.package
 
-include ../../../Make.PeleC
+# define the location of the PELE top directory
+PELEC_HOME    := ../../../..
+include $(PELEC_HOME)/Exec/Make.PeleC
 
 ifeq ($(DEBUG), TRUE)
 DEFINES += -DDEBUG

--- a/Exec/UnitTests/NSCBC_test_cases/2D_COVO_NSCBC_Y/GNUmakefile
+++ b/Exec/UnitTests/NSCBC_test_cases/2D_COVO_NSCBC_Y/GNUmakefile
@@ -10,9 +10,6 @@ COMP	   = gcc
 USE_MPI    = TRUE 
 USE_OMP    = FALSE
 
-# define the location of the PELE top directory
-PELE_HOME    := ../../../..
-
 # This sets the EOS directory in $(PELE_PHYSICS_HOME)/Eos
 Eos_dir     := GammaLaw
 
@@ -24,7 +21,9 @@ Transport_dir := Constant
 
 Bpack   := ./Make.package
 
-include ../../../Make.PeleC
+# define the location of the PELE top directory
+PELEC_HOME    := ../../../..
+include $(PELEC_HOME)/Exec/Make.PeleC
 
 ifeq ($(DEBUG), TRUE)
 DEFINES += -DDEBUG

--- a/Exec/UnitTests/NSCBC_test_cases/2D_Explo_Outflows_NSCBC/GNUmakefile
+++ b/Exec/UnitTests/NSCBC_test_cases/2D_Explo_Outflows_NSCBC/GNUmakefile
@@ -10,9 +10,6 @@ COMP	   = gcc
 USE_MPI    = TRUE 
 USE_OMP    = FALSE
 
-# define the location of the PELE top directory
-PELE_HOME    := ../../../..
-
 # This sets the EOS directory in $(PELE_PHYSICS_HOME)/Eos
 Eos_dir     := GammaLaw
 
@@ -24,7 +21,9 @@ Transport_dir := Constant
 
 Bpack   := ./Make.package
 
-include ../../../Make.PeleC
+# define the location of the PELE top directory
+PELEC_HOME    := ../../../..
+include $(PELEC_HOME)/Exec/Make.PeleC
 
 ifeq ($(DEBUG), TRUE)
 DEFINES += -DDEBUG

--- a/Exec/UnitTests/NSCBC_test_cases/2D_Explo_Walls_NSCBC/GNUmakefile
+++ b/Exec/UnitTests/NSCBC_test_cases/2D_Explo_Walls_NSCBC/GNUmakefile
@@ -10,9 +10,6 @@ COMP	   = gcc
 USE_MPI    = TRUE 
 USE_OMP    = FALSE
 
-# define the location of the PELE top directory
-PELE_HOME    := ../../../..
-
 # This sets the EOS directory in $(PELE_PHYSICS_HOME)/Eos
 Eos_dir     := GammaLaw
 
@@ -24,7 +21,9 @@ Transport_dir := Constant
 
 Bpack   := ./Make.package
 
-include ../../../Make.PeleC
+# define the location of the PELE top directory
+PELEC_HOME    := ../../../..
+include $(PELEC_HOME)/Exec/Make.PeleC
 
 ifeq ($(DEBUG), TRUE)
 DEFINES += -DDEBUG

--- a/Exec/UnitTests/NSCBC_test_cases/3D_Explo_Outflows_NSCBC/GNUmakefile
+++ b/Exec/UnitTests/NSCBC_test_cases/3D_Explo_Outflows_NSCBC/GNUmakefile
@@ -10,9 +10,6 @@ COMP	   = gcc
 USE_MPI    = TRUE 
 USE_OMP    = FALSE
 
-# define the location of the PELE top directory
-PELE_HOME    := ../../../..
-
 # This sets the EOS directory in $(PELE_PHYSICS_HOME)/Eos
 Eos_dir     := GammaLaw
 
@@ -24,7 +21,9 @@ Transport_dir := Constant
 
 Bpack   := ./Make.package
 
-include ../../../Make.PeleC
+# define the location of the PELE top directory
+PELEC_HOME    := ../../../..
+include $(PELEC_HOME)/Exec/Make.PeleC
 
 ifeq ($(DEBUG), TRUE)
 DEFINES += -DDEBUG

--- a/Exec/UnitTests/NSCBC_test_cases/3D_Explo_Walls_NSCBC/GNUmakefile
+++ b/Exec/UnitTests/NSCBC_test_cases/3D_Explo_Walls_NSCBC/GNUmakefile
@@ -10,9 +10,6 @@ COMP	   = gcc
 USE_MPI    = TRUE 
 USE_OMP    = FALSE
 
-# define the location of the PELE top directory
-PELE_HOME    := ../../../..
-
 # This sets the EOS directory in $(PELE_PHYSICS_HOME)/Eos
 Eos_dir     := GammaLaw
 
@@ -24,7 +21,9 @@ Transport_dir := Constant
 
 Bpack   := ./Make.package
 
-include ../../../Make.PeleC
+# define the location of the PELE top directory
+PELEC_HOME    := ../../../..
+include $(PELEC_HOME)/Exec/Make.PeleC
 
 ifeq ($(DEBUG), TRUE)
 DEFINES += -DDEBUG


### PR DESCRIPTION
This is my attempt and making all the makefiles in Exec consistent. It removes any use of `PELE_HOME` in favor of `PELEC_HOME` and uses `PELEC_HOME` in each `GNUmakefile` to find `Make.PeleC`. If `AMREX_HOME` and `PELE_PHYSICS_HOME` are defined, it should use them as defined. Otherwise, if you don't want to set them, this should still default to the provided submodules. I may be missing why `PELE_HOME` existed, but I assume it was intended to have `PeleC`, `PeleLM`, and `PelePhysics` cloned in the same directory, but in my opinion it made things confusing and seems unnecessary.

There are also makefiles that exist in PelePhysics `Exec` directory, that look like they circle back to PeleC for some reason, but I won't perturb them. Currently it looks like they set up `PELEC_HOME` correctly assuming it's been cloned in `PELE_HOME`.