### PR TITLE
Fix warnings from Clang

### DIFF
--- a/Source/PeleC.H
+++ b/Source/PeleC.H
@@ -83,36 +83,36 @@ public:
     //
     virtual void restart (amrex::Amr&     papa,
                           istream&        is,
-			              bool            bReadSpecial = false);
+			  bool            bReadSpecial = false) override;
     //
     //This is called only when we restart from an old checkpoint.
     //
     virtual void set_state_in_checkpoint (amrex::Vector<int>& 
-                                            state_in_checkpoint);
+                                          state_in_checkpoint) override;
     //
     //Call AmrLevel::checkPoint and then add radiation info
     //
     virtual void checkPoint(const std::string& dir,
                             std::ostream&      os,
                             amrex::VisMF::How         how,
-                            bool               dump_old);
+                            bool               dump_old) override;
 
     /*A string written as the first item in writePlotFile() at
       level zero. It is so we can distinguish between different
       types of plot files. For PeleC it has the form: PeleC-Vnnn
     */
-    virtual std::string thePlotFileType () const;
+    virtual std::string thePlotFileType () const override;
 
-    virtual void setPlotVariables ();
+    virtual void setPlotVariables () override;
     //
     //Write a plotfile to specified directory.
     //
     virtual void writePlotFile (const std::string& dir,
                                 ostream&       os,
-                                amrex::VisMF::How     how);
+                                amrex::VisMF::How     how) override;
     virtual void writeSmallPlotFile (const std::string& dir,
 				     ostream&       os,
-				     amrex::VisMF::How     how);
+				     amrex::VisMF::How     how) override;
     void writeJobInfo (const std::string& dir);
 
     //
@@ -126,7 +126,7 @@ public:
     //
     // Initialize grid data at problem start-up.
     //
-    virtual void initData ();
+    virtual void initData () override;
 
 #ifdef AMREX_PARTICLES
     //
@@ -230,15 +230,15 @@ public:
     //
     virtual void setTimeLevel (amrex::Real time,
                                amrex::Real dt_old,
-                               amrex::Real dt_new);
+                               amrex::Real dt_new) override;
     //
     // Initialize data on this level from another PeleC (during regrid).
     //
-    virtual void init (amrex::AmrLevel& old);
+    virtual void init (amrex::AmrLevel& old) override;
     //
     // Initialize data on this level after regridding if old level did not previously exist
     //
-    virtual void init ();
+    virtual void init () override;
     
     /**
      * Initialize EB geometry for finest_level and level grids for
@@ -267,14 +267,14 @@ public:
     //
     // Proceed with next timestep?
     //
-    virtual int okToContinue ();
+    virtual int okToContinue () override;
     //
     // Advance grids at this level in time.
     //
     virtual amrex::Real advance (amrex::Real time,
                           amrex::Real dt,
                           int  iteration,
-                          int  ncycle);
+                          int  ncycle) override;
 
     amrex::Real do_mol_advance(amrex::Real time,
                                amrex::Real dt,
@@ -357,7 +357,7 @@ public:
                                    amrex::Vector<int>&                  n_cycle,
                                    const amrex::Vector<amrex::IntVect>& ref_ratio,
                                    amrex::Vector<amrex::Real>&                 dt_level,
-                                   amrex::Real                                stop_time);
+                                   amrex::Real                                stop_time) override;
     //
     // Compute new `dt'.
     //
@@ -368,15 +368,15 @@ public:
                                amrex::Vector<amrex::Real>&                 dt_min,
                                amrex::Vector<amrex::Real>&                 dt_level,
                                amrex::Real                                stop_time,
-                               int                                 post_regrid_flag);
+                               int                                 post_regrid_flag) override;
     //
     // Allocate data at old time.
     //
-    virtual void allocOldData ();
+    virtual void allocOldData () override;
     //
     // Remove data at old time.
     //
-    virtual void removeOldData ();
+    virtual void removeOldData () override;
     //
     // Passes some data about the grid to a Fortran module.
     //
@@ -388,24 +388,24 @@ public:
     //
     // Do work after timestep().
     //
-    virtual void post_timestep (int iteration);
+    virtual void post_timestep (int iteration) override;
     //
     // Contains operations to be done only after a full coarse timestep.
     //
-    virtual void postCoarseTimeStep (amrex::Real cumtime);
+    virtual void postCoarseTimeStep (amrex::Real cumtime) override;
     //
     // Do work after regrid().
     //
     virtual void post_regrid (int lbase,
-                              int new_finest);   
+                              int new_finest) override;
     //
     // Do work after a restart().
     //
-    virtual void post_restart ();
+    virtual void post_restart () override;
     //
     // Do work after init().
     //
-    virtual void post_init (amrex::Real stop_time);
+    virtual void post_init (amrex::Real stop_time) override;
     //
     // Error estimation for regridding.
     //
@@ -414,7 +414,7 @@ public:
                            int                 tagval,
                            amrex::Real                time,
                            int                 n_error_buf = 0,
-                           int                 ngrow = 0);
+                           int                 ngrow = 0) override;
 
     // Returns a MultiFab containing the derived data for this level.
     // The user is responsible for deleting this pointer when done
@@ -422,13 +422,13 @@ public:
     // grown BoxArray.
     virtual std::unique_ptr<amrex::MultiFab> derive (const std::string& name,
                                      amrex::Real               time,
-                                     int                ngrow);
+                                     int                ngrow) override;
 
     // This version of derive() fills the dcomp'th component of mf with the derived quantity.
     virtual void derive (const std::string& name,
                          amrex::Real               time,
                          amrex::MultiFab&   mf,
-                         int                dcomp);
+                         int                dcomp) override;
 
     static int numGrow();
 


### PR DESCRIPTION
Just needed to mark a bunch of functions as `override`.