### PR TITLE
Add some missing implicit nones

### DIFF
--- a/Exec/RegTests/PMF/probdata.f90
+++ b/Exec/RegTests/PMF/probdata.f90
@@ -36,6 +36,7 @@ contains
     use chemistry_module, only : nspecies, get_species_index
     use eos_type_module
 
+    implicit none
     integer :: iN2, iO2, iH2, nPMF
     double precision :: vt, ek, a, yl, yr, sumY
     double precision, allocatable :: pmf_vals(:)
@@ -98,6 +99,7 @@ contains
 
   subroutine clear_bc()
 
+    implicit none
     deallocate(fuel_state)
 
   end subroutine clear_bc

--- a/Exec/RegTests/PMF_NSCBC/pmf_generic.f90
+++ b/Exec/RegTests/PMF_NSCBC/pmf_generic.f90
@@ -9,6 +9,7 @@ module pmf_module
 contains
 
   subroutine read_pmf()
+    implicit none
     character (len=20) :: ctmp1, ctmp2, fmt
     character (len=1) :: ctmp
     integer index, found, ist, reason, i, j, lsize, pos1, pos2, n
@@ -124,16 +125,19 @@ contains
   end subroutine read_pmf
 
   function pmf_ncomp() result(ncomp)
+    implicit none
     integer :: ncomp
     ncomp = pmf_M
   end function pmf_ncomp
 
   function pmf_npts() result(npts)
+    implicit none
     integer :: npts
     npts = pmf_N
   end function pmf_npts
 
   subroutine interp_pmf(xlo,xhi,y_vector,M_ret)
+    implicit none
     double precision xlo,xhi,y_vector(*)
     double precision sum,xmid
     integer i,j,k,lo_loside,lo_hiside       
@@ -288,6 +292,7 @@ end module pmf_module
 subroutine initialize_pmf(filename)
   use pmf_module
   use chemistry_module, only : nspecies, get_species_index
+  implicit none
   character (len=*) :: filename
   integer :: n
   pmf_filename = filename
@@ -310,6 +315,7 @@ end subroutine initialize_pmf
 
 subroutine pmf(xlo,xhi,y_vector,M)
   use pmf_module
+  implicit none
   double precision :: xlo,xhi,y_vector(*)
   integer :: M
   call interp_pmf(xlo,xhi,y_vector,M)

--- a/Exec/RegTests/SprayTests/amr_follow/particle_tagging_nd.F90
+++ b/Exec/RegTests/SprayTests/amr_follow/particle_tagging_nd.F90
@@ -38,6 +38,7 @@ contains
                           dx,xlo,problo,time,level) &
                           bind(C, name="pc_particle_tag")
 
+    implicit none
     integer          :: set, clear, nd, level
     integer          :: taglo(3), taghi(3)
     integer          :: varlo(3), varhi(3)

--- a/Source/Src_1d/PeleC_advection_1d.F90
+++ b/Source/Src_1d/PeleC_advection_1d.F90
@@ -129,6 +129,7 @@ contains
     use pelec_util_module, only : position, linear_to_angular_momentum
     use amrinfo_module, only : amr_level
 
+    implicit none
     integer lo(1), hi(1)
     integer   uin_l1,  uin_h1
     integer  uout_l1, uout_h1

--- a/Source/Src_1d/impose_NSCBC_1d.f90
+++ b/Source/Src_1d/impose_NSCBC_1d.f90
@@ -36,7 +36,6 @@ contains
  
   implicit none
    
-
   integer, intent(in) :: lo(1), hi(1)
   integer, intent(in) :: domlo(1), domhi(1)
   integer, intent(in) :: q_l1, q_h1

--- a/Source/Src_1d/riemann_1d.F90
+++ b/Source/Src_1d/riemann_1d.F90
@@ -34,6 +34,7 @@ contains
                     gamc,csml,c,qd_l1,qd_h1,ilo,ihi, &
                     bcMask)
 
+    implicit none
     integer lo(1),hi(1)
     integer domlo(1),domhi(1)
     integer ilo,ihi
@@ -111,6 +112,8 @@ contains
     use eos_type_module
     use eos_module
     use riemann_util_module
+
+    implicit none
 
     double precision, parameter :: small = 1.d-8
 
@@ -633,6 +636,9 @@ contains
                        ilo,ihi,domlo,domhi)
 
     use prob_params_module, only : physbc_lo, physbc_hi, Symmetry
+
+    implicit none
+
     double precision, parameter:: small = 1.d-8
 
     integer ilo,ihi

--- a/Source/Src_2d/PeleC_init_eb_2d.f90
+++ b/Source/Src_2d/PeleC_init_eb_2d.f90
@@ -9,6 +9,7 @@ module nbrsTest_nd_module
 
 contains
   pure logical function is_inside (i,j,lo,hi)
+    implicit none
     integer, intent(in) :: i,j,lo(2),hi(2)
     is_inside = i.ge.lo(1) .and. i.le.hi(1) &
          .and.  j.ge.lo(2) .and. j.le.hi(2)
@@ -18,6 +19,7 @@ contains
        bind(C,name="pc_fill_bndry_grad_stencil_amrex")
 
       ! Work in process - least squares boundary stencil capability. Currently doesn't work.
+      implicit none
       integer,            intent(in   ) :: lo(0:2),hi(0:2)
       integer,            intent(in   ) :: Nebg, Nsten
       type(eb_bndry_geom),intent(in   ) :: ebg(0:Nebg-1)
@@ -35,6 +37,7 @@ contains
        bind(C,name="pc_fill_bndry_grad_stencil_ls")
 
       ! Work in process - least squares boundary stencil capability. Currently doesn't work.
+      implicit none
       integer,            intent(in   ) :: lo(0:2),hi(0:2)
       integer,            intent(in   ) :: Nebg, Nsten
       type(eb_bndry_geom),intent(in   ) :: ebg(0:Nebg-1)
@@ -52,6 +55,7 @@ contains
   subroutine pc_fill_bndry_grad_stencil(lo, hi, ebg, Nebg, grad_stencil, Nsten, dx) &
        bind(C,name="pc_fill_bndry_grad_stencil")
 
+    implicit none
     integer,            intent(in   ) :: lo(0:1),hi(0:1)
     integer,            intent(in   ) :: Nebg, Nsten
     type(eb_bndry_geom),intent(in   ) :: ebg(0:Nebg-1)
@@ -139,6 +143,7 @@ contains
        bcval, Nvals, bcflux, Nflux, nc) &
        bind(C,name="pc_apply_eb_boundry_flux_stencil")
 
+    implicit none
     integer,          intent(in   ) ::  lo(0:1),  hi(0:1)
     integer,          intent(in   ) :: Nsten, Nvals, Nflux, nc
     type(eb_bndry_sten), intent(in) :: sten(0:Nsten-1)
@@ -179,6 +184,7 @@ contains
        bcval, Nvals, bcflux, Nflux, nc) &
        bind(C,name="pc_apply_eb_boundry_visc_flux_stencil")
 
+    implicit none
     integer,          intent(in   ) ::  lo(0:1),  hi(0:1)
     integer,          intent(in   ) :: Nsten, Nebg, Nvals, Nflux, nc
     type(eb_bndry_sten), intent(in) :: sten(0:Nsten-1)
@@ -249,6 +255,7 @@ contains
   subroutine pc_fill_flux_interp_stencil(lo, hi, slo, shi, sten, Nsten, idir, &
        fc, fclo, fchi, fa, falo, fahi) bind(C,name="pc_fill_flux_interp_stencil")
 
+    implicit none
     integer,          intent(in)  ::  lo(0:1),  hi(0:1)
     integer,          intent(in)  :: slo(0:1), shi(0:1)
     integer,          intent(in)  :: Nsten, idir
@@ -295,6 +302,7 @@ contains
   subroutine pc_apply_face_stencil(lo, hi, slo, shi, sten, Nsten, idir, vin, vin_lo, vin_hi, &
     vout, vout_lo, vout_hi, nc, in_place) bind(C,name="pc_apply_face_stencil")
 
+    implicit none
     integer,          intent(in   ) ::  lo(0:1),  hi(0:1)
     integer,          intent(in   ) :: slo(0:1), shi(0:1)
     integer,          intent(in   ) :: Nsten, idir, nc, in_place
@@ -405,6 +413,7 @@ contains
     
     use meth_params_module, only: levmsk_notcovered 
 
+    implicit none
     integer,          intent(in   ) ::  lo(0:1),  hi(0:1)
     integer,          intent(in   ) :: nc, Ncut, nebflux
     type(eb_bndry_geom), intent(in   ) :: sv_ebg(0:Ncut-1)
@@ -573,6 +582,7 @@ contains
 
   subroutine pc_set_body_state(lo, hi, S, Slo, Shi, mask, mlo, mhi, b, nc, bval) bind(C,name="pc_set_body_state")
 
+    implicit none
     integer,          intent(in   ) :: nc, bval
     integer,          intent(in   ) :: lo(1:2),hi(1:2)
     integer,          intent(in   ) :: Slo(1:2),Shi(1:2)
@@ -596,6 +606,7 @@ contains
        apx, axlo, axhi, apy, aylo, ayhi) &
        bind(C,name="pc_fill_sv_ebg")
 
+    implicit none
     integer,          intent(in   ) ::  lo(0:2),  hi(0:2)
     integer, dimension(3), intent(in) :: vflo, vfhi, blo, bhi, axlo, axhi, aylo, ayhi
     integer,          intent(in   ) :: Nebg

--- a/Source/Src_2d/impose_NSCBC_2d.f90
+++ b/Source/Src_2d/impose_NSCBC_2d.f90
@@ -25,7 +25,6 @@ contains
                          time,delta,dt,verbose) bind(C, name="impose_NSCBC")
     
   use amrex_fort_module
-  use network, only : nspecies
   use eos_module
   use fundamental_constants_module, only: k_B, n_A
 
@@ -470,6 +469,8 @@ end subroutine impose_NSCBC
                                
                                
   use meth_params_module, only : QVAR, QPRES, QU, QV, QRHO
+
+  implicit none
   
   integer, intent(in) :: i,j,idir,isign
   integer, intent(in) :: q_l1, q_l2, q_h1, q_h2
@@ -536,6 +537,8 @@ end subroutine impose_NSCBC
                                
                                
   use meth_params_module, only : QVAR, QPRES, QU, QV, QRHO
+
+  implicit none
   
   integer, intent(in) :: i,j,idir
   integer, intent(in) :: q_l1, q_l2, q_h1, q_h2
@@ -577,6 +580,8 @@ end subroutine impose_NSCBC
                                
                                
   use meth_params_module, only : QVAR, QPRES, QU, QV, QRHO, NQAUX, QC, QGAMC
+
+  implicit none
   
   integer, intent(in) :: i,j,idir
   integer, intent(in) :: q_l1, q_l2, q_h1, q_h2
@@ -620,6 +625,7 @@ end subroutine impose_NSCBC
                                 qaux, qa_l1, qa_l2, qa_h1, qa_h2)
                                
   use eos_module
+  use network, only : nspecies
   use amrex_constants_module, only : ONE
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UMZ, UEDEN, UEINT, UTEMP,&
                                  UFS, NQAUX, QC, QGAMC, QRSPEC, &
@@ -627,7 +633,8 @@ end subroutine impose_NSCBC
                                  QVAR, QRHO, QU, QV, QREINT, QPRES, QTEMP, &
                                  QFS, QFX, QGAME, NHYP
   use prob_params_module, only : SlipWall, NoSlipWall
-  
+
+  implicit none
   
   integer, intent(in) :: i,j,idir,isign,bc_type
   integer, intent(in) :: domlo(2), domhi(2)
@@ -907,7 +914,9 @@ end subroutine impose_NSCBC
                                                     
   use meth_params_module, only : QVAR, QPRES, QU, QV, QRHO, NQAUX, QC, QGAMC, QTEMP, QRSPEC
   use prob_params_module, only : probhi, UserBC, Inflow, Outflow, SlipWall, NoSlipWall
-  
+
+  implicit none
+
   integer, intent(in) :: i,j,idir,isign
   integer, intent(in) :: q_l1, q_l2, q_h1, q_h2
   integer, intent(in) :: qa_l1, qa_l2, qa_h1, qa_h2

--- a/Source/Src_2d/riemann_2d.F90
+++ b/Source/Src_2d/riemann_2d.F90
@@ -39,6 +39,7 @@ contains
     use eos_type_module
     use eos_module, only: eos_re, eos_rt, mine
 
+    implicit none
     integer, intent(in) :: qpd_l1,qpd_l2,qpd_h1,qpd_h2
     integer, intent(in) :: flx_l1,flx_l2,flx_h1,flx_h2
     integer, intent(in) :: qg_l1,qg_l2,qg_h1,qg_h2
@@ -268,6 +269,7 @@ contains
 
     use prob_params_module, only : coord_type
 
+    implicit none
     integer, intent(in) :: qd_l1, qd_l2, qd_h1, qd_h2
     integer, intent(in) :: s_l1, s_l2, s_h1, s_h2
     integer, intent(in) :: ilo1, ilo2, ihi1, ihi2
@@ -381,6 +383,7 @@ contains
     use eos_module
     use prob_params_module, only : coord_type
 
+    implicit none
     double precision, parameter:: small = 1.d-8
     double precision, parameter :: small_u = 1.d-10
 
@@ -923,8 +926,8 @@ contains
 
     use prob_params_module, only : coord_type
 
+    implicit none
     double precision, parameter:: small = 1.d-8
-
     integer :: qpd_l1, qpd_l2, qpd_h1, qpd_h2
     integer :: gd_l1, gd_l2, gd_h1, gd_h2
     integer :: uflx_l1, uflx_l2, uflx_h1, uflx_h2
@@ -1186,6 +1189,7 @@ contains
 
     use eos_module
 
+    implicit none
     integer :: qpd_l1, qpd_l2, qpd_h1, qpd_h2
     integer :: gd_l1, gd_l2, gd_h1, gd_h2
     integer :: uflx_l1, uflx_l2, uflx_h1, uflx_h2
@@ -1328,8 +1332,9 @@ contains
     ! to know the pressure and velocity on the interface for the grad p
     ! term in momentum and for an internal energy update
 
-    double precision, parameter:: small = 1.d-8
+    implicit none
 
+    double precision, parameter:: small = 1.d-8
     integer :: qpd_l1, qpd_l2, qpd_h1, qpd_h2
     integer :: gd_l1, gd_l2, gd_h1, gd_h2
     integer :: uflx_l1, uflx_l2, uflx_h1, uflx_h2

--- a/Source/Src_2d/trans_2d.F90
+++ b/Source/Src_2d/trans_2d.F90
@@ -33,6 +33,7 @@ contains
                     vol, vol_l1, vol_l2, vol_h1, vol_h2, &
                     ilo, ihi, jlo, jhi)
 
+    implicit none
     integer qd_l1, qd_l2, qd_h1, qd_h2
     integer gc_l1, gc_l2, gc_h1, gc_h2
     integer fx_l1, fx_l2, fx_h1, fx_h2
@@ -395,6 +396,7 @@ contains
                     srcQ, src_l1, src_l2, src_h1, src_h2, &
                     hdt, cdtdy, ilo, ihi, jlo, jhi)
 
+    implicit none
     integer qd_l1, qd_l2, qd_h1, qd_h2
     integer gc_l1, gc_l2, gc_h1, gc_h2
     integer fy_l1, fy_l2, fy_h1, fy_h2

--- a/Source/Src_3d/PeleC_init_eb_3d.f90
+++ b/Source/Src_3d/PeleC_init_eb_3d.f90
@@ -11,6 +11,7 @@ module nbrsTest_nd_module
 contains
 
   pure logical function is_inside (i,j,k,lo,hi)
+    implicit none
     integer, intent(in) :: i,j,k,lo(3),hi(3)
     is_inside = i.ge.lo(1) .and. i.le.hi(1) &
          .and.  j.ge.lo(2) .and. j.le.hi(2) &
@@ -18,6 +19,7 @@ contains
   end function is_inside
 
   pure subroutine mysort(c, n)
+    implicit none
     real(amrex_real), intent(in) :: n(dim)
     integer, intent(out) :: c(dim)
     logical          :: mask(dim)
@@ -57,6 +59,8 @@ contains
 
     use amrex_mlebabeclap_3d_module, only : amrex_get_dx_eb
 
+    implicit none
+
     ! Array bounds
     integer,            intent(in   ) :: lo(0:2), hi(0:2)
     integer,            intent(in   ) :: Nebg, Nsten
@@ -86,7 +90,6 @@ contains
     integer :: i, j, k, L
     AREA = dx**(dim-1)
     fac = AREA / dx
-
 
     do L = 0, Nsten-1
        i = ebg(L) % iv(0)
@@ -167,7 +170,7 @@ contains
        bind(C,name="pc_fill_bndry_grad_stencil_ls")
 
       ! Work in process - least squares boundary stencil capability. Currently doesn't work.
-
+    implicit none
     integer,            intent(in   ) :: lo(0:2),hi(0:2)
     integer,            intent(in   ) :: Nebg, Nsten
     type(eb_bndry_geom),intent(in   ) :: ebg(0:Nebg-1)
@@ -252,6 +255,7 @@ contains
   subroutine pc_fill_bndry_grad_stencil(lo, hi, ebg, Nebg, grad_stencil, Nsten, dx) &
        bind(C,name="pc_fill_bndry_grad_stencil")
 
+    implicit none
     integer,            intent(in   ) :: lo(0:2),hi(0:2)
     integer,            intent(in   ) :: Nebg, Nsten
     type(eb_bndry_geom),intent(in   ) :: ebg(0:Nebg-1)
@@ -353,6 +357,7 @@ contains
        bcval, Nvals, bcflux, Nflux, nc) &
        bind(C,name="pc_apply_eb_boundry_flux_stencil")
 
+    implicit none
     integer,          intent(in   ) ::  lo(0:2),  hi(0:2)
     integer,          intent(in   ) :: Nsten, Nvals, Nflux, nc
     type(eb_bndry_sten), intent(in) :: sten(0:Nsten-1)
@@ -398,6 +403,7 @@ contains
        bcval, Nvals, bcflux, Nflux, nc) &
        bind(C,name="pc_apply_eb_boundry_visc_flux_stencil")
 
+    implicit none
     integer,          intent(in   ) ::  lo(0:2),  hi(0:2)
     integer,          intent(in   ) :: Nsten, Nebg, Nvals, Nflux, nc
     type(eb_bndry_sten), intent(in) :: sten(0:Nsten-1)
@@ -498,6 +504,7 @@ contains
   subroutine pc_fill_flux_interp_stencil(lo, hi, slo, shi, sten, Nsten, idir, &
        fc, fclo, fchi, fa, falo, fahi) bind(C,name="pc_fill_flux_interp_stencil")
 
+    implicit none
     integer,          intent(in)  ::  lo(0:2),  hi(0:2)
     integer,          intent(in)  :: slo(0:2), shi(0:2)
     integer,          intent(in)  :: Nsten, idir
@@ -578,6 +585,7 @@ contains
   subroutine pc_apply_face_stencil(lo, hi, slo, shi, sten, Nsten, idir, vin, vin_lo, vin_hi, &
     vout, vout_lo, vout_hi, nc, in_place) bind(C,name="pc_apply_face_stencil")
 
+    implicit none
     integer,          intent(in   ) ::  lo(0:2),  hi(0:2)
     integer,          intent(in   ) :: slo(0:2), shi(0:2)
     integer,          intent(in   ) :: Nsten, idir, nc, in_place
@@ -739,6 +747,7 @@ contains
 
     use meth_params_module, only: levmsk_notcovered, eb_small_vfrac
 
+    implicit none
     integer,          intent(in   ) ::  lo(0:2),  hi(0:2)
     integer,          intent(in   ) :: nc, Ncut, nebflux
     type(eb_bndry_geom), intent(in   ) :: sv_ebg(0:Ncut-1)
@@ -932,6 +941,7 @@ contains
   subroutine pc_set_body_state(lo, hi, S, Slo, Shi, mask, mlo, mhi, b, nc, bval) &
        bind(C,name="pc_set_body_state")
 
+    implicit none
     integer,          intent(in   ) :: nc, bval
     integer,          intent(in   ) :: lo(1:3),hi(1:3)
     integer,          intent(in   ) :: Slo(1:3),Shi(1:3)
@@ -957,7 +967,7 @@ contains
        apx, axlo, axhi, apy, aylo, ayhi, apz, azlo, azhi) &
        bind(C,name="pc_fill_sv_ebg")
 
-
+    implicit none
     integer,          intent(in   ) ::  lo(0:2),  hi(0:2)
     integer, dimension(3), intent(in) :: vflo, vfhi, blo, bhi, axlo, axhi, aylo, ayhi, azlo, azhi
     integer,          intent(in   ) :: Nebg

--- a/Source/Src_3d/impose_NSCBC_3d.f90
+++ b/Source/Src_3d/impose_NSCBC_3d.f90
@@ -26,7 +26,6 @@ contains
                          time,delta,dt,verbose) bind(C, name="impose_NSCBC")
     
   use amrex_fort_module
-  use network, only : nspecies
   use eos_module
   use fundamental_constants_module, only: k_B, n_A
 
@@ -762,6 +761,8 @@ end subroutine impose_NSCBC
                                
                                
   use meth_params_module, only : QVAR, QPRES, QU, QV, QW, QRHO
+
+  implicit none
   
   integer, intent(in) :: i,j,k,idir,isign
   integer, intent(in) :: q_l1, q_l2, q_l3, q_h1, q_h2, q_h3
@@ -856,6 +857,8 @@ end subroutine impose_NSCBC
                                
                                
   use meth_params_module, only : QVAR, QPRES, QU, QV, QW, QRHO
+
+  implicit none
   
   integer, intent(in) :: i,j,k,idir
   integer, intent(in) :: q_l1, q_l2, q_l3, q_h1, q_h2, q_h3
@@ -911,6 +914,8 @@ end subroutine impose_NSCBC
                                
   use meth_params_module, only : QVAR, QPRES, QU, QV, QW, QRHO, NQAUX, QC, QGAMC
   
+  implicit none
+
   integer, intent(in) :: i,j,k,idir
   integer, intent(in) :: q_l1, q_l2, q_l3, q_h1, q_h2, q_h3
   integer, intent(in) :: qa_l1, qa_l2, qa_l3, qa_h1, qa_h2, qa_h3
@@ -1004,6 +1009,7 @@ end subroutine impose_NSCBC
                                  QFS, QFX, QGAME, NHYP
   use prob_params_module, only : SlipWall, NoSlipWall
   
+  implicit none
   
   integer, intent(in) :: i,j,k,idir,isign,bc_type
   integer, intent(in) :: domlo(3), domhi(3)
@@ -1429,6 +1435,8 @@ end subroutine impose_NSCBC
                                 
   use meth_params_module, only : QVAR, QPRES, QU, QV, QW, QRHO, NQAUX, QC, QGAMC, QTEMP, QRSPEC
   use prob_params_module, only : probhi, Inflow, Outflow, SlipWall, NoSlipWall
+
+  implicit none
   
   integer, intent(in) :: i, j, k, idir, isign
   integer, intent(in) :: q_l1, q_l2, q_l3, q_h1, q_h2, q_h3

--- a/Source/Src_3d/riemann_3d.F90
+++ b/Source/Src_3d/riemann_3d.F90
@@ -39,6 +39,7 @@ contains
     use network, only : nspecies
     use eos_module
 
+    implicit none
     integer, intent(in) :: qpd_lo(3), qpd_hi(3)
     integer, intent(in) :: flx_lo(3), flx_hi(3)
     integer, intent(in) :: q_lo(3), q_hi(3)
@@ -261,6 +262,7 @@ contains
     use prob_params_module, only : coord_type
     use amrex_constants_module
 
+    implicit none
     integer, intent(in) :: qd_lo(3), qd_hi(3)
     integer, intent(in) :: s_lo(3), s_hi(3)
     integer, intent(in) :: lo(3), hi(3)
@@ -382,8 +384,10 @@ contains
     use network, only : nspecies, naux
     use eos_type_module
     use eos_module
-    double precision, parameter:: small = 1.d-8
 
+    implicit none
+
+    double precision, parameter:: small = 1.d-8
     integer :: qpd_lo(3),qpd_hi(3)
     integer :: gd_lo(2),gd_hi(2)
     integer :: uflx_lo(3),uflx_hi(3)
@@ -966,8 +970,10 @@ contains
 
     use amrex_mempool_module, only : bl_allocate, bl_deallocate
     use prob_params_module, only : physbc_lo, physbc_hi, Symmetry, SlipWall, NoSlipWall
-    double precision, parameter:: small = 1.d-8
 
+    implicit none
+
+    double precision, parameter:: small = 1.d-8
     integer :: qpd_lo(3),qpd_hi(3)
     integer :: gd_lo(2),gd_hi(2)
     integer :: uflx_lo(3),uflx_hi(3)
@@ -1240,8 +1246,9 @@ contains
     use amrex_mempool_module, only : bl_allocate, bl_deallocate
     use prob_params_module, only : physbc_lo, physbc_hi, Symmetry, SlipWall, NoSlipWall
 
-    double precision, parameter:: small = 1.d-8
+    implicit none
 
+    double precision, parameter:: small = 1.d-8
     integer :: qpd_lo(3),qpd_hi(3)
     integer :: gd_lo(2),gd_hi(2)
     integer :: uflx_lo(3),uflx_hi(3)

--- a/Source/Src_3d/trans_3d.F90
+++ b/Source/Src_3d/trans_3d.F90
@@ -22,6 +22,7 @@ contains
 
   subroutine reset_edge_state_thermo(qedge, qd_lo, qd_hi, ii, jj, kk, eos_state)
 
+    implicit none
     integer, intent(in) :: ii, jj, kk
     integer, intent(in) :: qd_lo(3), qd_hi(3)
     double precision, intent(inout) :: qedge(qd_lo(1):qd_hi(1),qd_lo(2):qd_hi(2),qd_lo(3):qd_hi(3),QVAR)
@@ -92,6 +93,7 @@ contains
     ! Note that what we call jlo here is jlo = lo(2) - 1
     ! Note that what we call jhi here is jhi = hi(2) + 1
 
+    implicit none
     integer :: qd_lo(3),qd_hi(3)
     integer :: fx_lo(3),fx_hi(3)
     integer :: qx_lo(3),qx_hi(3)
@@ -360,6 +362,7 @@ contains
                      gamc,gd_lo,gd_hi, &
                      cdtdx,ilo,ihi,jlo,jhi,kc,km,k3d)
 
+    implicit none
     integer :: qd_lo(3),qd_hi(3)
     integer :: fx_lo(3),fx_hi(3)
     integer :: qx_lo(3),qx_hi(3)
@@ -632,6 +635,7 @@ contains
                      gamc,gd_lo,gd_hi, &
                      cdtdy,ilo,ihi,jlo,jhi,kc,k3d)
 
+    implicit none
     integer :: qd_lo(3),qd_hi(3)
     integer :: fy_lo(3),fy_hi(3)
     integer :: qy_lo(3),qy_hi(3)
@@ -897,6 +901,7 @@ contains
                      gamc,gd_lo,gd_hi, &
                      cdtdy,ilo,ihi,jlo,jhi,kc,km,k3d)
 
+    implicit none
     integer :: qd_lo(3),qd_hi(3)
     integer :: fy_lo(3),fy_hi(3)
     integer :: qy_lo(3),qy_hi(3)
@@ -1170,6 +1175,7 @@ contains
                     gamc,gd_lo,gd_hi, &
                     cdtdz,ilo,ihi,jlo,jhi,km,kc,k3d)
 
+    implicit none
     integer :: qd_lo(3),qd_hi(3)
     integer :: fz_lo(3),fz_hi(3)
     integer :: qz_lo(3),qz_hi(3)
@@ -1593,6 +1599,7 @@ contains
                      srcQ,src_lo,src_hi, &
                      hdt,cdtdx,cdtdy,ilo,ihi,jlo,jhi,kc,km,k3d)
 
+    implicit none
     integer :: qd_lo(3),qd_hi(3)
     integer :: fx_lo(3),fx_hi(3)
     integer :: fy_lo(3),fy_hi(3)
@@ -1930,6 +1937,7 @@ contains
                      srcQ,src_lo,src_hi, &
                      hdt,cdtdx,cdtdz,ilo,ihi,jlo,jhi,km,kc,k3d)
 
+    implicit none
     integer :: qd_lo(3),qd_hi(3)
     integer :: fx_lo(3),fx_hi(3)
     integer :: fz_lo(3),fz_hi(3)
@@ -2237,6 +2245,7 @@ contains
                      srcQ,src_lo,src_hi, &
                      hdt,cdtdy,cdtdz,ilo,ihi,jlo,jhi,km,kc,k3d)
 
+    implicit none
     integer :: qd_lo(3),qd_hi(3)
     integer :: fy_lo(3),fy_hi(3)
     integer :: fz_lo(3),fz_hi(3)

--- a/Source/Src_nd/PeleC_nd.F90
+++ b/Source/Src_nd/PeleC_nd.F90
@@ -1,6 +1,7 @@
 subroutine pc_network_init() bind(C, name="pc_network_init")
 
   use network, only: network_init
+  implicit none
 
   call network_init()
 
@@ -14,6 +15,7 @@ end subroutine pc_network_init
 subroutine pc_network_close() bind(C, name="pc_network_close")
 
   use network, only: network_close
+  implicit none
 
   call network_close()
 
@@ -27,6 +29,7 @@ end subroutine pc_network_close
 subroutine pc_transport_init() bind(C, name="pc_transport_init")
 
   use transport_module, only: transport_init
+  implicit none
 
   call transport_init()
 
@@ -40,6 +43,7 @@ end subroutine pc_transport_init
 subroutine pc_transport_close() bind(C, name="pc_transport_close")
 
   use transport_module, only: transport_close
+  implicit none
 
   call transport_close()
 
@@ -55,6 +59,7 @@ subroutine pc_extern_init(name,namlen) bind(C, name="pc_extern_init")
   ! initialize the external runtime parameters in
   ! extern_probin_module
 
+  implicit none
   integer :: namlen
   integer :: name(namlen)
 
@@ -69,6 +74,8 @@ end subroutine pc_extern_init
 subroutine pc_reactor_init() bind(C, name="pc_reactor_init")
 
   use reactor_module, only: reactor_init
+
+  implicit none
 
 #ifdef _OPENMP
 !$omp parallel
@@ -87,6 +94,7 @@ end subroutine pc_reactor_init
 subroutine pc_reactor_close() bind(C, name="pc_reactor_close")
 
   use reactor_module, only: reactor_close
+  implicit none
 
 #ifdef _OPENMP
 !$omp parallel
@@ -590,6 +598,7 @@ subroutine clear_method_params() &
      bind(C, name="clear_method_params")
 
   use meth_params_module
+  implicit none
 
   ! call to match parallel_initialize()?
   deallocate(qpass_map)
@@ -751,6 +760,7 @@ end subroutine clear_grid_info
 
 subroutine pc_set_special_tagging_flag(dummy,flag) &
      bind(C, name="pc_set_special_tagging_flag")
+  implicit none
   double precision :: dummy
   integer          :: flag
 end subroutine pc_set_special_tagging_flag
@@ -764,6 +774,7 @@ subroutine get_tagging_params(name, namlen) &
 
   use tagging_module
 
+  implicit none
   ! Initialize the tagging parameters
 
   integer :: namlen

--- a/Source/Src_nd/PeleC_util.F90
+++ b/Source/Src_nd/PeleC_util.F90
@@ -15,6 +15,7 @@ contains
     use amrex_constants_module, only: ZERO, HALF
 
     ! Input arguments
+    implicit none
     integer :: i, j, k
     logical, optional :: ccx, ccy, ccz
 
@@ -448,6 +449,7 @@ contains
     use amrinfo_module, only: amr_level
     use prob_params_module, only: dx_level, dim
     
+    implicit none
     double precision :: loc(3)
 
     integer :: index(3)

--- a/Source/Src_nd/interpolate.f90
+++ b/Source/Src_nd/interpolate.f90
@@ -10,6 +10,7 @@ module interpolate_module
 !     find the value of model_var at point r using linear interpolation.
 !     Eventually, we can do something fancier here.
       
+      implicit none
       double precision, intent(in   ) :: r
       integer         , intent(in   ) :: npts_model
       double precision, intent(in   ) :: model_r(npts_model), model_var(npts_model)
@@ -88,6 +89,7 @@ module interpolate_module
       ! tri-linear interpolation; useful for EOS tables
       ! this is stricly interpolation, so if the point (x,y,z) is outside
       ! the bounds of model_x,model_y,model_z, then we abort
+      implicit none
       double precision, intent(in   ) :: x,y,z
       integer,          intent(in   ) :: npts_x, npts_y, npts_z
       double precision, intent(in   ) :: model_x(npts_x), &
@@ -157,6 +159,7 @@ module interpolate_module
 
 
     function locate(x, n, xs)
+      implicit none
       integer, intent(in) :: n
       double precision, intent(in) :: x, xs(n)
       integer :: locate      

--- a/Source/Src_nd/parmparse_mod.f90
+++ b/Source/Src_nd/parmparse_mod.f90
@@ -110,12 +110,14 @@ module parmparse_module
 contains
 
   subroutine parmparse_build (pp, name)
+    implicit none
     type(ParmParse) :: pp
     character(*), intent(in) :: name
     call fi_new_parmparse(pp%p, string_f_to_c(name))
   end subroutine parmparse_build
 
   subroutine parmparse_destroy (this)
+    implicit none
     type(ParmParse) :: this
     if (c_associated(this%p)) then
        call fi_delete_parmparse(this%p)
@@ -124,6 +126,7 @@ contains
   end subroutine parmparse_destroy
 
   subroutine get_int (this, name, v)
+    implicit none
     class(ParmParse), intent(in) :: this
     character(len=*), intent(in) :: name
     integer :: v
@@ -131,6 +134,7 @@ contains
   end subroutine get_int
 
   subroutine get_double (this, name, v)
+    implicit none
     class(ParmParse), intent(in) :: this
     character(*), intent(in) :: name
     double precision :: v
@@ -138,6 +142,7 @@ contains
   end subroutine get_double
 
   subroutine get_logical (this, name, v)
+    implicit none
     class(ParmParse), intent(in) :: this
     character(*), intent(in) :: name
     logical :: v
@@ -147,6 +152,7 @@ contains
   end subroutine get_logical
 
   subroutine get_string (this, name, v)
+    implicit none
     class(ParmParse), intent(in) :: this
     character(*), intent(in) :: name
     character(*), intent(inout) :: v
@@ -161,6 +167,7 @@ contains
   end subroutine get_string
 
   subroutine query_int (this, name, v)
+    implicit none
     class(ParmParse), intent(in) :: this
     character(len=*), intent(in) :: name
     integer :: v
@@ -168,6 +175,7 @@ contains
   end subroutine query_int
 
   subroutine query_double (this, name, v)
+    implicit none
     class(ParmParse), intent(in) :: this
     character(*), intent(in) :: name
     double precision :: v
@@ -175,6 +183,7 @@ contains
   end subroutine query_double
 
   subroutine query_logical (this, name, v)
+    implicit none
     class(ParmParse), intent(in) :: this
     character(*), intent(in) :: name
     logical :: v
@@ -184,6 +193,7 @@ contains
   end subroutine query_logical
 
   subroutine query_string (this, name, v)
+    implicit none
     class(ParmParse), intent(in) :: this
     character(*), intent(in) :: name
     character(*), intent(inout) :: v

--- a/Source/Src_nd/riemann_util.f90
+++ b/Source/Src_nd/riemann_util.f90
@@ -13,6 +13,7 @@ contains
 
     use prob_params_module, only : physbc_lo, physbc_hi, Symmetry, SlipWall, NoSlipWall
     
+    implicit none
     integer, intent(in) :: idir, i, j, domlo(*), domhi(*)
     integer, intent(in) :: bcMask_l1, bcMask_l2, bcMask_h1, bcMask_h2
     integer, intent(in) :: bcMask(bcMask_l1:bcMask_h1,bcMask_l2:bcMask_h2)
@@ -63,6 +64,7 @@ contains
 
     use prob_params_module, only : physbc_lo, physbc_hi, Symmetry, SlipWall, NoSlipWall
     
+    implicit none
     integer, intent(in) :: idir, i, j, k, domlo(*), domhi(*)
     integer, intent(in) :: bcMask_l1, bcMask_l2, bcMask_l3, bcMask_h1, bcMask_h2, bcMask_h3
     integer, intent(in) :: bcMask(bcMask_l1:bcMask_h1,bcMask_l2:bcMask_h2,bcMask_l3:bcMask_h3)
@@ -130,6 +132,7 @@ contains
 
     use prob_params_module, only : physbc_lo, physbc_hi, Outflow
 
+    implicit none
     double precision, intent(inout) :: ul,ur,vl,vr,v2l,v2r,rel,rer
     integer, intent(in) :: idir, i, j, domlo(*), domhi(*)
     integer, intent(in) :: bcMask_l1, bcMask_l2, bcMask_h1, bcMask_h2
@@ -162,6 +165,7 @@ contains
 
     ! compute the lagrangian wave speeds.
 
+    implicit none
     double precision, intent(in) :: p,v,gam,gdot,pstar,csq,gmin,gmax
     double precision, intent(out) :: wsq, gstar
 
@@ -208,6 +212,7 @@ contains
 
     use meth_params_module, only : cg_maxiter, cg_tol
 
+    implicit none
     double precision, intent(inout) :: pstar_lo, pstar_hi
     double precision, intent(in) :: ul, pl, taul, gamel, clsql
     double precision, intent(in) :: ur, pr, taur, gamer, clsqr
@@ -302,6 +307,7 @@ contains
          npassive, upass_map, qpass_map
     use prob_params_module, only : coord_type
 
+    implicit none
     double precision, intent(in) :: ql(QVAR), qr(QVAR), cl, cr
     double precision, intent(inout) :: f(NVAR)
     integer, intent(in) :: idir, ndim
@@ -457,6 +463,7 @@ contains
          NVAR, URHO, UMX, UMY, UMZ, UEDEN, UEINT, UTEMP, &
          npassive, upass_map, qpass_map
 
+    implicit none
     real (amrex_real), intent(in)  :: q(QVAR)
     real (amrex_real), intent(out) :: U(NVAR)
 
@@ -492,6 +499,7 @@ contains
          NVAR, URHO, UMX, UMY, UMZ, UEDEN, UEINT, UTEMP, &
          npassive, upass_map, qpass_map
 
+    implicit none
     integer, intent(in) :: idir
     real (amrex_real), intent(in)  :: S_k, S_c
     real (amrex_real), intent(in)  :: q(QVAR)
@@ -546,6 +554,7 @@ contains
          npassive, upass_map
     use prob_params_module, only : coord_type
 
+    implicit none
     integer, intent(in) :: idir, ndim, bnd_fac
     real (amrex_real), intent(in) :: U(NVAR)
     real (amrex_real), intent(in) :: p
@@ -600,7 +609,6 @@ contains
 
     use eos_module
     use meth_params_module, only : small_dens, small_pres
-
 
     implicit none
 
@@ -827,7 +835,6 @@ contains
 
     use eos_module
     use meth_params_module, only : small_dens, small_pres
-
 
     implicit none
 

--- a/Source/Src_nd/string_mod.f90
+++ b/Source/Src_nd/string_mod.f90
@@ -12,6 +12,7 @@ module string_module
 contains
 
   function string_f_to_c (fstr) result(cstr)
+    implicit none
     character(*), intent(in) :: fstr
     character(c_char) :: cstr(len_trim(fstr)+1)
     integer :: i, n
@@ -23,6 +24,7 @@ contains
   end function string_f_to_c
 
   function string_c_to_f (cstr) result(fstr)
+    implicit none
     character(c_char), intent(in) :: cstr(:)
     character(len=size(cstr)-1) :: fstr
     integer :: i, n

--- a/Source/Src_nd/weno.f90
+++ b/Source/Src_nd/weno.f90
@@ -32,6 +32,7 @@ contains
   !     3: WENO-Z  7th order
         
  subroutine weno5z_face(v, vl, vr)
+    implicit none
     real(amrex_real), intent(in)  :: v(-2:3)
     real(amrex_real), intent(out) :: vl , vr   ! left and right at i+1/2
 
@@ -94,6 +95,7 @@ contains
   ! :::
   
   subroutine weno7z_face(v, vl, vr)
+    implicit none
     real(amrex_real), intent(in)  :: v(-3:4)
     real(amrex_real), intent(out) :: vl , vr   ! left and right at i+1/2
 
@@ -186,7 +188,7 @@ contains
   ! :::
   
   subroutine weno5js_face(v, vl, vr)
-    
+    implicit none
     real(amrex_real), intent(in)  :: v(-2:3)
     real(amrex_real), intent(out) :: vl , vr   ! left and right at i+1/2
 
@@ -245,6 +247,7 @@ contains
    
   
     subroutine weno3z_face(v, vl, vr)
+      implicit none
       real(amrex_real), intent(in)  :: v(-2:3)
       real(amrex_real), intent(out) :: vl, vr  ! left and right at i + 1/2
 
@@ -298,6 +301,7 @@ contains
   
   ! Normalizes ``alphas'' into weights.
   subroutine getWghts(alpha, len)
+      implicit none
       integer         , intent(in)    :: len
       real(amrex_real), intent(inout) :: alpha(1:len)
 

--- a/Source/TurbInflow/turbinflow_f.f90
+++ b/Source/TurbInflow/turbinflow_f.f90
@@ -2,7 +2,6 @@ module turbinflow_module
 
   use amrex_fort_module, only : amrex_real
 
-
   implicit none
 
   logical, save :: turbinflow_initialized = .false.
@@ -27,6 +26,7 @@ module turbinflow_module
   interface
      subroutine getplane (filename, len, data, plane, ncomp, isswirltype) bind(c)
        use amrex_fort_module, only : amrex_real
+       implicit none
        integer, intent(in) :: len, ncomp, isswirltype, plane
        integer, intent(in) :: filename(len)
        real(amrex_real), intent(inout) :: data(*)
@@ -39,6 +39,7 @@ module turbinflow_module
 contains
 
   subroutine init_turbinflow(turbfile, is_cgs)
+    implicit none
     character (len=*), intent(in) :: turbfile
     logical, intent(in), optional :: is_cgs
 
@@ -97,6 +98,7 @@ contains
 
 
   subroutine get_turbvelocity(lo1,lo2,hi1,hi2,x,y,z,v)
+    implicit none
     integer, intent(in) :: lo1,lo2,hi1,hi2
     real(amrex_real), intent(in) :: x(lo1:hi1), y(lo2:hi2)
     real(amrex_real), intent(in) :: z
@@ -160,6 +162,7 @@ contains
   end subroutine get_turbvelocity
 
   subroutine store_planes(z)
+    implicit none
     real(amrex_real), intent(in) :: z
     integer :: izlo, iplane, k, n
     izlo = nint(z*dxinv(3)) - 1


### PR DESCRIPTION
I noticed some inconsistencies between compilers which seemed to be because of some missing `implicit none`s. So I tried to catch them all here.