### PR TITLE
Fix makefiles and make them more consistent

### DIFF
--- a/Source/Make.package
+++ b/Source/Make.package
@@ -1,4 +1,5 @@
 #C++ files
+CEXE_sources += Filter.cpp
 CEXE_sources += PeleC.cpp
 CEXE_sources += PeleC_advance.cpp
 CEXE_sources += PeleCBld.cpp
@@ -28,7 +29,6 @@ FEXE_headers += Problem_F.H
 FEXE_headers += PeleC_error_F.H
 FEXE_headers += Filter_F.H
 CEXE_headers += Filter.H
-CEXE_sources += Filter.cpp
 
 #Source file logic
 ifeq ($(USE_REACT), TRUE)

--- a/Source/Make.package
+++ b/Source/Make.package
@@ -1,52 +1,51 @@
-
+#C++ files
 CEXE_sources += PeleC.cpp
 CEXE_sources += PeleC_advance.cpp
-CEXE_sources += PeleC_hydro.cpp
-CEXE_sources += PeleC_sources.cpp
-CEXE_sources += PeleC_setup.cpp
+CEXE_sources += PeleCBld.cpp
 CEXE_sources += PeleC_bcfill.cpp
+CEXE_sources += PeleC_external.cpp
+CEXE_sources += PeleC_forcing.cpp
+CEXE_sources += PeleC_hydro.cpp
 CEXE_sources += PeleC_init_eb.cpp
 CEXE_sources += PeleC_io.cpp 
-CEXE_sources += PeleCBld.cpp
+CEXE_sources += PeleC_les.cpp
+CEXE_sources += PeleC_MOL.cpp
+CEXE_sources += PeleC_sources.cpp
+CEXE_sources += PeleC_setup.cpp
+CEXE_sources += Prob.cpp
 CEXE_sources += main.cpp
+CEXE_sources += sum_integrated_quantities.cpp
+CEXE_sources += sum_utils.cpp
 
+#C++ headers
 CEXE_headers += PeleC.H
 CEXE_headers += PeleC_io.H
 CEXE_headers += Problem.H
 CEXE_headers += Problem_Derives.H
 FEXE_headers += Problem_Derive_F.H
-
-CEXE_sources += PeleC_external.cpp
-CEXE_sources += PeleC_forcing.cpp
-CEXE_sources += sum_utils.cpp
-CEXE_sources += sum_integrated_quantities.cpp
-CEXE_sources += Prob.cpp
-
 FEXE_headers += PeleC_F.H
 FEXE_headers += Problem_F.H
 FEXE_headers += PeleC_error_F.H
-ifeq ($(USE_REACT), TRUE)
-CEXE_sources += PeleC_react.cpp
-endif
-
-ifeq ($(USE_PARTICLES), TRUE)
-CEXE_sources += PeleCParticles.cpp
-endif
-
-CEXE_sources += PeleC_MOL.cpp
-
-CEXE_sources += PeleC_les.cpp
 FEXE_headers += Filter_F.H
 CEXE_headers += Filter.H
 CEXE_sources += Filter.cpp
 
+#Source file logic
+ifeq ($(USE_REACT), TRUE)
+  CEXE_sources += PeleC_react.cpp
+endif
+
+ifeq ($(USE_PARTICLES), TRUE)
+  CEXE_sources += PeleCParticles.cpp
+endif
+
 ifeq ($(USE_MASA), TRUE)
-CEXE_sources += PeleC_mms.cpp
+  CEXE_sources += PeleC_mms.cpp
 endif
 
 ifeq ($(USE_EB), TRUE)
-  CEXE_headers += EBStencilTypes.H
-  CEXE_headers += SparseData.H
   F90EXE_sources += EBStencilTypes_mod.F90
   CEXE_sources += PeleC_test_normal.cpp
+  CEXE_headers += EBStencilTypes.H
+  CEXE_headers += SparseData.H
 endif

--- a/Source/Src_1d/Make.package
+++ b/Source/Src_1d/Make.package
@@ -1,21 +1,22 @@
+#Non-preprocessed Fortran files
+f90EXE_sources += advection_util_$(DIM)d.f90 
+f90EXE_sources += filter_$(DIM)d.f90
+f90EXE_sources += impose_NSCBC_$(DIM)d.f90 
+f90EXE_sources += lesterm_$(DIM)d.f90
+f90EXE_sources += ppm_$(DIM)d.f90
+f90EXE_sources += set_bc_mask_$(DIM)d.f90 
+f90EXE_sources += slope_$(DIM)d.f90
 f90EXE_sources += trace_$(DIM)d.f90
 f90EXE_sources += trace_ppm_$(DIM)d.f90
-f90EXE_sources += slope_$(DIM)d.f90
-f90EXE_sources += ppm_$(DIM)d.f90
+
+#Preprocessed Fortran files
+F90EXE_sources += PeleC_$(DIM)d.F90 
+F90EXE_sources += PeleC_advection_$(DIM)d.F90 
+F90EXE_sources += riemann_$(DIM)d.F90 
+
+#Source file logic
 ifeq ($(TRANSPORT_TYPE), IDEAL_GAS)
   f90EXE_sources += diffterm_$(DIM)d.f90
 else
   f90EXE_sources += diffterm_nonideal_$(DIM)d.f90
 endif
-
-F90EXE_sources += PeleC_$(DIM)d.F90 
-F90EXE_sources += PeleC_advection_$(DIM)d.F90 
-
-F90EXE_sources += riemann_$(DIM)d.F90 
-f90EXE_sources += advection_util_$(DIM)d.f90 
-
-f90EXE_sources += lesterm_$(DIM)d.f90
-f90EXE_sources += filter_$(DIM)d.f90
-
-f90EXE_sources += impose_NSCBC_$(DIM)d.f90 
-f90EXE_sources += set_bc_mask_$(DIM)d.f90 

--- a/Source/Src_2d/Make.package
+++ b/Source/Src_2d/Make.package
@@ -1,34 +1,34 @@
+#Non-preprocessed Fortran files
+f90EXE_sources += advection_util_$(DIM)d.f90 
+f90EXE_sources += filter_$(DIM)d.f90
+f90EXE_sources += impose_NSCBC_$(DIM)d.f90
+f90EXE_sources += lesterm_$(DIM)d.f90
+f90EXE_sources += ppm_$(DIM)d.f90
+f90EXE_sources += set_bc_mask_$(DIM)d.f90 
+f90EXE_sources += trace_$(DIM)d.f90
+f90EXE_sources += trace_ppm_$(DIM)d.f90
+
+#Preprocessed Fortran files
+F90EXE_sources += grad_utils_$(DIM)d.F90
+F90EXE_sources += riemann_$(DIM)d.F90 
+F90EXE_sources += trans_$(DIM)d.F90
+
+#Source file logic
 ifeq ($(TRANSPORT_TYPE), IDEAL_GAS)
   f90EXE_sources += diffterm_$(DIM)d.f90
 else
   f90EXE_sources += diffterm_nonideal_$(DIM)d.f90
 endif
-F90EXE_sources += grad_utils_$(DIM)d.F90
 
 ifeq ($(HYP_TYPE), MOL)
-  #F90EXE_sources += PeleC_mol_$(DIM)d.F90
   f90EXE_sources += slope_mol_$(DIM)d_EB.f90
   F90EXE_sources += Hyp_pele_MOL_$(DIM)d.F90
 else
-  f90EXE_sources += trace_$(DIM)d.f90
-  f90EXE_sources += trace_ppm_$(DIM)d.f90
-  F90EXE_sources += trans_$(DIM)d.F90
-  f90EXE_sources += ppm_$(DIM)d.f90
   f90EXE_sources += slope_$(DIM)d.f90
   F90EXE_sources += PeleC_advection_$(DIM)d.F90
   F90EXE_sources += PeleC_$(DIM)d.F90 
 endif
 
-F90EXE_sources += riemann_$(DIM)d.F90 
-f90EXE_sources += advection_util_$(DIM)d.f90 
-
-f90EXE_sources += impose_NSCBC_$(DIM)d.f90
-f90EXE_sources += set_bc_mask_$(DIM)d.f90 
-
-f90EXE_sources += lesterm_$(DIM)d.f90
-f90EXE_sources += filter_$(DIM)d.f90
-
 ifeq ($(USE_EB), TRUE)
   F90EXE_sources += PeleC_init_eb_$(DIM)d.F90
 endif
-

--- a/Source/Src_3d/Make.package
+++ b/Source/Src_3d/Make.package
@@ -1,16 +1,26 @@
+#Non-preprocessed Fortran files
+f90EXE_sources += advection_util_$(DIM)d.f90
+f90EXE_sources += filter_$(DIM)d.f90
+f90EXE_sources += impose_NSCBC_$(DIM)d.f90
+f90EXE_sources += lesterm_$(DIM)d.f90
+f90EXE_sources += ppm_$(DIM)d.f90
+f90EXE_sources += set_bc_mask_$(DIM)d.f90 
 f90EXE_sources += trace_$(DIM)d.f90
 f90EXE_sources += trace_ppm_$(DIM)d.f90
+
+#Preprocessed Fortran files
+F90EXE_sources += grad_utils_$(DIM)d.F90
+F90EXE_sources += riemann_$(DIM)d.F90
 F90EXE_sources += trans_$(DIM)d.F90
-f90EXE_sources += ppm_$(DIM)d.f90
+
+#Source file logic
 ifeq ($(TRANSPORT_TYPE), IDEAL_GAS)
   f90EXE_sources += diffterm_$(DIM)d.f90
 else
   f90EXE_sources += diffterm_nonideal_$(DIM)d.f90
 endif
-F90EXE_sources += grad_utils_$(DIM)d.F90
 
 ifeq ($(HYP_TYPE), MOL)
-  #F90EXE_sources += PeleC_mol_$(DIM)d.F90
   f90EXE_sources += slope_mol_$(DIM)d_EB.f90
   F90EXE_sources += Hyp_pele_MOL_$(DIM)d.F90
 else
@@ -18,14 +28,6 @@ else
   F90EXE_sources += PeleC_advection_$(DIM)d.F90
   F90EXE_sources += PeleC_$(DIM)d.F90
 endif
-
-F90EXE_sources += riemann_$(DIM)d.F90
-f90EXE_sources += advection_util_$(DIM)d.f90
-f90EXE_sources += impose_NSCBC_$(DIM)d.f90
-f90EXE_sources += set_bc_mask_$(DIM)d.f90 
-
-f90EXE_sources += lesterm_$(DIM)d.f90
-f90EXE_sources += filter_$(DIM)d.f90
 
 ifeq ($(USE_EB), TRUE)
   F90EXE_sources += PeleC_init_eb_$(DIM)d.F90

--- a/Source/Src_nd/Make.package
+++ b/Source/Src_nd/Make.package
@@ -1,45 +1,42 @@
-F90EXE_sources += PeleC_nd.F90
+#Non-preprocessed Fortran files
 f90EXE_sources += amrinfo.f90
-F90EXE_sources += PeleC_util.F90
-F90EXE_sources += advection_util_nd.F90
-f90EXE_sources += Tagging_nd.f90
+f90EXE_sources += Diffusion_nd.f90
+f90EXE_sources += ext_src_nd.f90
+f90EXE_sources += io.f90
+f90EXE_sources += interpolate.f90
+f90EXE_sources += math.f90
+f90EXE_sources += parmparse_mod.f90
 f90EXE_sources += Problem.f90
-F90EXE_sources += meth_params.F90
 f90EXE_sources += prob_params.f90
 f90EXE_sources += rk_params.f90
-
-f90EXE_sources += interpolate.f90
-
-f90EXE_sources += sums_nd.f90
-F90EXE_sources += timestep.F90
-F90EXE_sources += Derive_nd.F90
-F90EXE_sources += problem_derive_nd.F90
 f90EXE_sources += riemann_util.f90
-
-F90EXE_sources += flatten_nd.F90
-
-f90EXE_sources += math.f90
-
-f90EXE_sources += io.f90
-
-#ifeq ($(USE_REACT), TRUE)
-F90EXE_sources += React_nd.F90
-#endif
-F90EXE_sources += bc_fill_nd.F90
-F90EXE_sources += filcc_nd.F90
-f90EXE_sources += ext_src_nd.f90
-F90EXE_sources += forcing_src_nd.F90
-F90EXE_sources += Prob_nd.F90
-F90EXE_sources += problem_tagging_nd.F90
-
-f90EXE_sources += Diffusion_nd.f90
-
-f90EXE_sources += parmparse_mod.f90
+f90EXE_sources += sums_nd.f90
 f90EXE_sources += string_mod.f90
-CEXE_sources   += parmparse_fi.cpp
-
+f90EXE_sources += Tagging_nd.f90
 f90EXE_sources += weno.f90
 
-#ifeq ($(USE_MASA), TRUE)
-F90EXE_sources += mms_src_nd.F90
-#endif
+#Preprocessed Fortran files
+F90EXE_sources += advection_util_nd.F90
+F90EXE_sources += bc_fill_nd.F90
+F90EXE_sources += Derive_nd.F90
+F90EXE_sources += flatten_nd.F90
+F90EXE_sources += filcc_nd.F90
+F90EXE_sources += forcing_src_nd.F90
+F90EXE_sources += meth_params.F90
+F90EXE_sources += PeleC_util.F90
+F90EXE_sources += PeleC_nd.F90
+F90EXE_sources += problem_derive_nd.F90
+F90EXE_sources += Prob_nd.F90
+F90EXE_sources += problem_tagging_nd.F90
+F90EXE_sources += timestep.F90
+
+#C++ files
+CEXE_sources += parmparse_fi.cpp
+
+#Source file logic
+ifeq ($(USE_MASA), TRUE)
+  F90EXE_sources += mms_src_nd.F90
+endif
+ifeq ($(USE_REACT), TRUE)
+  F90EXE_sources += React_nd.F90
+endif

--- a/Source/TurbInflow/Make.package
+++ b/Source/TurbInflow/Make.package
@@ -1,4 +1,5 @@
-CEXE_sources += turbinflow.cpp
-
+#Non-preprocessed Fortran files
 f90EXE_sources += turbinflow_f.f90
 
+#C++ files
+CEXE_sources += turbinflow.cpp


### PR DESCRIPTION
Changes were made in PelePhysics to the `react` call. It turns out the GNU makefiles were always compiling `React_nd.F90` even when `USE_REACT=FALSE`. This caused compilation errors since cases with `Null` and `Null_air` were not updated in PelePhysics. Those `react` routines will be updated in PelePhysics, but this fixes the makefiles so that when `USE_REACT=FALSE`, the call to `react` will not be compiled.

This also tries to make the makefiles between `Src` folders more consistent with one another.