### PR TITLE
Fix issues with specific configurations

### DIFF
--- a/CMake/build_pelec.cmake
+++ b/CMake/build_pelec.cmake
@@ -44,10 +44,6 @@ function(build_pelec pelec_exe_name pelec_exe_options_file)
     message(FATAL_ERROR "PELEC_ENABLE_MOL does not work with PELEC_DIM=1")
   endif()
 
-  if(${PELEC_DIM} EQUAL 2 AND PELEC_ENABLE_MOL)
-    message(FATAL_ERROR "PELEC_ENABLE_MOL does not work with PELEC_DIM=2")
-  endif()
-
   if(${PELEC_DIM} EQUAL 1 AND PELEC_ENABLE_EB)
     message(FATAL_ERROR "PELEC_ENABLE_EB does not work with PELEC_DIM=1")
   endif()

--- a/CMake/build_pelec.cmake
+++ b/CMake/build_pelec.cmake
@@ -44,6 +44,10 @@ function(build_pelec pelec_exe_name pelec_exe_options_file)
     message(FATAL_ERROR "PELEC_ENABLE_MOL does not work with PELEC_DIM=1")
   endif()
 
+  if(${PELEC_DIM} EQUAL 2 AND PELEC_ENABLE_MOL)
+    message(FATAL_ERROR "PELEC_ENABLE_MOL does not work with PELEC_DIM=2")
+  endif()
+
   if(${PELEC_DIM} EQUAL 1 AND PELEC_ENABLE_EB)
     message(FATAL_ERROR "PELEC_ENABLE_EB does not work with PELEC_DIM=1")
   endif()

--- a/Exec/Make.PeleC
+++ b/Exec/Make.PeleC
@@ -14,7 +14,6 @@ EBASE = PeleC
 # this list will be searched for runtime parameters
 EXTERN_CORE ?=
 
-#USE_EB = TRUE
 ifeq ($(DIM), 1)
   USE_EB = FALSE
 endif
@@ -43,6 +42,12 @@ all: $(executable)
 # Hyperbolic integrator
 ifeq ($(HYP_TYPE), MOL)
     DEFINES+=-DPELEC_USE_MOL
+    ifneq ($(DIM), 3)
+        $(error MOL integrator currently requires DIM=3)
+    endif
+    ifeq ($(USE_EB), FALSE)
+        $(error MOL integrator currently requires USE_EB=TRUE)
+    endif
 endif
 
 # EOS

--- a/Exec/Make.PeleC
+++ b/Exec/Make.PeleC
@@ -42,9 +42,6 @@ all: $(executable)
 # Hyperbolic integrator
 ifeq ($(HYP_TYPE), MOL)
     DEFINES+=-DPELEC_USE_MOL
-    ifneq ($(DIM), 3)
-        $(error MOL integrator currently requires DIM=3)
-    endif
     ifeq ($(USE_EB), FALSE)
         $(error MOL integrator currently requires USE_EB=TRUE)
     endif

--- a/Source/Src_2d/Make.package
+++ b/Source/Src_2d/Make.package
@@ -3,10 +3,7 @@ f90EXE_sources += advection_util_$(DIM)d.f90
 f90EXE_sources += filter_$(DIM)d.f90
 f90EXE_sources += impose_NSCBC_$(DIM)d.f90
 f90EXE_sources += lesterm_$(DIM)d.f90
-f90EXE_sources += ppm_$(DIM)d.f90
 f90EXE_sources += set_bc_mask_$(DIM)d.f90 
-f90EXE_sources += trace_$(DIM)d.f90
-f90EXE_sources += trace_ppm_$(DIM)d.f90
 
 #Preprocessed Fortran files
 F90EXE_sources += grad_utils_$(DIM)d.F90
@@ -27,6 +24,9 @@ else
   f90EXE_sources += slope_$(DIM)d.f90
   F90EXE_sources += PeleC_advection_$(DIM)d.F90
   F90EXE_sources += PeleC_$(DIM)d.F90 
+  f90EXE_sources += ppm_$(DIM)d.f90
+  f90EXE_sources += trace_$(DIM)d.f90
+  f90EXE_sources += trace_ppm_$(DIM)d.f90
 endif
 
 ifeq ($(USE_EB), TRUE)

--- a/Source/Src_3d/Make.package
+++ b/Source/Src_3d/Make.package
@@ -3,10 +3,7 @@ f90EXE_sources += advection_util_$(DIM)d.f90
 f90EXE_sources += filter_$(DIM)d.f90
 f90EXE_sources += impose_NSCBC_$(DIM)d.f90
 f90EXE_sources += lesterm_$(DIM)d.f90
-f90EXE_sources += ppm_$(DIM)d.f90
 f90EXE_sources += set_bc_mask_$(DIM)d.f90 
-f90EXE_sources += trace_$(DIM)d.f90
-f90EXE_sources += trace_ppm_$(DIM)d.f90
 
 #Preprocessed Fortran files
 F90EXE_sources += grad_utils_$(DIM)d.F90
@@ -27,6 +24,9 @@ else
   f90EXE_sources += slope_$(DIM)d.f90
   F90EXE_sources += PeleC_advection_$(DIM)d.F90
   F90EXE_sources += PeleC_$(DIM)d.F90
+  f90EXE_sources += ppm_$(DIM)d.f90
+  f90EXE_sources += trace_$(DIM)d.f90
+  f90EXE_sources += trace_ppm_$(DIM)d.f90
 endif
 
 ifeq ($(USE_EB), TRUE)


### PR DESCRIPTION
I must have made a mistake when reorganizing the makefiles and this reenables building with DIM=2 with EB. It also explicitly states that MOL without EB is currently unsupported, although we could support it with a little bit of work like I have done in the GPU branch.