### PR TITLE
OMP bug

### DIFF
--- a/Source/PeleC_MOL.cpp
+++ b/Source/PeleC_MOL.cpp
@@ -140,6 +140,7 @@ PeleC::getMOLSrcTerm(const amrex::MultiFab& S,
          mfi.isValid(); ++mfi) {
 #ifdef PELE_USE_EB
       Real wt = ParallelDescriptor::second();
+
 #endif
 
       const Box  vbox = mfi.tilebox();
@@ -169,6 +170,8 @@ PeleC::getMOLSrcTerm(const amrex::MultiFab& S,
 
       int local_i = mfi.LocalIndex();
       int Ncut = no_eb_in_domain ? 0 : sv_eb_bndry_grad_stencil[local_i].size();
+      SparseData<amrex::Real,EBBndrySten> eb_flux_thdlocal;
+      eb_flux_thdlocal.define(sv_eb_bndry_grad_stencil[local_i], NUM_STATE);
 #else
       const FArrayBox& Sfab = S[mfi];
 #endif
@@ -369,10 +372,11 @@ PeleC::getMOLSrcTerm(const amrex::MultiFab& S,
       //  non-zero only for heat flux on isothermal boundaries,
       //  and momentum fluxes at no-slip walls
       if (typ == FabType::singlevalued && Ncut > 0) {
-        sv_eb_flux[local_i].setVal(0);  // Default to Neumann for all fields
+        eb_flux_thdlocal.setVal(0);  // Default to Neumann for all fields
 
         int Nvals = sv_eb_bcval[local_i].numPts();
         int Nflux = sv_eb_flux[local_i].numPts();
+
         BL_ASSERT(Nvals == Ncut);
         BL_ASSERT(Nflux == Ncut);
 
@@ -391,7 +395,7 @@ PeleC::getMOLSrcTerm(const amrex::MultiFab& S,
                                              BL_TO_FORTRAN_N_ANYD(coeff_cc, dComp_lambda),
                                              sv_eb_bcval[local_i].dataPtr(cQTEMP),
                                              &Nvals,
-                                             sv_eb_flux[local_i].dataPtr(Eden),
+                                             eb_flux_thdlocal.dataPtr(Eden),
                                              &Nflux, &nComp);
           }
         }
@@ -411,7 +415,7 @@ PeleC::getMOLSrcTerm(const amrex::MultiFab& S,
                                                   BL_TO_FORTRAN_N_ANYD(coeff_cc, dComp_mu),
                                                   BL_TO_FORTRAN_N_ANYD(coeff_cc, dComp_xi),
                                                   sv_eb_bcval[local_i].dataPtr(cQU), &Nvals,
-                                                  sv_eb_flux[local_i].dataPtr(Xmom), &Nflux,
+                                                  eb_flux_thdlocal.dataPtr(Xmom), &Nflux,
                                                   &nComp);
           }
         }
@@ -423,20 +427,20 @@ PeleC::getMOLSrcTerm(const amrex::MultiFab& S,
 #ifdef PELEC_USE_MOL
       /* At this point flux_ec contains the diffusive fluxes in each direction
          at face centers for the (potentially partially covered) grid-aligned 
-         faces and sv_eb_flux contains the flux for the cut faces. Before 
+         faces and eb_flux_thdlocal contains the flux for the cut faces. Before
          computing hybrid divergence, comptue and add in the hydro fluxes. 
          Also, Dterm currently contains the divergence of the face-centered
-         diffusion fluxes.  Increment this with the divergence of the 
+         diffusion fluxes.  Increment this with the divergence of the
          face-centered hyperbloic fluxes.
       */
-      if (do_hydro && do_mol_AD) 
+      if (do_hydro && do_mol_AD)
       {
         flatn.resize(cbox,1);
         flatn.setVal(1.0);  // Set flattening to 1.0
 #ifdef PELEC_USE_EB
         int nFlux = sv_eb_flux.size()==0 ? 0 : sv_eb_flux[local_i].numPts();
         const EBBndryGeom* sv_ebbg_ptr = (Ncut>0 ? sv_eb_bndry_geom[local_i].data() : 0);
-        Real* sv_eb_flux_ptr = (nFlux>0 ? sv_eb_flux[local_i].dataPtr() : 0);
+        Real* sv_eb_flux_ptr = (nFlux>0 ? eb_flux_thdlocal.dataPtr() : 0);
 #endif
 
         // save off the diffusion source term and fluxes (don't want to filter these)
@@ -514,7 +518,18 @@ PeleC::getMOLSrcTerm(const amrex::MultiFab& S,
       }
 #endif
 
-
+      std::vector<int> eb_tile_mask;
+      eb_tile_mask.resize(Ncut);
+      for (int icut = 0; icut < Ncut; ++icut){
+          if (gbox.contains(sv_eb_bndry_geom[local_i][icut].iv)) {
+              eb_tile_mask[icut] = 1;
+          } else {
+              eb_tile_mask[icut] = 0;
+          }
+      }
+      if (typ == FabType::singlevalued) {
+          sv_eb_flux[local_i].merge(eb_flux_thdlocal,0, nCompTr, eb_tile_mask);
+      }
 
 #ifdef PELEC_USE_EB
       if (typ == FabType::singlevalued) {

--- a/Source/PeleC_MOL.cpp
+++ b/Source/PeleC_MOL.cpp
@@ -522,6 +522,7 @@ PeleC::getMOLSrcTerm(const amrex::MultiFab& S,
       }
 #endif
 
+#ifdef PELEC_USE_EB
       std::vector<int> eb_tile_mask;
       eb_tile_mask.resize(Ncut);
       for (int icut = 0; icut < Ncut; ++icut){
@@ -535,7 +536,6 @@ PeleC::getMOLSrcTerm(const amrex::MultiFab& S,
           sv_eb_flux[local_i].merge(eb_flux_thdlocal,0, NUM_STATE, eb_tile_mask);
       }
 
-#ifdef PELEC_USE_EB
       if (typ == FabType::singlevalued) {
         /* Interpolate fluxes from face centers to face centroids
          * Note that hybrid divergence and redistribution algorithms require that we

--- a/Source/PeleC_init_eb.cpp
+++ b/Source/PeleC_init_eb.cpp
@@ -193,6 +193,13 @@ PeleC::initialize_eb2_structs() {
       sv_eb_flux[iLocal].define(sv_eb_bndry_grad_stencil[iLocal], NUM_STATE);
       sv_eb_bcval[iLocal].define(sv_eb_bndry_grad_stencil[iLocal], QVAR);
 
+      if (eb_isothermal && (diffuse_temp != 0 || diffuse_enth != 0)) {
+          sv_eb_bcval[iLocal].setVal(eb_boundary_T, cQTEMP);
+      }
+      if (eb_noslip && diffuse_vel == 1) {
+          sv_eb_bcval[iLocal].setVal(0, cQU, BL_SPACEDIM);
+      }
+
     } else {
       amrex::Print() << "unknown (or multivalued) fab type" << std::endl;
       amrex::Abort();

--- a/Source/SparseData.H
+++ b/Source/SparseData.H
@@ -50,6 +50,7 @@
         void setVal(const T& val);
 
         void setVal(const T& val, int comp, int ncomp=1);
+        void merge(const SparseData& thdlocal, int comp, int ncomp, const std::vector<int> mask);
 
         ///
         T& operator() (int i, int comp) {return m_data[getIndex(i,comp)];}
@@ -76,6 +77,7 @@ SparseData<T,Cell>::SparseData(const std::vector<Cell>& _region,
                                int                      _nComp)
 {
     define(_region,_nComp);
+    amrex::Print() << "Init SparseData with ncomp = " << _nComp <<std::endl;
 }
 
 template <class T, class Cell> inline
@@ -118,6 +120,25 @@ SparseData<T,Cell>::setVal(const T& val, int comp, int ncomp)
       {
         m_data[getIndex(i,comp+n)] = val;
       }
+    }
+}
+
+template <class T, class Cell> inline
+void
+SparseData<T,Cell>::merge(const SparseData& thdlocal, int comp, int ncomp, const std::vector<int> mask)
+{
+    BL_ASSERT(comp+ncomp <= m_ncomp);
+
+#pragma omp critical
+    for (int n=0; n<ncomp; ++n)
+    {
+        for (int i=0; i<m_region.size(); ++i)
+        {
+            if (mask[i]) {
+
+                m_data[getIndex(i,comp+n)] = thdlocal.m_data[getIndex(i,comp+n)];
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This version gets fcompare==0 differences when running EB_Backstep case single threaded and multithreaded with tile size 4^3. Have not checked thread sanitizer (yet... @jrood-nrel if you have time that would be great, although I want to learn how to do it myself eventually!)

Changes:
- Made eb flux local to each thread
- Explicitly merge thread-safe to per fab eb flux before computed HD. Note to be thread safe, computation of eb flux in overlap between tiles in 'nextra-1' cells must be consistent (threads are allowed to overwrite the data in the per fab eb flux structure within a box of tile size grown by 2 within a critical region). I believe this is a necessary limitation, because each thread needs those fluxes to be valid in the next part of the computation and I don't want/can't sync the threads after the merge. 
- Eventually we might want to break this into two passes to reduce computation in the 'nextra' region, but there would be a tradeoff with scratch space and I don't want to do this now
- Couple of minor things to move setting ev values to init. If we eventually want a time dependent eb bc this will need to be updated.
