### PR TITLE
Use absolute value for velocity component for tagging

### DIFF
--- a/Source/Src_nd/Tagging_nd.f90
+++ b/Source/Src_nd/Tagging_nd.f90
@@ -316,7 +316,7 @@ contains
        do k = lo(3), hi(3)
           do j = lo(2), hi(2)
              do i = lo(1), hi(1)
-                if (vel(i,j,k,1) .ge. velerr) then
+                if (ABS(vel(i,j,k,1)) .ge. velerr) then
                    tag(i,j,k) = set
                 endif
              enddo


### PR DESCRIPTION
Found and fixed by @hsitaram . Just resubmitting the PR with only this change.