### PR TITLE
Add error output for unsupported PeleC configurations in GNU makefiles.

### DIFF
--- a/CMake/build_pelec.cmake
+++ b/CMake/build_pelec.cmake
@@ -44,6 +44,10 @@ function(build_pelec pelec_exe_name pelec_exe_options_file)
     message(FATAL_ERROR "PELEC_ENABLE_MOL does not work with PELEC_DIM=1")
   endif()
 
+  if(${PELEC_DIM} EQUAL 2 AND PELEC_ENABLE_MOL)
+    message(FATAL_ERROR "PELEC_ENABLE_MOL does not work with PELEC_DIM=2")
+  endif()
+
   if(${PELEC_DIM} EQUAL 1 AND PELEC_ENABLE_EB)
     message(FATAL_ERROR "PELEC_ENABLE_EB does not work with PELEC_DIM=1")
   endif()

--- a/Exec/Make.PeleC
+++ b/Exec/Make.PeleC
@@ -14,7 +14,6 @@ EBASE = PeleC
 # this list will be searched for runtime parameters
 EXTERN_CORE ?=
 
-#USE_EB = TRUE
 ifeq ($(DIM), 1)
   USE_EB = FALSE
 endif
@@ -43,6 +42,12 @@ all: $(executable)
 # Hyperbolic integrator
 ifeq ($(HYP_TYPE), MOL)
     DEFINES+=-DPELEC_USE_MOL
+    ifneq ($(DIM), 3)
+        $(error MOL integrator currently requires DIM=3)
+    endif
+    ifeq ($(USE_EB), FALSE)
+        $(error MOL integrator currently requires USE_EB=TRUE)
+    endif
 endif
 
 # EOS


### PR DESCRIPTION
This addresses #123 by listing unsupported configurations at least temporarily. Currently `HYP_TYPE=MOL` does not support `USE_EB=FALSE`, although we can make this work if we clean up `slope_mol_$(DIM)d.f90` to actually compile or use `plm_iorder=1` and add some `USE_EB` ifdefs to `slople_mol_$(DIM)d_EB.f90` like I do in the GPU branch. Also `trace_$(DIM)d.f90` and `slope_$(DIM)d.f90` need to be cleaned up between 2d and 3d (and probably 1d) so that they are consistent, because currently `trace_$(DIM)d.f90` uses slope functions in different ways where 3d works, and 2d does not.