### PR TITLE
Explicit filtering of hydro fluxes and source term.

### DIFF
--- a/CMake/pelec_sources.cmake
+++ b/CMake/pelec_sources.cmake
@@ -22,6 +22,7 @@ function(get_pelec_sources pelec_exe_name)
      ${PELEC_SOURCE_DIR}/main.cpp
      ${PELEC_SOURCE_DIR}/sum_integrated_quantities.cpp
      ${PELEC_SOURCE_DIR}/sum_utils.cpp
+     ${PELEC_SOURCE_DIR}/Filter.cpp
      #${PELEC_SOURCE_DIR}/PeleC_error.cpp
   )
   if(PELEC_ENABLE_REACTIONS)
@@ -51,6 +52,7 @@ function(get_pelec_sources pelec_exe_name)
      ${PELEC_SOURCE_DIR}/impose_NSCBC_${PELEC_DIM}d.f90
      ${PELEC_SOURCE_DIR}/riemann_${PELEC_DIM}d.F90
      ${PELEC_SOURCE_DIR}/set_bc_mask_${PELEC_DIM}d.f90
+     ${PELEC_SOURCE_DIR}/filter_${PELEC_DIM}d.f90
      #${PELEC_SOURCE_DIR}/slope_mol_${PELEC_DIM}d.f90
      #${PELEC_SOURCE_DIR}/PeleC_mol_${PELEC_DIM}d.F90
   )

--- a/Docs/sphinx_doc/LES.rst
+++ b/Docs/sphinx_doc/LES.rst
@@ -11,3 +11,73 @@ LES and Hybrid LES/DNS Support
 ------------------------------
 
 .. note:: PeleC has support for LES subgrid models for *non-reacting* flows; documentation is a work in progress.
+
+Explicit filtering of the hydrodynamic source terms
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. warning:: Explicit filtering is a work in progress. It should not be used with wall boundary conditions. Filtering at coarse-fine boundaries is experimental.
+
+In some instances the user may want to explicitly filter the
+Navier-Stokes equations to perform explicitly filtered large eddy
+simulations. The objective of explicitly filtering the PDEs is to
+remove wavenumber content in the solution that may be contaminated by
+numerical error. To achieve this objective, the hydrodynamic source
+terms, i.e. the source terms that may introduce wavenumbers that
+cannot be represented accurately by the grid, are explicitly filtered
+after each computation of the hydrodynamic source terms.
+
+Using
+#####
+
+To explicitly filter the hydrodynamic source terms, the following
+should option should be turned on in the input file:
+``pelec.use_explicit_filter = 1``. The user specifies the filter-grid
+ratio using ``pelec.les_filter_fgr = NUM``, where ``NUM`` is the
+filter-grid ratio desired, e.g. ``pelec.les_filter_fgr = 2``. The user
+also specifies a filter type through ``pelec.les_filter_type = NUM``:
+
+* ``les_filter_type = 0``: no filtering
+* ``les_filter_type = 1``: standard box filter
+* ``les_filter_type = 2``: standard Gaussian filter
+
+We have also implemented a set of filters defined in Sagaut & Grohens (1999) Int. J. Num. Meth. Fluids:
+
+* ``les_filter_type = 3``: 3 point box filter approximation (Eq. 26)
+* ``les_filter_type = 4``: 5 point box filter approximation (Eq. 27)
+* ``les_filter_type = 5``: 3 point box filter optimized approximation (Table 1)
+* ``les_filter_type = 6``: 5 point box filter optimized approximation (Table 1)
+* ``les_filter_type = 7``: 3 point Gaussian filter approximation
+* ``les_filter_type = 8``: 5 point Gaussian filter approximation (Eq. 29)
+* ``les_filter_type = 9``: 3 point Gaussian filter optimized approximation (Table 1)
+* ``les_filter_type = 10``: 5 point Gaussian filter optimized approximation (Table 1)
+
+An example input file section for a Gaussian filter with a filter-grid
+ration of 2 would be:
+
+::
+
+   pelec.use_explicit_filter=1
+   pelec.les_filter_type=2
+   pelec.les_filter_fgr=2
+
+
+Developing
+##########
+
+The weights for these filters are set in ``Filter.cpp``. To add a
+filter type, one needs to add an enum to the ``filter_types`` and
+define a corresponding ``set_NAME_weights`` function to be called at
+initialization.
+
+The application of a filter can be done on a Fab or MultiFab. The
+implementation is done in ``filter_DIMd.f90``. The loop nesting
+ordering was chosen to be performant on existing HPC architectures and
+discussed in PeleC milestone reports. An example call to the filtering operation is
+
+::
+
+   les_filter = Filter(les_filter_type, les_filter_fgr);
+   ...
+   les_filter.apply_filter(bxtmp, flux[i], filtered_flux[i], Density, NUM_STATE);
+
+The user must ensure that the correct number of grow cells is present in the Fab or MultiFab.

--- a/Source/Filter.H
+++ b/Source/Filter.H
@@ -1,0 +1,145 @@
+#ifndef _FILTER_H_
+#define _FILTER_H_
+
+#include <AMReX_REAL.H>
+#include <AMReX_Array.H>
+#include <AMReX_MultiFab.H>
+#include <Filter_F.H>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+// Filter types
+enum filter_types { no_filter = 0,
+                    box,                           // 1
+                    gaussian,                      // 2
+                    box_3pt_approx,                // 3
+                    box_5pt_approx,                // 4
+                    box_3pt_optimized_approx,      // 5
+                    box_5pt_optimized_approx,      // 6
+                    gaussian_3pt_approx,           // 7
+                    gaussian_5pt_approx,           // 8
+                    gaussian_3pt_optimized_approx, // 9
+                    gaussian_5pt_optimized_approx, // 10
+                    num_filter_types};
+
+class Filter
+{
+
+public:
+
+  // Default constructor
+  Filter (const int type = box,
+          const int fgr = 2)
+    : _type(type), _fgr(fgr)
+  {
+
+    switch(_type) {
+
+    case box:
+      set_box_weights();
+      break;
+
+    case gaussian:
+      set_gaussian_weights();
+      break;
+
+    case box_3pt_approx:
+    case gaussian_3pt_approx: // same as box_3pt_approx
+      set_box_3pt_approx_weights();
+      break;
+
+    case box_5pt_approx:
+      set_box_5pt_approx_weights();
+      break;
+
+    case box_3pt_optimized_approx:
+      set_box_3pt_optimized_approx_weights();
+      break;
+
+    case box_5pt_optimized_approx:
+      set_box_5pt_optimized_approx_weights();
+      break;
+
+    case gaussian_5pt_approx:
+      set_gaussian_5pt_approx_weights();
+      break;
+
+    case gaussian_3pt_optimized_approx:
+      set_gaussian_3pt_optimized_approx_weights();
+      break;
+
+    case gaussian_5pt_optimized_approx:
+      set_gaussian_5pt_optimized_approx_weights();
+      break;
+
+    case no_filter:
+    default:
+      _fgr = 1;
+      _ngrow = 0;
+      _nweights = 2 *_ngrow + 1;
+      _weights.resize(_nweights);
+      _weights[0] = 1.;
+      break;
+
+
+    } // end switch
+
+  };
+
+  // Default destructor
+  ~Filter () {};
+
+  int get_filter_ngrow(){return _ngrow;};
+
+  void apply_filter(const amrex::IntVect& tile_size,
+                    const amrex::MultiFab& in,
+                    amrex::MultiFab& out);
+
+  void apply_filter(const amrex::IntVect& tile_size,
+                    const amrex::MultiFab& in,
+                    amrex::MultiFab& out,
+                    const int nstart,
+                    const int ncnt);
+
+  void apply_filter(const amrex::Box cbox,
+                    const amrex::FArrayBox& in,
+                    amrex::FArrayBox& out);
+
+  void apply_filter(const amrex::Box cbox,
+                    const amrex::FArrayBox& in,
+                    amrex::FArrayBox& out,
+                    const int nstart,
+                    const int ncnt);
+
+
+
+private:
+  int _type;
+  int _fgr;
+  int _ngrow;
+  int _nweights;
+  amrex::Vector<amrex::Real> _weights;
+
+  void set_box_weights();
+
+  void set_gaussian_weights();
+
+  void set_box_3pt_approx_weights();
+
+  void set_box_5pt_approx_weights();
+
+  void set_box_3pt_optimized_approx_weights();
+
+  void set_box_5pt_optimized_approx_weights();
+
+  void set_gaussian_5pt_approx_weights();
+
+  void set_gaussian_3pt_optimized_approx_weights();
+
+  void set_gaussian_5pt_optimized_approx_weights();
+
+};
+
+#endif /*_FILTER_H_*/

--- a/Source/Filter.cpp
+++ b/Source/Filter.cpp
@@ -1,0 +1,459 @@
+#include <Filter.H>
+
+/**
+ * Set the filter weights for the standard box filter
+ **/
+void Filter::set_box_weights(){
+
+  BL_ASSERT(_fgr % 2 == 0 || _fgr == 1);
+  _ngrow = _fgr / 2;
+  _nweights = 2 * _ngrow + 1;
+  _weights.resize(_nweights);
+
+  // Set the weights
+  for(int i=0; i<_nweights; i++){
+    _weights[i] = 1.0 / _fgr;
+  }
+
+  // Only half the cell is used at the ends
+  if (_fgr > 1){
+    _weights[0] = 0.5*_weights[0];
+    _weights[_nweights-1] = _weights[0];
+  }
+}
+
+/**
+ * Set the filter weights for the standard gaussian filter
+ **/
+void Filter::set_gaussian_weights(){
+
+  BL_ASSERT(_fgr % 2 == 0);
+  _ngrow = _fgr / 2;
+  _nweights = 2 * _ngrow + 1;
+  _weights.resize(_nweights);
+
+  // Set the weights
+  double gamma = 6.0;
+  double sigma = std::sqrt(1.0 / (2.0 * gamma)) * _fgr;
+  for(int i=0; i<_nweights; i++){
+    // equivalent to: std::sqrt(gamma / (M_PI * _fgr * _fgr)) * std::exp((-gamma * (i-_ngrow) * (i-_ngrow)) / (_fgr * _fgr));
+    _weights[i] = 1.0 / (std::sqrt(2.0 * M_PI) * sigma) * std::exp((- (i-_ngrow) * (i-_ngrow)) / (2 * sigma * sigma));
+  }
+  // normalize to ensure it all sums to one
+  double sum = std::accumulate(_weights.begin(), _weights.end(), 0.0);
+  for(int i=0; i<_nweights; i++){
+    _weights[i] /= sum;
+  }
+}
+
+/**
+ * Set the filter weights for the 3pt polynomial truncation
+ * approximation of the box filter. See Eq. 26 in Sagaut & Grohens
+ * (1999) Int. J. Num. Meth. Fluids.
+ **/
+void Filter::set_box_3pt_approx_weights(){
+
+  _ngrow = 1;
+  _nweights = 2 * _ngrow + 1;
+  _weights.resize(_nweights);
+
+  // Set the weights
+  _weights[0] = _fgr*_fgr / 24.0;
+  _weights[1] = (12.0 - _fgr*_fgr) / 12.0;
+  _weights[2] = _weights[0];
+}
+
+/**
+ * Set the filter weights for the 5pt polynomial truncation
+ * approximation of the box filter. See Eq. 27 in Sagaut & Grohens
+ * (1999) Int. J. Num. Meth. Fluids (though there are typos).
+ **/
+void Filter::set_box_5pt_approx_weights(){
+
+  _ngrow = 2;
+  _nweights = 2 * _ngrow + 1;
+  _weights.resize(_nweights);
+
+  // Set the weights
+  int _fgr2 = _fgr*_fgr;
+  int _fgr4 = _fgr2*_fgr2;
+  _weights[0] = (3.0*_fgr4 - 20.0*_fgr2) / 5760.0;
+  _weights[1] = (80.0*_fgr2 - 3.0*_fgr4) / 1440.0;
+  _weights[2] = (3.0*_fgr4 - 100.0*_fgr2 + 960.0) / 960.0;
+  _weights[3] = _weights[1];
+  _weights[4] = _weights[0];
+}
+
+/**
+ * Set the filter weights for the 3pt optimized approximation of the
+ * box filter. See Table I in Sagaut & Grohens (1999)
+ * Int. J. Num. Meth. Fluids.
+ **/
+void Filter::set_box_3pt_optimized_approx_weights(){
+
+  _ngrow = 1;
+  _nweights = 2 * _ngrow + 1;
+  _weights.resize(_nweights);
+
+  double ratio;
+  switch(_fgr) {
+
+  case 1:
+    ratio = 0.079;
+    break;
+
+  case 2:
+    ratio = 0.274;
+    break;
+
+  case 3:
+    ratio = 1.377;
+    break;
+
+  case 4:
+    ratio = -2.375;
+    break;
+
+  case 5:
+    ratio = -1.000;
+    break;
+
+  case 6:
+    ratio = -0.779;
+    break;
+
+  case 7:
+    ratio = -0.680;
+    break;
+
+  case 8:
+    ratio = -0.627;
+    break;
+
+  case 9:
+    ratio = -0.596;
+    break;
+
+  case 10:
+    ratio = -0.575;
+    break;
+
+  default: // default to standard box filter
+    set_box_weights();
+    return;
+    break;
+
+  } // end switch
+
+  // Set the weights
+  _weights[0] = ratio / (1+2.0*ratio);
+  _weights[1] = 1.0 - 2.0*_weights[0];
+  _weights[2] = _weights[0];
+}
+
+/**
+ * Set the filter weights for the 5pt optimized approximation of the
+ * box filter. See Table I in Sagaut & Grohens (1999)
+ * Int. J. Num. Meth. Fluids.
+ **/
+void Filter::set_box_5pt_optimized_approx_weights(){
+
+  _ngrow = 2;
+  _nweights = 2 * _ngrow + 1;
+  _weights.resize(_nweights);
+
+  double ratio1;
+  double ratio2;
+  switch(_fgr) {
+
+  case 1:
+    ratio1 = 0.0886;
+    ratio2 = -0.0169;
+    break;
+
+  case 2:
+    ratio1 = 0.3178;
+    ratio2 = -0.0130;
+    break;
+
+  case 3:
+    ratio1 = 1.0237;
+    ratio2 = 0.0368;
+    break;
+
+  case 4:
+    ratio1 = 2.4414;
+    ratio2 = 0.5559;
+    break;
+
+  case 5:
+    ratio1 = 0.2949;
+    ratio2 = 0.7096;
+    break;
+
+  case 6:
+    ratio1 = -0.5276;
+    ratio2 = 0.4437;
+    break;
+
+  case 7:
+    ratio1 = -0.6708;
+    ratio2 = 0.3302;
+    break;
+
+  case 8:
+    ratio1 = -0.7003;
+    ratio2 = 0.2767;
+    break;
+
+  case 9:
+    ratio1 = -0.7077;
+    ratio2 = 0.2532;
+    break;
+
+  case 10:
+    ratio1 = -0.6996;
+    ratio2 = 0.2222;
+    break;
+
+  default: // default to standard box filter
+    set_box_weights();
+    return;
+    break;
+
+  } // end switch
+
+  // Set the weights
+  _weights[0] = ratio2 / (1+2.0*ratio1+2.0*ratio2);
+  _weights[1] = ratio1 / ratio2 * _weights[0];
+  _weights[2] = 1.0 - 2.0*_weights[0] - 2.0*_weights[1];
+  _weights[3] = _weights[1];
+  _weights[4] = _weights[0];
+}
+
+/**
+ * Set the filter weights for the 5pt polynomial truncation
+ * approximation of the gaussian filter. See Eq. 29 in Sagaut &
+ * Grohens (1999) Int. J. Num. Meth. Fluids.
+ **/
+void Filter::set_gaussian_5pt_approx_weights(){
+
+  _ngrow = 2;
+  _nweights = 2 * _ngrow + 1;
+  _weights.resize(_nweights);
+
+  // Set the weights
+  int _fgr2 = _fgr*_fgr;
+  int _fgr4 = _fgr2*_fgr2;
+  _weights[0] = (_fgr4 - 4.0*_fgr2) / 1152.0;
+  _weights[1] = (16.0*_fgr2 - _fgr4) / 288.0;
+  _weights[2] = (_fgr4 - 20.0*_fgr2 + 192.0) / 192.0;
+  _weights[3] = _weights[1];
+  _weights[4] = _weights[0];
+}
+
+/**
+ * Set the filter weights for the 3pt optimized approximation of the
+ * gaussian filter. See Table I in Sagaut & Grohens (1999)
+ * Int. J. Num. Meth. Fluids.
+ **/
+void Filter::set_gaussian_3pt_optimized_approx_weights(){
+
+  _ngrow = 1;
+  _nweights = 2 * _ngrow + 1;
+  _weights.resize(_nweights);
+
+  double ratio;
+  switch(_fgr) {
+
+  case 1:
+    ratio = 0.0763;
+    break;
+
+  case 2:
+    ratio = 0.2527;
+    break;
+
+  case 3:
+    ratio = 1.1160;
+    break;
+
+  case 4:
+    ratio = -3.144;
+    break;
+
+  case 5:
+    ratio = -1.102;
+    break;
+
+  case 6:
+    ratio = -0.809;
+    break;
+
+  case 7:
+    ratio = -0.696;
+    break;
+
+  case 8:
+    ratio = -0.638;
+    break;
+
+  case 9:
+    ratio = -0.604;
+    break;
+
+  case 10:
+    ratio = -0.581;
+    break;
+
+  default: // default to the 3pt gaussian filter
+    set_box_3pt_approx_weights();
+    return;
+    break;
+
+  } // end switch
+
+  // Set the weights
+  _weights[0] = ratio / (1+2.0*ratio);
+  _weights[1] = 1.0 - 2.0*_weights[0];
+  _weights[2] = _weights[0];
+}
+
+/**
+ * Set the filter weights for the 5pt optimized approximation of the
+ * gaussian filter. See Table I in Sagaut & Grohens (1999)
+ * Int. J. Num. Meth. Fluids.
+ **/
+void Filter::set_gaussian_5pt_optimized_approx_weights(){
+
+  _ngrow = 2;
+  _nweights = 2 * _ngrow + 1;
+  _weights.resize(_nweights);
+
+  double ratio1;
+  double ratio2;
+  switch(_fgr) {
+
+  case 1:
+    ratio1 = 0.0871;
+    ratio2 = -0.0175;
+    break;
+
+  case 2:
+    ratio1 = 0.2596;
+    ratio2 = -0.0021;
+    break;
+
+  case 3:
+    ratio1 = 0.4740;
+    ratio2 = 0.0785;
+    break;
+
+  case 4:
+    ratio1 = 0.1036;
+    ratio2 = 0.2611;
+    break;
+
+  case 5:
+    ratio1 = -0.4252;
+    ratio2 = 0.3007;
+    break;
+
+  case 6:
+    ratio1 = -0.6134;
+    ratio2 = 0.2696;
+    break;
+
+  case 7:
+    ratio1 = -0.6679;
+    ratio2 = 0.2419;
+    break;
+
+  case 8:
+    ratio1 = -0.6836;
+    ratio2 = 0.2231;
+    break;
+
+  case 9:
+    ratio1 = -0.6873;
+    ratio2 = 0.2103;
+    break;
+
+  case 10:
+    ratio1 = -0.6870;
+    ratio2 = 0.2014;
+    break;
+
+  default: // default to 5pt gaussian filter
+    set_gaussian_5pt_approx_weights();
+    return;
+    break;
+
+  } // end switch
+
+  // Set the weights
+  _weights[0] = ratio2 / (1+2.0*ratio1+2.0*ratio2);
+  _weights[1] = ratio1 / ratio2 * _weights[0];
+  _weights[2] = 1.0 - 2.0*_weights[0] - 2.0*_weights[1];
+  _weights[3] = _weights[1];
+  _weights[4] = _weights[0];
+}
+
+/**
+ * Run the filtering operation on a MultiFab
+ **/
+void Filter::apply_filter(const amrex::IntVect& tile_size,
+                          const amrex::MultiFab& in,
+                          amrex::MultiFab& out){
+  apply_filter(tile_size, in, out, 0, out.nComp());
+}
+
+void Filter::apply_filter(const amrex::IntVect& tile_size,
+                          const amrex::MultiFab& in,
+                          amrex::MultiFab& out,
+                          const int nstart,
+                          const int ncnt){
+
+  // Ensure enough grow cells
+  BL_ASSERT(in.nGrow() >= out.nGrow() + _ngrow);
+
+#ifdef _OPENMP
+#pragma omp parallel
+#endif
+  for (amrex::MFIter mfi(in, amrex::MFItInfo().EnableTiling(tile_size).SetDynamic(true)); mfi.isValid(); ++mfi){
+    const amrex::Box cbox = mfi.growntilebox(out.nGrow());
+    apply_filter(cbox, in[mfi], out[mfi], nstart, ncnt);
+  }
+}
+
+/**
+ * Run the filtering operation on a FAB
+ **/
+void Filter::apply_filter(const amrex::Box cbox,
+                          const amrex::FArrayBox& in,
+                          amrex::FArrayBox& out){
+  apply_filter(cbox, in, out, 0, out.nComp());
+}
+
+void Filter::apply_filter(const amrex::Box cbox,
+                          const amrex::FArrayBox& in,
+                          amrex::FArrayBox& out,
+                          const int nstart,
+                          const int ncnt){
+
+  BL_PROFILE("Filter::apply_filter()");
+  BL_ASSERT(in.nComp() == out.nComp());
+
+  const int ncomp = in.nComp();
+  out.setVal(0,cbox,nstart,ncnt);
+
+  const int nstartf = nstart+1;
+  filter(cbox.loVect(), cbox.hiVect(),
+         BL_TO_FORTRAN_ANYD(in),
+         BL_TO_FORTRAN_ANYD(out),
+         &_ngrow,
+         _weights.dataPtr(),
+         &nstartf,
+         &ncnt,
+         &ncomp);
+}

--- a/Source/Filter_F.H
+++ b/Source/Filter_F.H
@@ -1,0 +1,20 @@
+
+#ifndef _FILTER_F_H_
+#define _FILTER_F_H_
+#include <AMReX_BLFort.H>
+
+#include <AMReX.H>
+
+extern "C"
+{
+  void filter(const int* lo, const int* hi,
+              const BL_FORT_FAB_ARG_3D(Q),
+              BL_FORT_FAB_ARG_3D(Qh),
+              const int* ngrow,
+              const amrex::Real* weights,
+              const int* nstart,
+              const int* ncnt,
+              const int* ncomp);
+}
+
+#endif /*_FILTER_F_H_*/

--- a/Source/Make.package
+++ b/Source/Make.package
@@ -35,6 +35,10 @@ endif
 
 CEXE_sources += PeleC_MOL.cpp
 
+FEXE_headers += Filter_F.H
+CEXE_headers += Filter.H
+CEXE_sources += Filter.cpp
+
 ifeq ($(USE_MASA), TRUE)
 CEXE_sources += PeleC_mms.cpp
 endif

--- a/Source/PeleC.H
+++ b/Source/PeleC.H
@@ -24,6 +24,8 @@
 #include <SprayParticles.H>
 #endif
 
+#include <Filter.H>
+
 #include <iostream>
 
 using std::istream;
@@ -559,6 +561,8 @@ protected:
     static void init_transport ();
     static void close_transport ();
 
+    void init_filters ();
+
 #ifdef USE_MASA
     static void init_mms();
 #endif
@@ -636,6 +640,11 @@ protected:
     static int       diffuse_vel;
     static amrex::Real      diffuse_cutoff_density;
     static bool      do_diffuse;
+
+    static int       les_filter_type;
+    static int       les_filter_fgr;
+    Filter           les_filter;
+    int       nGrowF;
 
 #ifdef USE_MASA
     static bool      mms_initialized;

--- a/Source/PeleC_advance.cpp
+++ b/Source/PeleC_advance.cpp
@@ -333,7 +333,7 @@ PeleC::do_sdc_iteration (Real time,
   if (do_hydro)
   {
     fill_Sborder = true;
-    nGrow_Sborder = NUM_GROW;
+    nGrow_Sborder = NUM_GROW+nGrowF;
   }
   else if (do_diffuse)
   {

--- a/Source/PeleC_hydro.cpp
+++ b/Source/PeleC_hydro.cpp
@@ -22,7 +22,7 @@ PeleC::construct_hydro_source(const MultiFab& S, Real time, Real dt, int amr_ite
         std::cout << "... Computing hydro advance" << std::endl;
     }
 
-    BL_ASSERT(S.nGrow() == NUM_GROW);
+    BL_ASSERT(S.nGrow() == NUM_GROW+nGrowF);
 
     sources_for_hydro.setVal(0.0);
 
@@ -91,6 +91,9 @@ PeleC::construct_hydro_source(const MultiFab& S, Real time, Real dt, int amr_ite
     {
 	FArrayBox flux[BL_SPACEDIM];
 
+        FArrayBox filtered_flux[BL_SPACEDIM];
+	FArrayBox filtered_source_out;
+
 	FArrayBox pradial(Box::TheUnitBox(),1);
 	FArrayBox q, qaux, src_q;
 	IArrayBox bcMask[BL_SPACEDIM];
@@ -108,10 +111,12 @@ PeleC::construct_hydro_source(const MultiFab& S, Real time, Real dt, int amr_ite
 	for (MFIter mfi(S_new,hydro_tile_size); mfi.isValid(); ++mfi)
 	{
 	    const Box& bx    = mfi.tilebox();
-	    const Box& qbx = amrex::grow(bx, NUM_GROW);
+	    const Box& qbx = amrex::grow(bx, NUM_GROW+nGrowF);
 
-	    const int* lo = bx.loVect();
-	    const int* hi = bx.hiVect();
+	    const Box& fbx = amrex::grow(bx, nGrowF);
+
+	    const int* lo = fbx.loVect();
+	    const int* hi = fbx.hiVect();
 
 	    const FArrayBox &statein  = S[mfi];
 	    FArrayBox &stateout = S_new[mfi];
@@ -138,7 +143,7 @@ PeleC::construct_hydro_source(const MultiFab& S, Real time, Real dt, int amr_ite
       // Allocate fabs for bcMask. Note that we grow in the opposite direction
       // because the Riemann solver wants a face value in a ghost-cell
       for (int i = 0; i < BL_SPACEDIM ; i++)  {
-        const Box& bxtmp = amrex::surroundingNodes(bx,i);
+        const Box& bxtmp = amrex::surroundingNodes(fbx,i);
         Box TestBox(bxtmp);
         for(int d=0; d<BL_SPACEDIM; ++d) {
           if (i!=d) TestBox.grow(d,1);
@@ -175,8 +180,8 @@ PeleC::construct_hydro_source(const MultiFab& S, Real time, Real dt, int amr_ite
 
       // Allocate fabs for fluxes
 	    for (int i = 0; i < BL_SPACEDIM ; i++)  {
-		    const Box& bxtmp = amrex::surroundingNodes(bx,i);
-		    flux[i].resize(bxtmp,NUM_STATE);
+		const Box& bxtmp = amrex::surroundingNodes(fbx,i);
+		flux[i].resize(bxtmp,NUM_STATE);
 	    }
 
 	    if (!DefaultGeometry().IsCartesian()) {
@@ -219,6 +224,25 @@ PeleC::construct_hydro_source(const MultiFab& S, Real time, Real dt, int amr_ite
 		 eden_lost, xang_lost, yang_lost, zang_lost);
 
 	    courno = std::max(courno,cflLoc);
+
+            // Filter hydro source and fluxes here
+            if (use_explicit_filter)
+            {
+              for (int i = 0; i < BL_SPACEDIM ; i++)  {
+	        const Box& bxtmp = amrex::surroundingNodes(bx,i);
+	        filtered_flux[i].resize(bxtmp,NUM_STATE);
+                les_filter.apply_filter(bxtmp, flux[i], filtered_flux[i], Density, NUM_STATE);
+
+                flux[i].setVal(0);
+                flux[i].copy(filtered_flux[i], Density, Density, NUM_STATE);
+              }
+
+              filtered_source_out.resize(bx, NUM_STATE);
+              les_filter.apply_filter(bx, source_out, filtered_source_out, Density, NUM_STATE);
+
+              source_out.setVal(0);
+              source_out.copy(filtered_source_out, Density, Density, NUM_STATE);
+            }
 
             if (do_reflux  && sub_iteration == sub_ncycle-1 )
             {

--- a/Source/Src_1d/Make.package
+++ b/Source/Src_1d/Make.package
@@ -14,5 +14,7 @@ F90EXE_sources += PeleC_advection_$(DIM)d.F90
 F90EXE_sources += riemann_$(DIM)d.F90 
 f90EXE_sources += advection_util_$(DIM)d.f90 
 
+f90EXE_sources += filter_$(DIM)d.f90
+
 f90EXE_sources += impose_NSCBC_$(DIM)d.f90 
 f90EXE_sources += set_bc_mask_$(DIM)d.f90 

--- a/Source/Src_1d/filter_1d.f90
+++ b/Source/Src_1d/filter_1d.f90
@@ -1,0 +1,52 @@
+! Filtering functions
+module filter_module
+
+  implicit none
+
+  public :: filter
+
+contains
+
+  ! ------------------------------------------------------------------------------
+  !> Multidimensional filter kernel given filtering weights
+  ! ------------------------------------------------------------------------------
+  subroutine filter(lo,  hi,&
+                    Q,   Qlo,   Qhi,&
+                    Qh,  Qhlo,  Qhhi,&
+                    ng,&
+                    w,&
+                    nstart,&
+                    ncnt,&
+                    ncomp) bind(C, name = "filter")
+
+    use amrex_constants_module
+
+    implicit none
+
+    integer, intent(in) :: lo  (1), hi  (1)
+    integer, intent(in) :: Qlo (1), Qhi (1)
+    integer, intent(in) :: Qhlo(1), Qhhi(1)
+    integer, intent(in) :: ng ! (2*ng+1) filter points
+    integer, intent(in) :: nstart
+    integer, intent(in) :: ncnt
+    integer, intent(in) :: ncomp
+
+    double precision, intent (in   ) :: Q ( Qlo  (1):Qhi  (1), ncomp)
+    double precision, intent (inout) :: Qh( Qhlo (1):Qhhi (1), ncomp)
+    double precision, intent (in   ) :: w(-ng:ng)
+
+    integer :: i, nc, l
+
+    do nc=nstart, nstart+ncnt-1
+
+       do l = -ng, ng
+          do i=lo(1),hi(1)
+             Qh(i,nc) = Qh(i,nc) + w(l) * Q(i+l,nc)
+          end do
+       end do
+
+    end do
+
+  end subroutine filter
+
+end module filter_module

--- a/Source/Src_2d/Make.package
+++ b/Source/Src_2d/Make.package
@@ -25,6 +25,8 @@ f90EXE_sources += advection_util_$(DIM)d.f90
 f90EXE_sources += impose_NSCBC_$(DIM)d.f90
 f90EXE_sources += set_bc_mask_$(DIM)d.f90 
 
+f90EXE_sources += filter_$(DIM)d.f90
+
 ifeq ($(USE_EB), TRUE)
   f90EXE_sources += PeleC_init_eb_$(DIM)d.f90
 endif

--- a/Source/Src_2d/filter_2d.f90
+++ b/Source/Src_2d/filter_2d.f90
@@ -1,0 +1,56 @@
+! Filtering functions
+module filter_module
+
+  implicit none
+
+  public :: filter
+
+contains
+
+  ! ------------------------------------------------------------------------------
+  !> Multidimensional filter kernel given filtering weights
+  ! ------------------------------------------------------------------------------
+  subroutine filter(lo,  hi,&
+                    Q,   Qlo,   Qhi,&
+                    Qh,  Qhlo,  Qhhi,&
+                    ng,&
+                    w,&
+                    nstart,&
+                    ncnt,&
+                    ncomp) bind(C, name = "filter")
+
+    use amrex_constants_module
+
+    implicit none
+
+    integer, intent(in) :: lo  (2), hi  (2)
+    integer, intent(in) :: Qlo (2), Qhi (2)
+    integer, intent(in) :: Qhlo(2), Qhhi(2)
+    integer, intent(in) :: ng ! (2*ng+1) filter points
+    integer, intent(in) :: nstart
+    integer, intent(in) :: ncnt
+    integer, intent(in) :: ncomp
+
+    double precision, intent (in   ) :: Q (  Qlo  (1):Qhi  (1),   Qlo  (2): Qhi  (2), ncomp)
+    double precision, intent (inout) :: Qh(  Qhlo (1):Qhhi (1),   Qhlo (2): Qhhi (2), ncomp)
+    double precision, intent (in   ) :: w(-ng:ng)
+
+    integer :: i, j, nc, l, m
+
+    do nc=nstart, nstart+ncnt-1
+
+       do m = -ng, ng
+          do j=lo(2),hi(2)
+             do l = -ng, ng
+                do i=lo(1),hi(1)
+                   Qh(i,j,nc) = Qh(i,j,nc) + w(l) * w(m) * Q(i+l,j+m,nc)
+                end do
+             end do
+          end do
+       end do
+
+    end do
+
+  end subroutine filter
+
+end module filter_module

--- a/Source/Src_3d/Make.package
+++ b/Source/Src_3d/Make.package
@@ -24,6 +24,8 @@ f90EXE_sources += advection_util_$(DIM)d.f90
 f90EXE_sources += impose_NSCBC_$(DIM)d.f90
 f90EXE_sources += set_bc_mask_$(DIM)d.f90 
 
+f90EXE_sources += filter_$(DIM)d.f90
+
 ifeq ($(USE_EB), TRUE)
   f90EXE_sources += PeleC_init_eb_$(DIM)d.f90
 endif

--- a/Source/Src_3d/filter_3d.f90
+++ b/Source/Src_3d/filter_3d.f90
@@ -1,0 +1,60 @@
+! Filtering functions
+module filter_module
+
+  implicit none
+
+  public :: filter
+
+contains
+
+  ! ------------------------------------------------------------------------------
+  !> Multidimensional filter kernel given filtering weights
+  ! ------------------------------------------------------------------------------
+  subroutine filter(lo,  hi,&
+                    Q,   Qlo,   Qhi,&
+                    Qh,  Qhlo,  Qhhi,&
+                    ng,&
+                    w,&
+                    nstart,&
+                    ncnt,&
+                    ncomp) bind(C, name = "filter")
+
+    use amrex_constants_module
+
+    implicit none
+
+    integer, intent(in) :: lo  (3), hi  (3)
+    integer, intent(in) :: Qlo (3), Qhi (3)
+    integer, intent(in) :: Qhlo(3), Qhhi(3)
+    integer, intent(in) :: ng ! (2*ng+1) filter points
+    integer, intent(in) :: nstart
+    integer, intent(in) :: ncnt
+    integer, intent(in) :: ncomp
+
+    double precision, intent (in   ) :: Q (  Qlo  (1):Qhi  (1),   Qlo  (2): Qhi  (2), Qlo  (3): Qhi  (3), ncomp)
+    double precision, intent (inout) :: Qh(  Qhlo (1):Qhhi (1),   Qhlo (2): Qhhi (2), Qhlo (3): Qhhi (3), ncomp)
+    double precision, intent (in   ) :: w(-ng:ng)
+
+    integer :: i, j, k, nc, l, m, n
+
+    do nc=nstart, nstart+ncnt-1
+
+       do n = -ng, ng
+          do k=lo(3),hi(3)
+             do m = -ng, ng
+                do j=lo(2),hi(2)
+                   do l = -ng, ng
+                      do i=lo(1),hi(1)
+                         Qh(i,j,k,nc) = Qh(i,j,k,nc) + w(l) * w(m) * w(n) * Q(i+l,j+m,k+n,nc)
+                      end do
+                   end do
+                end do
+             end do
+          end do
+       end do
+
+    end do
+
+  end subroutine filter
+
+end module filter_module

--- a/Source/Src_nd/meth_params.F90
+++ b/Source/Src_nd/meth_params.F90
@@ -133,6 +133,7 @@ module meth_params_module
   character (len=128), save :: yr_ext_bc_type
   character (len=128), save :: zl_ext_bc_type
   character (len=128), save :: zr_ext_bc_type
+  integer         , save :: use_explicit_filter
   double precision, save :: eb_small_vfrac
   integer         , save :: do_mms
   double precision, save :: cfl
@@ -164,11 +165,12 @@ module meth_params_module
   !$acc create(dual_energy_eta2, dual_energy_eta3, use_pslope) &
   !$acc create(fix_mass_flux, limit_fluxes_on_small_dens, density_reset_method) &
   !$acc create(allow_negative_energy, allow_small_energy, first_order_hydro) &
-  !$acc create(eb_small_vfrac, do_mms, cfl) &
-  !$acc create(dtnuc_e, dtnuc_X, dtnuc_mode) &
-  !$acc create(dxnuc, do_react, react_T_min) &
-  !$acc create(react_T_max, react_rho_min, react_rho_max) &
-  !$acc create(disable_shock_burning, do_acc, track_grid_losses)
+  !$acc create(use_explicit_filter, eb_small_vfrac, do_mms) &
+  !$acc create(cfl, dtnuc_e, dtnuc_X) &
+  !$acc create(dtnuc_mode, dxnuc, do_react) &
+  !$acc create(react_T_min, react_T_max, react_rho_min) &
+  !$acc create(react_rho_max, disable_shock_burning, do_acc) &
+  !$acc create(track_grid_losses)
 
   ! End the declarations of the ParmParse parameters
 
@@ -234,6 +236,7 @@ contains
     yr_ext_bc_type = "";
     zl_ext_bc_type = "";
     zr_ext_bc_type = "";
+    use_explicit_filter = 0;
     eb_small_vfrac = 1.0d-2;
     do_mms = 0;
     cfl = 0.8d0;
@@ -298,6 +301,7 @@ contains
     call pp%query("yr_ext_bc_type", yr_ext_bc_type)
     call pp%query("zl_ext_bc_type", zl_ext_bc_type)
     call pp%query("zr_ext_bc_type", zr_ext_bc_type)
+    call pp%query("use_explicit_filter", use_explicit_filter)
     call pp%query("eb_small_vfrac", eb_small_vfrac)
     call pp%query("do_mms", do_mms)
     call pp%query("cfl", cfl)
@@ -329,11 +333,12 @@ contains
     !$acc device(dual_energy_eta2, dual_energy_eta3, use_pslope) &
     !$acc device(fix_mass_flux, limit_fluxes_on_small_dens, density_reset_method) &
     !$acc device(allow_negative_energy, allow_small_energy, first_order_hydro) &
-    !$acc device(eb_small_vfrac, do_mms, cfl) &
-    !$acc device(dtnuc_e, dtnuc_X, dtnuc_mode) &
-    !$acc device(dxnuc, do_react, react_T_min) &
-    !$acc device(react_T_max, react_rho_min, react_rho_max) &
-    !$acc device(disable_shock_burning, do_acc, track_grid_losses)
+    !$acc device(use_explicit_filter, eb_small_vfrac, do_mms) &
+    !$acc device(cfl, dtnuc_e, dtnuc_X) &
+    !$acc device(dtnuc_mode, dxnuc, do_react) &
+    !$acc device(react_T_min, react_T_max, react_rho_min) &
+    !$acc device(react_rho_max, disable_shock_burning, do_acc) &
+    !$acc device(track_grid_losses)
 
 
     ! now set the external BC flags

--- a/Source/_cpp_parameters
+++ b/Source/_cpp_parameters
@@ -236,6 +236,12 @@ zl_ext_bc_type               string        ""                 y
 # if we are doing an external +z boundary condition, who do we interpret it?
 zr_ext_bc_type               string        ""                 y
 
+#-----------------------------------------------------------------------------
+# category: large eddy simulation
+#-----------------------------------------------------------------------------
+
+# LES filtering
+use_explicit_filter          int           0                  y
 
 #-----------------------------------------------------------------------------
 # category: EB diffusion

--- a/Source/param_includes/pelec_defaults.H
+++ b/Source/param_includes/pelec_defaults.H
@@ -63,6 +63,7 @@ std::string PeleC::yl_ext_bc_type = "";
 std::string PeleC::yr_ext_bc_type = "";
 std::string PeleC::zl_ext_bc_type = "";
 std::string PeleC::zr_ext_bc_type = "";
+int         PeleC::use_explicit_filter = 0;
 amrex::Real PeleC::eb_boundary_T = 1.0;
 int         PeleC::eb_isothermal = 1;
 int         PeleC::eb_noslip = 1;

--- a/Source/param_includes/pelec_params.H
+++ b/Source/param_includes/pelec_params.H
@@ -63,6 +63,7 @@ static std::string yl_ext_bc_type;
 static std::string yr_ext_bc_type;
 static std::string zl_ext_bc_type;
 static std::string zr_ext_bc_type;
+static int use_explicit_filter;
 static amrex::Real eb_boundary_T;
 static int eb_isothermal;
 static int eb_noslip;

--- a/Source/param_includes/pelec_queries.H
+++ b/Source/param_includes/pelec_queries.H
@@ -63,6 +63,7 @@ pp.query("yl_ext_bc_type", yl_ext_bc_type);
 pp.query("yr_ext_bc_type", yr_ext_bc_type);
 pp.query("zl_ext_bc_type", zl_ext_bc_type);
 pp.query("zr_ext_bc_type", zr_ext_bc_type);
+pp.query("use_explicit_filter", use_explicit_filter);
 pp.query("eb_boundary_T", eb_boundary_T);
 pp.query("eb_isothermal", eb_isothermal);
 pp.query("eb_noslip", eb_noslip);

--- a/Testing/CTestList.cmake
+++ b/Testing/CTestList.cmake
@@ -225,6 +225,8 @@ add_test_r(sod-3d-1 4)
 add_test_r(tg-2d-1 4)
 add_test_r(tg-3d-1 4)
 add_test_r(tg-3d-2 4)
+add_test_r(tg-3d-3 4)
+add_test_r(tg-3d-4 4)
 
 #=============================================================================
 # Verification tests

--- a/Testing/test_files/tg-3d-3/exe_options.cmake
+++ b/Testing/test_files/tg-3d-3/exe_options.cmake
@@ -1,0 +1,15 @@
+#User-specific source files
+list(APPEND PELEC_EXTRA_SOURCES ${CMAKE_SOURCE_DIR}/Exec/RegTests/TG/probdata.f90)
+list(APPEND PELEC_EXTRA_SOURCES ${CMAKE_SOURCE_DIR}/Exec/RegTests/TG/Prob_nd.F90)
+list(APPEND PELEC_EXTRA_SOURCES ${CMAKE_SOURCE_DIR}/Source/Src_nd/bc_fill_nd.F90)
+
+#Compile-time options for executable
+set(PELEC_DIM 3)
+set(PELEC_ENABLE_EB OFF)
+set(PELEC_ENABLE_MASA OFF)
+set(PELEC_ENABLE_REACTIONS OFF)
+set(PELEC_ENABLE_MOL OFF)
+set(PELEC_ENABLE_PARTICLES OFF)
+set(PELEC_EOS_MODEL GammaLaw)
+set(PELEC_REACTIONS_MODEL Null)
+set(PELEC_TRANSPORT_MODEL Constant)

--- a/Testing/test_files/tg-3d-3/tg-3d-3.ext.gold
+++ b/Testing/test_files/tg-3d-3/tg-3d-3.ext.gold
@@ -1,0 +1,12 @@
+ plotfile = /home/jrood/combustion/PeleC/Build/Testing/test_files/tg-3d-1/plt00010
+ time = 3.5222021953735101e-06
+              variables          minimum value          maximum value
+ density                       0.0011704027572        0.0011826754504
+ Temp                             299.98984011           300.00690522
+ pressure                         1007729.2211           1018296.9179
+ magvort                          63.850446223           21684.907616
+ x_velocity                       -3462.115276            3462.115276
+ y_velocity                       -3462.115276            3462.115276
+ z_velocity                      -33.053398222           33.053398222
+ magvel                           12.387110614            3462.121271
+

--- a/Testing/test_files/tg-3d-3/tg-3d-3.i
+++ b/Testing/test_files/tg-3d-3/tg-3d-3.i
@@ -1,0 +1,65 @@
+# ------------------  INPUTS TO MAIN PROGRAM  -------------------
+#stop_time = 0.0018336339443081453
+max_step = 10
+
+# PROBLEM SIZE & GEOMETRY
+geometry.is_periodic = 1 1 1
+geometry.coord_sys   = 0  # 0 => cart, 1 => RZ  2=>spherical
+geometry.prob_lo     =  -1.0 -1.0 -1.0
+geometry.prob_hi     =   1.0  1.0  1.0
+# use with single level
+amr.n_cell           =  32 32 32
+
+# >>>>>>>>>>>>>  BC KEYWORDS <<<<<<<<<<<<<<<<<<<<<<
+# Interior, UserBC, Symmetry, SlipWall, NoSlipWall
+# >>>>>>>>>>>>>  BC KEYWORDS <<<<<<<<<<<<<<<<<<<<<<
+pelec.lo_bc       =  "Interior"  "Interior"  "Interior"
+pelec.hi_bc       =  "Interior"  "Interior"  "Interior"
+
+# WHICH PHYSICS
+pelec.do_hydro = 1
+pelec.diffuse_vel = 1
+pelec.diffuse_temp = 1
+pelec.do_react = 0
+pelec.do_grav = 0
+pelec.allow_negative_energy = 0
+pelec.use_explicit_filter=1
+pelec.les_filter_type=2
+pelec.les_filter_fgr=2
+
+# TIME STEP CONTROL
+pelec.cfl            = 0.9     # cfl number for hyperbolic system
+pelec.init_shrink    = 0.3     # scale back initial timestep
+pelec.change_max     = 1.1     # max time step growth
+pelec.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
+# DIAGNOSTICS & VERBOSITY
+pelec.sum_interval   = 1       # timesteps between computing mass
+pelec.v              = 1       # verbosity in Castro.cpp
+amr.v                = 1       # verbosity in Amr.cpp
+amr.data_log         = datlog
+#amr.grid_log        = grdlog  # name of grid logging file
+
+# REFINEMENT / REGRIDDING
+amr.max_level       = 0       # maximum level number allowed
+#amr.max_level       = 1       # maximum level number allowed
+amr.ref_ratio       = 2 2 2 2 # refinement ratio
+amr.regrid_int      = 2 2 2 2 # how often to regrid
+amr.blocking_factor = 4       # block factor in grid generation
+amr.max_grid_size   = 16
+amr.n_error_buf     = 2 2 2 2 # number of buffer cells in error est
+
+# CHECKPOINT FILES
+amr.checkpoint_files_output = 0
+amr.check_file      = chk        # root name of checkpoint file
+amr.check_int       = 100        # number of timesteps between checkpoints
+
+# PLOTFILES
+amr.plot_files_output = 1
+amr.plot_file       = plt        # root name of plotfile
+amr.plot_int        = 100        # number of timesteps between plotfiles
+amr.plot_vars  =  density Temp
+amr.derive_plot_vars = x_velocity y_velocity z_velocity magvel magvort pressure
+
+#PROBIN FILENAME
+amr.probin_file = tg-3d-3.probin

--- a/Testing/test_files/tg-3d-3/tg-3d-3.probin
+++ b/Testing/test_files/tg-3d-3/tg-3d-3.probin
@@ -1,0 +1,25 @@
+&fortin
+
+ reynolds = 1600.0
+ mach = 0.1
+ prandtl = 0.71
+
+/
+
+&tagging
+
+  denerr = 1.d20
+  dengrad = 0.01
+  max_denerr_lev = 5
+  max_dengrad_lev = 5
+
+  presserr = 1.d20
+  pressgrad = 1.d20
+  max_presserr_lev = 5
+  max_pressgrad_lev = 5
+
+/
+
+&extern
+  eos_gamma = 1.4
+/

--- a/Testing/test_files/tg-3d-4/exe_options.cmake
+++ b/Testing/test_files/tg-3d-4/exe_options.cmake
@@ -1,0 +1,15 @@
+#User-specific source files
+list(APPEND PELEC_EXTRA_SOURCES ${CMAKE_SOURCE_DIR}/Exec/RegTests/TG/probdata.f90)
+list(APPEND PELEC_EXTRA_SOURCES ${CMAKE_SOURCE_DIR}/Exec/RegTests/TG/Prob_nd.F90)
+list(APPEND PELEC_EXTRA_SOURCES ${CMAKE_SOURCE_DIR}/Source/Src_nd/bc_fill_nd.F90)
+
+#Compile-time options for executable
+set(PELEC_DIM 3)
+set(PELEC_ENABLE_EB ON)
+set(PELEC_ENABLE_MASA OFF)
+set(PELEC_ENABLE_REACTIONS OFF)
+set(PELEC_ENABLE_MOL ON)
+set(PELEC_ENABLE_PARTICLES OFF)
+set(PELEC_EOS_MODEL GammaLaw)
+set(PELEC_REACTIONS_MODEL Null)
+set(PELEC_TRANSPORT_MODEL Constant)

--- a/Testing/test_files/tg-3d-4/tg-3d-4.ext.gold
+++ b/Testing/test_files/tg-3d-4/tg-3d-4.ext.gold
@@ -1,0 +1,12 @@
+ plotfile = /home/jrood/combustion/PeleC/Build/Testing/test_files/tg-3d-1/plt00010
+ time = 3.5222021953735101e-06
+              variables          minimum value          maximum value
+ density                       0.0011704027572        0.0011826754504
+ Temp                             299.98984011           300.00690522
+ pressure                         1007729.2211           1018296.9179
+ magvort                          63.850446223           21684.907616
+ x_velocity                       -3462.115276            3462.115276
+ y_velocity                       -3462.115276            3462.115276
+ z_velocity                      -33.053398222           33.053398222
+ magvel                           12.387110614            3462.121271
+

--- a/Testing/test_files/tg-3d-4/tg-3d-4.i
+++ b/Testing/test_files/tg-3d-4/tg-3d-4.i
@@ -1,0 +1,70 @@
+# ------------------  INPUTS TO MAIN PROGRAM  -------------------
+#stop_time = 0.0018336339443081453
+max_step = 10
+
+# PROBLEM SIZE & GEOMETRY
+geometry.is_periodic = 1 1 1
+geometry.coord_sys   = 0  # 0 => cart, 1 => RZ  2=>spherical
+geometry.prob_lo     =  -1.0 -1.0 -1.0
+geometry.prob_hi     =   1.0  1.0  1.0
+# use with single level
+amr.n_cell           =  32 32 32
+
+# >>>>>>>>>>>>>  BC KEYWORDS <<<<<<<<<<<<<<<<<<<<<<
+# Interior, UserBC, Symmetry, SlipWall, NoSlipWall
+# >>>>>>>>>>>>>  BC KEYWORDS <<<<<<<<<<<<<<<<<<<<<<
+pelec.lo_bc       =  "Interior"  "Interior"  "Interior"
+pelec.hi_bc       =  "Interior"  "Interior"  "Interior"
+
+# WHICH PHYSICS
+pelec.do_mol_AD=1
+pelec.do_hydro = 1
+pelec.diffuse_vel = 1
+pelec.diffuse_temp = 1
+pelec.do_react = 0
+pelec.do_grav = 0
+pelec.allow_negative_energy = 0
+pelec.use_explicit_filter=1
+pelec.les_filter_type=2
+pelec.les_filter_fgr=2
+
+# TIME STEP CONTROL
+pelec.cfl            = 0.9     # cfl number for hyperbolic system
+pelec.init_shrink    = 0.3     # scale back initial timestep
+pelec.change_max     = 1.1     # max time step growth
+pelec.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
+# DIAGNOSTICS & VERBOSITY
+pelec.sum_interval   = 1       # timesteps between computing mass
+pelec.v              = 1       # verbosity in Castro.cpp
+amr.v                = 1       # verbosity in Amr.cpp
+amr.data_log         = datlog
+#amr.grid_log        = grdlog  # name of grid logging file
+
+# REFINEMENT / REGRIDDING
+amr.max_level       = 0       # maximum level number allowed
+#amr.max_level       = 1       # maximum level number allowed
+amr.ref_ratio       = 2 2 2 2 # refinement ratio
+amr.regrid_int      = 2 2 2 2 # how often to regrid
+amr.blocking_factor = 4       # block factor in grid generation
+amr.max_grid_size   = 16
+amr.n_error_buf     = 2 2 2 2 # number of buffer cells in error est
+
+# CHECKPOINT FILES
+amr.checkpoint_files_output = 0
+amr.check_file      = chk        # root name of checkpoint file
+amr.check_int       = 100        # number of timesteps between checkpoints
+
+# PLOTFILES
+amr.plot_files_output = 1
+amr.plot_file       = plt        # root name of plotfile
+amr.plot_int        = 100        # number of timesteps between plotfiles
+amr.plot_vars  =  density Temp
+amr.derive_plot_vars = x_velocity y_velocity z_velocity magvel magvort pressure
+
+#PROBIN FILENAME
+amr.probin_file = tg-3d-4.probin
+
+#EB
+eb2.geom_type="all_regular"
+

--- a/Testing/test_files/tg-3d-4/tg-3d-4.probin
+++ b/Testing/test_files/tg-3d-4/tg-3d-4.probin
@@ -1,0 +1,25 @@
+&fortin
+
+ reynolds = 1600.0
+ mach = 0.1
+ prandtl = 0.71
+
+/
+
+&tagging
+
+  denerr = 1.d20
+  dengrad = 0.01
+  max_denerr_lev = 5
+  max_dengrad_lev = 5
+
+  presserr = 1.d20
+  pressgrad = 1.d20
+  max_presserr_lev = 5
+  max_pressgrad_lev = 5
+
+/
+
+&extern
+  eos_gamma = 1.4
+/


### PR DESCRIPTION
This commit implements explicit filtering of the hydro fluxes and
source term (for both MOL and PPM code paths). This is necessary to
perform explicitly filtered Large Eddy Simulations.

Contains:
- regressions tests
- documentation
- CMake implementation