### PR TITLE
Fix intel warnings

### DIFF
--- a/CMake/set_compile_flags.cmake
+++ b/CMake/set_compile_flags.cmake
@@ -52,11 +52,12 @@ function(set_compile_flags)
       # Add extra optimization flags
       list(APPEND CMAKE_CXX_FLAGS     "-ip"
                                       "-qopt-report=5"
-                                      "-qopt-report-phase=vec")
+                                      "-qopt-report-phase=vec"
+                                      "-diag-disable:10397") # Hundreds of remarks about .optrpt generated in the "output" location
       list(APPEND CMAKE_C_FLAGS       "-ip"
                                       "-qopt-report=5"
                                       "-qopt-report-phase=vec")
-      list(APPEND CMAKE_Fortran_FLAGS "")
+      list(APPEND CMAKE_Fortran_FLAGS "-diag-disable:8291") # Remark about high precision in an stdout write statement that a mainframe can't handle
     else()
       # Add extra debug flags
       list(APPEND CMAKE_CXX_FLAGS     "-traceback"

--- a/Source/Src_2d/Hyp_pele_MOL_2d.F90
+++ b/Source/Src_2d/Hyp_pele_MOL_2d.F90
@@ -270,7 +270,6 @@ module hyp_advection_module
                      idir, coord_type, bc_test_val, csmall(vii), cav(vii) )
              else
                 write(*,*) "Aborting, no valid Riemann sovler", riemann_solver
-                call flush()
                 call abort()
              endif
 

--- a/Source/Src_nd/riemann_util.f90
+++ b/Source/Src_nd/riemann_util.f90
@@ -1054,7 +1054,7 @@ contains
     double precision, intent(in) :: csmall, cav
 
     ! Work values sent back to compute passive scalar flux
-    double precision, intent(in) :: regd !currently not used
+    double precision, intent(in) :: regd !currently not used, and only set to intent(in) to avoid warning
     double precision, intent(out) :: rgd, ustar
     double precision, intent(out) :: ugd, v1gd, v2gd, pgd, gamegd
 

--- a/Source/Src_nd/riemann_util.f90
+++ b/Source/Src_nd/riemann_util.f90
@@ -1054,14 +1054,12 @@ contains
     double precision, intent(in) :: csmall, cav
 
     ! Work values sent back to compute passive scalar flux
-    double precision, intent(out) :: rgd, regd, ustar 
+    double precision, intent(in) :: regd !currently not used
+    double precision, intent(out) :: rgd, ustar
     double precision, intent(out) :: ugd, v1gd, v2gd, pgd, gamegd
 
-
     ! Outputs
-
     double precision, intent(inout):: uflx_rho, uflx_u, uflx_v, uflx_w, uflx_eden, uflx_eint
-
 
     double precision, parameter:: small = 1.d-8
     double precision, parameter :: small_u = 1.d-10


### PR DESCRIPTION
This fixes some warnings with the Intel compiler and suppresses some diagnostics from the Intel compiler for CTest.

`regd` isn't being used in `Source/Src_nd/riemann_util.f90` so I set it to `intent(in)` which someone will quickly see that if they need to use it in the future.

I'm also updating the PelePhysics submodule here to utilize a warning fix that was pushed to the repo.