### PR TITLE
Branch to comply with PP Anne/cpp

### DIFF
--- a/Exec/Make.PeleC
+++ b/Exec/Make.PeleC
@@ -49,12 +49,16 @@ ifeq ($(HYP_TYPE), MOL)
 endif
 
 # EOS
+# Both Fortran and cpp can be loaded for EOS
+EOS_HOME_F90 := $(EOS_HOME)/F90
 EOS_PATH := $(EOS_HOME)/$(strip $(Eos_dir))
-include $(EOS_HOME)/Make.package
+EOS_PATH_F90 := $(EOS_PATH)/F90
+include $(EOS_HOME_F90)/Make.package
 include $(EOS_PATH)/Make.package
-EXTERN_CORE       += $(EOS_HOME) $(EOS_PATH)
-INCLUDE_LOCATIONS += $(EOS_HOME) $(EOS_PATH)
-VPATH_LOCATIONS   += $(EOS_HOME) $(EOS_PATH)
+include $(EOS_PATH_F90)/Make.package
+EXTERN_CORE       += $(EOS_HOME_F90) $(EOS_PATH_F90)
+INCLUDE_LOCATIONS += $(EOS_HOME) $(EOS_HOME_F90) $(EOS_PATH) $(EOS_PATH_F90)
+VPATH_LOCATIONS   += $(EOS_HOME) $(EOS_HOME_F90) $(EOS_PATH) $(EOS_PATH_F90)
 ifeq ($(Eos_dir), Fuego)
   TRANSPORT_TYPE := IDEAL_GAS
 else
@@ -69,13 +73,19 @@ endif
 ifeq ($(USE_SUNDIALS_PP),TRUE) 
   include $(PELE_PHYSICS_HOME)/ThirdParty/Make.ThirdParty
 endif
+REACTIONS_HOME_F90 := $(REACTIONS_HOME)/F90
 REACTIONS_PATH := $(REACTIONS_HOME)/$(strip $(Reactions_dir))
-include $(REACTIONS_HOME)/Make.package
+REACTIONS_PATH_F90 := $(REACTIONS_PATH)/F90
 include $(REACTIONS_PATH)/Make.package
-EXTERN_CORE       += $(REACTIONS_HOME) $(REACTIONS_PATH)
-INCLUDE_LOCATIONS += $(REACTIONS_HOME) $(REACTIONS_PATH)
-VPATH_LOCATIONS   += $(REACTIONS_HOME) $(REACTIONS_PATH)
-ifdef Chemistry_Model
+EXTERN_CORE       += $(REACTIONS_HOME_F90) $(REACTIONS_PATH_F90)
+INCLUDE_LOCATIONS += $(REACTIONS_HOME) $(REACTIONS_HOME_F90) $(REACTIONS_PATH) $(REACTIONS_PATH_F90)
+VPATH_LOCATIONS   += $(REACTIONS_HOME) $(REACTIONS_HOME_F90) $(REACTIONS_PATH) $(REACTIONS_PATH_F90)
+#ifdef Chemistry_Model
+  ifeq ($(Eos_dir), GammaLaw)
+    ifneq ($(Chemistry_Model), Null)
+      $(error Chemistry_Model definition not compatible with Eos_Dir=GammaLaw)
+    endif
+  endif
   CHEM_HOME = $(PELE_PHYSICS_HOME)/Support/Fuego/Mechanism/Models/$(Chemistry_Model)
   CHEM_ALL  = $(PELE_PHYSICS_HOME)/Support/Fuego/Mechanism/Models
   VPATH_LOCATIONS += $(CHEM_HOME) $(CHEM_ALL)
@@ -83,22 +93,23 @@ ifdef Chemistry_Model
            $(CHEM_ALL)/Make.package
   Blocs += $(CHEM_HOME) $(CHEM_ALL)
 
-  CHEM_HOME1 = $(PELE_PHYSICS_HOME)/Support/Fuego/Mechanism
-  VPATH_LOCATIONS += $(CHEM_HOME1)
-  Bpack += $(CHEM_HOME1)/Make.package
-  Blocs += $(CHEM_HOME1)
-
   Bpack += $(PELE_PHYSICS_HOME)/Support/Fuego/Evaluation/Make.package
-  Blocs += $(PELE_PHYSICS_HOME)/Support/Fuego/Evaluation
-endif
+  Blocs += $(PELE_PHYSICS_HOME)/Support/Fuego/Mechanism \
+           $(PELE_PHYSICS_HOME)/Support/Fuego/Evaluation
+#endif
 
 # Transport
+TRAN_HOME_F90 := $(TRAN_HOME)/F90
 TRAN_PATH := $(TRAN_HOME)/$(strip $(Transport_dir))
-include $(TRAN_HOME)/Make.package
-include $(TRAN_PATH)/Make.package
-EXTERN_CORE       += $(TRAN_HOME) $(TRAN_PATH)
-INCLUDE_LOCATIONS += $(TRAN_HOME) $(TRAN_PATH)
-VPATH_LOCATIONS   += $(TRAN_HOME) $(TRAN_PATH)
+TRAN_PATH_F90 := $(TRAN_PATH)/F90
+# Put inside an if use FORTRAN later
+include $(TRAN_HOME_F90)/Make.package
+include $(TRAN_PATH_F90)/Make.package
+# CPP TRANSPORT NOT USED RIGHT NOW
+#include $(TRAN_PATH)/Make.package
+EXTERN_CORE       += $(TRAN_HOME_F90) $(TRAN_PATH_F90)
+INCLUDE_LOCATIONS += $(TRAN_HOME_F90) $(TRAN_PATH_F90)
+VPATH_LOCATIONS   += $(TRAN_HOME_F90) $(TRAN_PATH_F90)
 USE_FUEGO = FALSE
 ifeq ($(Transport_dir), EGLib)
   USE_FUEGO = TRUE

--- a/Exec/RegTests/PMF/Prob_nd.F90
+++ b/Exec/RegTests/PMF/Prob_nd.F90
@@ -91,7 +91,7 @@ contains
     use meth_params_module, only : URHO, UMX, UMY, UMZ, UEINT, UEDEN, UTEMP, UFS
     use prob_params_module, only : problo, dim
     use eos_module
-    use network, only: nspecies
+    use fuego_chemistry, only: nspecies
     use amrex_constants_module, only: M_PI, HALF
 
     implicit none

--- a/Exec/RegTests/PMF/bc_fill_nd.F90
+++ b/Exec/RegTests/PMF/bc_fill_nd.F90
@@ -133,7 +133,7 @@ contains
     use eos_type_module
     use eos_module
     use meth_params_module, only : URHO, UMX, UMY, UMZ, UTEMP, UEDEN, UEINT, UFS, NVAR
-    use network, only: nspecies, naux
+    use fuego_chemistry, only: nspecies, naux
     use prob_params_module, only : Interior, Inflow, Outflow, SlipWall, NoSlipWall, &
                                    problo, probhi, dim
         

--- a/Exec/RegTests/PMF/pmf_generic.f90
+++ b/Exec/RegTests/PMF/pmf_generic.f90
@@ -287,7 +287,7 @@ end module pmf_module
 
 subroutine initialize_pmf(filename)
   use pmf_module
-  use chemistry_module, only : nspecies, get_species_index
+  use fuego_chemistry, only : nspecies, get_species_index
   character (len=*) :: filename
   integer :: n
   pmf_filename = filename

--- a/Exec/RegTests/PMF/probdata.f90
+++ b/Exec/RegTests/PMF/probdata.f90
@@ -33,7 +33,7 @@ contains
   subroutine init_bc
 
     use meth_params_module, only : NVAR, URHO, UMX, UMY, UMZ, UEINT, UEDEN, UTEMP, UFS
-    use chemistry_module, only : nspecies, get_species_index
+    use fuego_chemistry, only : nspecies, get_species_index
     use eos_type_module
 
     implicit none

--- a/Exec/RegTests/TG/GNUmakefile
+++ b/Exec/RegTests/TG/GNUmakefile
@@ -15,10 +15,12 @@ USE_OMP    = FALSE
 Eos_dir     := GammaLaw
 
 # This sets the network directory in $(PELE_PHYSICS_HOME)/Reactions
-Reactions_dir := Null
+Reactions_dir := Fuego
 
 # This sets the transport directory in $(PELE_PHYSICS_HOME)/Transport
 Transport_dir := Constant
+
+Chemistry_Model := Null
 
 Bpack   := ./Make.package
 

--- a/Exec/RegTests/TG/Prob_nd.F90
+++ b/Exec/RegTests/TG/Prob_nd.F90
@@ -84,7 +84,7 @@ contains
 
     use amrex_paralleldescriptor_module, only: amrex_pd_ioprocessor
     use probdata_module
-    use network, only: nspecies, naux, molec_wt
+    use fuego_chemistry, only: nspecies, naux, molecular_weight
     use eos_type_module
     use meth_params_module, only : URHO, UMX, UMY, UMZ, &
          UEDEN, UEINT, UFS, UTEMP, small_temp
@@ -112,7 +112,7 @@ contains
     call build(eos_state)
 
     ! Define the molecular weight for air
-    molec_wt = 28.97
+    molecular_weight = 28.97
 
     ! Define the length scale
     L = 1.d0/M_PI

--- a/Exec/RegTests/TG/probin
+++ b/Exec/RegTests/TG/probin
@@ -22,4 +22,5 @@
 
 &extern
   eos_gamma = 1.4
+  mwt_scalar = 28.97
 /

--- a/Source/PeleC_MOL.cpp
+++ b/Source/PeleC_MOL.cpp
@@ -233,9 +233,9 @@ PeleC::getMOLSrcTerm(const amrex::MultiFab& S,
       
       // Compute transport coefficients, coincident with Q
       {
-        BL_PROFILE("PeleC::get_transport_coeffs call");
+        BL_PROFILE("PeleC::get_transport_coeffs_F call");
         coeff_cc.resize(gbox, nCompTr);
-        get_transport_coeffs(ARLIM_3D(gbox.loVect()),
+        get_transport_coeffs_F(ARLIM_3D(gbox.loVect()),
                              ARLIM_3D(gbox.hiVect()),
                              BL_TO_FORTRAN_N_3D(Qfab, cQFS),
                              BL_TO_FORTRAN_N_3D(Qfab, cQTEMP),

--- a/Source/Src_1d/advection_util_1d.f90
+++ b/Source/Src_1d/advection_util_1d.f90
@@ -10,7 +10,7 @@ contains
 
   subroutine normalize_species_fluxes(flux,flux_l1,flux_h1,lo,hi)
 
-    use network, only : nspecies
+    use fuego_chemistry, only : nspecies
     use meth_params_module, only : NVAR, URHO, UFS
     use amrex_constants_module
 
@@ -47,7 +47,7 @@ contains
 
   subroutine normalize_new_species(u,u_l1,u_h1,lo,hi)
 
-    use network, only : nspecies
+    use fuego_chemistry, only : nspecies
     use meth_params_module, only : NVAR, URHO, UFS
     use amrex_constants_module    
 

--- a/Source/Src_1d/diffterm_1d.f90
+++ b/Source/Src_1d/diffterm_1d.f90
@@ -24,7 +24,7 @@ contains
                          D,   Dlo,   Dhi,&
                          deltax) bind(C, name = "pc_diffterm")
 
-    use network, only : nspecies
+    use fuego_chemistry, only : nspecies
     use meth_params_module, only : NVAR, UMX, UMY, UMZ, UEDEN, UFS, QVAR, QU, QV, QPRES, QTEMP, QFS, QRHO
     use amrex_constants_module
     use eos_type_module

--- a/Source/Src_1d/diffterm_nonideal_1d.f90
+++ b/Source/Src_1d/diffterm_nonideal_1d.f90
@@ -24,7 +24,7 @@ contains
                          D,   Dlo,   Dhi,&
                          deltax) bind(C, name = "pc_diffterm")
 
-    use network, only : nspecies
+    use fuego_chemistry, only : nspecies
     use meth_params_module, only : NVAR, UMX, UEDEN, UFS, QVAR, QU, QPRES, QTEMP, QFS, QRHO
     use amrex_constants_module
     use eos_type_module

--- a/Source/Src_1d/impose_NSCBC_1d.f90
+++ b/Source/Src_1d/impose_NSCBC_1d.f90
@@ -18,7 +18,7 @@ contains
                           flag_nscbc_isAnyPerio, flag_nscbc_perio, &
                           time,delta,dt) bind(C, name="impose_NSCBC")
     
-  use network, only : nspecies
+  use fuego_chemistry, only : nspecies
   use eos_module
   use fundamental_constants_module, only: k_B, n_A
   use amrex_fort_module

--- a/Source/Src_1d/lesterm_1d.f90
+++ b/Source/Src_1d/lesterm_1d.f90
@@ -26,7 +26,7 @@ contains
                          L,   Llo,   Lhi,&
                          deltax) bind(C, name = "pc_smagorinsky_sfs_term")
 
-    use network, only : nspecies
+    use fuego_chemistry, only : nspecies
     use meth_params_module, only : NVAR, UMX, UEDEN, QVAR, QRHO, QU, QW, QTEMP, QFS, Cs, CI, PrT
     use amrex_constants_module
     use eos_type_module
@@ -116,7 +116,7 @@ contains
                                              L,   Llo,   Lhi,&
                                              deltax) bind(C, name = "pc_dynamic_smagorinsky_sfs_term")
 
-    use network, only : nspecies
+    use fuego_chemistry, only : nspecies
     use meth_params_module, only : NVAR, UMX, UEDEN, QVAR, QRHO, QU, QTEMP, QFS
     use amrex_constants_module
     use eos_type_module

--- a/Source/Src_1d/riemann_1d.F90
+++ b/Source/Src_1d/riemann_1d.F90
@@ -108,7 +108,7 @@ contains
     ! this implements the approximate Riemann solver of Colella & Glaz (1985)
 
     use amrex_fort_module
-    use network, only : nspecies, naux
+    use fuego_chemistry, only : nspecies, naux
     use eos_type_module
     use eos_module
     use riemann_util_module

--- a/Source/Src_2d/Hyp_pele_MOL_2d.F90
+++ b/Source/Src_2d/Hyp_pele_MOL_2d.F90
@@ -51,7 +51,7 @@ module hyp_advection_module
                                    riemann_solver
 
     use slope_module, only : slopex, slopey
-    use network, only : nspecies, naux
+    use fuego_chemistry, only : nspecies, naux
     use eos_type_module
     use eos_module, only : eos_t, eos_rp
     use riemann_module, only: cmpflx, shock

--- a/Source/Src_2d/advection_util_2d.f90
+++ b/Source/Src_2d/advection_util_2d.f90
@@ -13,7 +13,7 @@ contains
                     flux2,flux2_l1,flux2_l2,flux2_h1,flux2_h2, &
                     lo,hi)
 
-    use network, only : nspecies
+    use fuego_chemistry, only : nspecies
     use meth_params_module, only : NVAR, URHO, UFS
     use amrex_constants_module
     
@@ -70,7 +70,7 @@ contains
 
   subroutine normalize_new_species(u,u_l1,u_l2,u_h1,u_h2,lo,hi)
 
-    use network, only : nspecies
+    use fuego_chemistry, only : nspecies
     use meth_params_module, only : NVAR, URHO, UFS
     use amrex_constants_module
     

--- a/Source/Src_2d/diffterm_2d.f90
+++ b/Source/Src_2d/diffterm_2d.f90
@@ -32,7 +32,7 @@ contains
                          D,   Dlo,   Dhi,&
                          deltax) bind(C, name = "pc_diffterm")
 
-    use network, only : nspecies
+    use fuego_chemistry, only : nspecies
     use meth_params_module, only : NVAR, UMX, UMY, UMZ, UEDEN, UFS, QVAR, QU, QV, QPRES, QTEMP, QFS, QRHO
     use amrex_constants_module
     use eos_type_module

--- a/Source/Src_2d/diffterm_nonideal_2d.f90
+++ b/Source/Src_2d/diffterm_nonideal_2d.f90
@@ -32,7 +32,7 @@ contains
                          D,   Dlo,   Dhi,&
                          deltax) bind(C, name = "pc_diffterm")
 
-    use network, only : nspecies
+    use fuego_chemistry, only : nspecies
     use meth_params_module, only : NVAR, UMX, UMY, UEDEN, UFS, QVAR, QU, QV, QPRES, QTEMP, QFS, QRHO
     use amrex_constants_module
     use eos_type_module

--- a/Source/Src_2d/impose_NSCBC_2d.f90
+++ b/Source/Src_2d/impose_NSCBC_2d.f90
@@ -632,7 +632,7 @@ end subroutine impose_NSCBC
                                 qaux, qa_l1, qa_l2, qa_h1, qa_h2)
                                
   use eos_module
-  use network, only : nspecies
+  use fuego_chemistry, only : nspecies
   use amrex_constants_module, only : ONE
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UMZ, UEDEN, UEINT, UTEMP,&
                                  UFS, NQAUX, QC, QGAMC, QRSPEC, &

--- a/Source/Src_2d/lesterm_2d.f90
+++ b/Source/Src_2d/lesterm_2d.f90
@@ -31,7 +31,7 @@ contains
                                      L,   Llo,   Lhi,&
                                      deltax) bind(C, name = "pc_smagorinsky_sfs_term")
 
-    use network, only : nspecies
+    use fuego_chemistry, only : nspecies
     use meth_params_module, only : NVAR, UMX, UMY, UEDEN, QVAR, QRHO, QU, QV, QTEMP, QFS, Cs, CI, PrT
     use amrex_constants_module
     use eos_type_module
@@ -178,7 +178,7 @@ contains
                                              L,   Llo,   Lhi,&
                                              deltax) bind(C, name = "pc_dynamic_smagorinsky_sfs_term")
 
-    use network, only : nspecies
+    use fuego_chemistry, only : nspecies
     use meth_params_module, only : NVAR, UMX, UMY, UEDEN, QVAR, QRHO, QU, QV, QTEMP, QFS
     use amrex_constants_module
     use eos_type_module

--- a/Source/Src_2d/riemann_2d.F90
+++ b/Source/Src_2d/riemann_2d.F90
@@ -378,7 +378,7 @@ contains
     ! this implements the approximate Riemann solver of Colella & Glaz (1985)
 
     use amrex_fort_module
-    use network, only : nspecies, naux
+    use fuego_chemistry, only : nspecies, naux
     use eos_type_module
     use eos_module
     use prob_params_module, only : coord_type
@@ -1185,7 +1185,7 @@ contains
                        idir, ilo1, ihi1, ilo2, ihi2, domlo, domhi)
 
     use prob_params_module, only : coord_type
-    use network, only : nspecies
+    use fuego_chemistry, only : nspecies
 
     use eos_module
 

--- a/Source/Src_2d/slope_mol_2d_EB.f90
+++ b/Source/Src_2d/slope_mol_2d_EB.f90
@@ -25,7 +25,7 @@ contains
       use amrex_mempool_module, only : bl_allocate, bl_deallocate
       use meth_params_module
       use amrex_constants_module
-      use network, only : nspecies
+      use fuego_chemistry, only : nspecies
 
       implicit none
 
@@ -134,7 +134,7 @@ contains
       use amrex_mempool_module, only : bl_allocate, bl_deallocate
       use meth_params_module
       use amrex_constants_module
-      use network, only : nspecies
+      use fuego_chemistry, only : nspecies
 
       implicit none
 

--- a/Source/Src_2d/trace_ppm_2d.f90
+++ b/Source/Src_2d/trace_ppm_2d.f90
@@ -18,7 +18,7 @@ contains
                        gamc,gc_l1,gc_l2,gc_h1,gc_h2, &
                        ilo1,ilo2,ihi1,ihi2,dx,dy,dt)
 
-    use network, only : nspecies
+    use fuego_chemistry, only : nspecies
     use eos_type_module
     use eos_module
     use amrex_constants_module

--- a/Source/Src_2d/trans_2d.F90
+++ b/Source/Src_2d/trans_2d.F90
@@ -1,7 +1,7 @@
 module transverse_module
 
   use amrex_constants_module
-  use network, only : nspecies
+  use fuego_chemistry, only : nspecies
   use meth_params_module, only : NQ, QVAR, NVAR, QRHO, QU, QV, QW, QPRES, QREINT, QGAME, &
                                  URHO, UMX, UMY, UEDEN, UEINT, QFS, QFX, &
                                  GDU, GDV, GDPRES, GDGAME, &

--- a/Source/Src_3d/Hyp_pele_MOL_3d.F90
+++ b/Source/Src_3d/Hyp_pele_MOL_3d.F90
@@ -57,7 +57,7 @@ module hyp_advection_module
                                    URHO, UMX, UMY, UMZ, UEDEN, UEINT, UFS, UTEMP, UFX, UFA, &
                                    eb_small_vfrac
     use slope_module, only : slopex, slopey, slopez
-    use network, only : nspecies, naux
+    use fuego_chemistry, only : nspecies, naux
     use eos_type_module
     use eos_module, only : eos_t, eos_rp
     use riemann_module, only: cmpflx, shock

--- a/Source/Src_3d/PeleC_advection_3d.F90
+++ b/Source/Src_3d/PeleC_advection_3d.F90
@@ -58,7 +58,7 @@ contains
                                   transxy, transxz, transyz
     use ppm_module, only : ppm
     use slope_module, only : uslope, pslope
-    use network, only : nspecies, naux
+    use fuego_chemistry, only : nspecies, naux
     use eos_type_module
     use eos_module, only : eos_t, eos_rt
     use riemann_module, only: cmpflx, shock
@@ -741,7 +741,7 @@ contains
                     eden_lost,xang_lost,yang_lost,zang_lost, &
                     verbose)
 
-    use network, only : nspecies, naux
+    use fuego_chemistry, only : nspecies, naux
     use meth_params_module, only : difmag, NVAR, URHO, UMX, UMY, UMZ, &
                                    UEDEN, UEINT, UTEMP, NGDNV, QVAR, track_grid_losses, limit_fluxes_on_small_dens
     use amrex_constants_module, only : ZERO, FOURTH, ONE

--- a/Source/Src_3d/advection_util_3d.f90
+++ b/Source/Src_3d/advection_util_3d.f90
@@ -17,7 +17,7 @@ contains
     ! they sum to 0.  This is essentially the CMA procedure that is
     ! defined in Plewa & Muller, 1999, A&A, 342, 179
 
-    use network, only : nspecies
+    use fuego_chemistry, only : nspecies
     use meth_params_module, only : NVAR, URHO, UFS
     use amrex_constants_module
 

--- a/Source/Src_3d/diffterm_3d.f90
+++ b/Source/Src_3d/diffterm_3d.f90
@@ -39,7 +39,7 @@ contains
                          D,   Dlo,   Dhi,&
                          deltax) bind(C, name = "pc_diffterm")
 
-    use network, only : nspecies
+    use fuego_chemistry, only : nspecies
     use meth_params_module, only : NVAR, UMX, UMY, UMZ, UEDEN, UFS, QVAR, QU, QV, QW, QPRES, QTEMP, QFS, QRHO
     use amrex_constants_module
     use eos_type_module

--- a/Source/Src_3d/diffterm_nonideal_3d.f90
+++ b/Source/Src_3d/diffterm_nonideal_3d.f90
@@ -39,7 +39,7 @@ contains
                          D,   Dlo,   Dhi,&
                          deltax) bind(C, name = "pc_diffterm")
 
-    use network, only : nspecies
+    use fuego_chemistry, only : nspecies
     use meth_params_module, only : NVAR, UMX, UMY, UMZ, UEDEN, UFS, QVAR, QU, QV, QW, QPRES, QTEMP, QFS, QRHO
     use amrex_constants_module
     use eos_type_module

--- a/Source/Src_3d/impose_NSCBC_3d.f90
+++ b/Source/Src_3d/impose_NSCBC_3d.f90
@@ -1010,7 +1010,7 @@ end subroutine impose_NSCBC
                                
   use eos_module
   use amrex_constants_module, only : ONE
-  use network, only : nspecies
+  use fuego_chemistry, only : nspecies
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UMZ, UEDEN, UEINT, UTEMP,&
                                  UFS, NQAUX, QC, QGAMC, QRSPEC, &
                                  QC, QDPDE, QDPDR, QCSML, QGAMC, &

--- a/Source/Src_3d/lesterm_3d.f90
+++ b/Source/Src_3d/lesterm_3d.f90
@@ -69,7 +69,7 @@ contains
        L,   Llo,   Lhi,&
        deltax) bind(C, name = "pc_smagorinsky_sfs_term")
 
-    use network, only   : nspecies
+    use fuego_chemistry, only   : nspecies
     use meth_params_module, only : NVAR, UMX, UMY, UMZ, UEDEN, QVAR, QRHO, QU, QW, QTEMP, QFS, Cs, CI, PrT
     use amrex_constants_module
     use eos_type_module
@@ -295,7 +295,7 @@ contains
                                              L,   Llo,   Lhi,&
                                              deltax) bind(C, name = "pc_dynamic_smagorinsky_sfs_term")
 
-    use network, only : nspecies
+    use fuego_chemistry, only : nspecies
     use meth_params_module, only : NVAR, UMX, UMY, UMZ, UEDEN, QVAR, QRHO, QU, QW, QTEMP, QFS
     use amrex_constants_module
     use eos_type_module

--- a/Source/Src_3d/riemann_3d.F90
+++ b/Source/Src_3d/riemann_3d.F90
@@ -36,7 +36,7 @@ contains
                     idir,ilo,ihi,jlo,jhi,kc,kflux,k3d,domlo,domhi)
 
     use amrex_mempool_module, only : bl_allocate, bl_deallocate
-    use network, only : nspecies
+    use fuego_chemistry, only : nspecies
     use eos_module
 
     implicit none
@@ -381,7 +381,7 @@ contains
 
     use amrex_mempool_module, only : bl_allocate, bl_deallocate
     use prob_params_module, only : physbc_lo, physbc_hi, Symmetry, SlipWall, NoSlipWall
-    use network, only : nspecies, naux
+    use fuego_chemistry, only : nspecies, naux
     use eos_type_module
     use eos_module
 

--- a/Source/Src_3d/slope_mol_3d.f90
+++ b/Source/Src_3d/slope_mol_3d.f90
@@ -21,7 +21,7 @@ contains
       use amrex_mempool_module, only : bl_allocate, bl_deallocate
       use meth_params_module
       use amrex_constants_module
-      use network, only : nspecies
+      use fuego_chemistry, only : nspecies
 
       implicit none
 
@@ -144,7 +144,7 @@ contains
       use amrex_mempool_module, only : bl_allocate, bl_deallocate
       use meth_params_module
       use amrex_constants_module
-      use network, only : nspecies
+      use fuego_chemistry, only : nspecies
 
       implicit none
 
@@ -270,7 +270,7 @@ contains
       use amrex_mempool_module, only : bl_allocate, bl_deallocate
       use meth_params_module
       use amrex_constants_module
-      use network, only : nspecies
+      use fuego_chemistry, only : nspecies
 
       implicit none
 

--- a/Source/Src_3d/slope_mol_3d_EB.f90
+++ b/Source/Src_3d/slope_mol_3d_EB.f90
@@ -25,7 +25,7 @@ contains
       use amrex_mempool_module, only : bl_allocate, bl_deallocate
       use meth_params_module
       use amrex_constants_module
-      use network, only : nspecies
+      use fuego_chemistry, only : nspecies
       use prob_params_module, only : physbc_lo, physbc_hi, Inflow
 
       implicit none
@@ -146,7 +146,7 @@ contains
       use amrex_mempool_module, only : bl_allocate, bl_deallocate
       use meth_params_module
       use amrex_constants_module
-      use network, only : nspecies
+      use fuego_chemistry, only : nspecies
       use prob_params_module, only : physbc_lo, physbc_hi, Inflow
 
       implicit none
@@ -268,7 +268,7 @@ contains
       use amrex_mempool_module, only : bl_allocate, bl_deallocate
       use meth_params_module
       use amrex_constants_module
-      use network, only : nspecies
+      use fuego_chemistry, only : nspecies
       use prob_params_module, only : physbc_lo, physbc_hi, Inflow
 
       implicit none

--- a/Source/Src_3d/trace_3d.f90
+++ b/Source/Src_3d/trace_3d.f90
@@ -13,7 +13,7 @@ contains
                          qxm,qxp,qym,qyp,qpd_lo,qpd_hi, &
                          ilo1,ilo2,ihi1,ihi2,dx,dt,kc,k3d)
 
-      use network, only : nspecies, naux
+      use fuego_chemistry, only : nspecies, naux
       use meth_params_module, only : QVAR, QRHO, QU, QV, QW, &
                                      QREINT, QPRES, &
                                      npassive, qpass_map, small_dens, small_pres, ppm_type
@@ -426,7 +426,7 @@ contains
                         qzm,qzp,qpd_lo,qpd_hi, &
                         ilo1,ilo2,ihi1,ihi2,dx,dt,km,kc,k3d)
 
-      use network, only : nspecies, naux
+      use fuego_chemistry, only : nspecies, naux
       use meth_params_module, only : QVAR, QRHO, QU, QV, QW, &
                                      QREINT, QPRES, &
                                      npassive, qpass_map, small_dens, small_pres, ppm_type

--- a/Source/Src_3d/trace_ppm_3d.f90
+++ b/Source/Src_3d/trace_ppm_3d.f90
@@ -17,7 +17,7 @@ contains
                          gamc,gc_lo,gc_hi, &
                          ilo1,ilo2,ihi1,ihi2,dt,kc,k3d)
 
-    use network, only : nspecies, naux
+    use fuego_chemistry, only : nspecies, naux
     use meth_params_module, only : QVAR, QRHO, QU, QV, QW, &
          QREINT, QPRES, QGAME, &
          small_dens, small_pres, &
@@ -964,7 +964,7 @@ contains
                         gamc,gc_lo,gc_hi, &
                         ilo1,ilo2,ihi1,ihi2,dt,km,kc,k3d)
 
-    use network, only : nspecies, naux
+    use fuego_chemistry, only : nspecies, naux
     use meth_params_module, only : QVAR, QRHO, QU, QV, QW, &
          QREINT, QPRES, QGAME, &
          small_dens, small_pres, &

--- a/Source/Src_3d/trans_3d.F90
+++ b/Source/Src_3d/trans_3d.F90
@@ -2,7 +2,7 @@ module transverse_module
 
   use amrex_constants_module
 
-  use network, only : nspecies, naux
+  use fuego_chemistry, only : nspecies, naux
   use meth_params_module, only : NQ, QVAR, NVAR, QRHO, QU, QV, QW, &
                                  QPRES, QREINT, QGAME, QFS, QFX, &
                                  URHO, UMX, UMY, UMZ, UEDEN, UEINT, UFS, &

--- a/Source/Src_nd/Derive_nd.F90
+++ b/Source/Src_nd/Derive_nd.F90
@@ -179,7 +179,7 @@ contains
                           domhi,delta,xlo,time,dt,bc,level,grid_no) &
                           bind(C, name="pc_deruplusc")
 
-    use network, only : nspecies, naux
+    use fuego_chemistry, only : nspecies, naux
     use eos_module
     use meth_params_module, only : URHO, UEINT, UTEMP, UFS, UFX
     use amrex_constants_module
@@ -233,7 +233,7 @@ contains
                            domhi,delta,xlo,time,dt,bc,level,grid_no) &
                            bind(C, name="pc_deruminusc")
 
-    use network, only : nspecies, naux
+    use fuego_chemistry, only : nspecies, naux
     use eos_module
     use meth_params_module, only : URHO, UEINT, UTEMP, UFS, UFX
     use amrex_constants_module
@@ -406,7 +406,7 @@ contains
                         domhi,dx,xlo,time,dt,bc,level,grid_no) &
                         bind(C, name="pc_derpres")
 
-    use network, only: nspecies, naux
+    use fuego_chemistry, only: nspecies, naux
     use eos_module
     use meth_params_module, only: URHO, UEINT, UTEMP, UFS, UFX
     use amrex_constants_module
@@ -532,7 +532,7 @@ contains
                               domhi,dx,xlo,time,dt,bc,level,grid_no) &
                               bind(C, name="pc_dersoundspeed")
 
-    use network, only: nspecies, naux
+    use fuego_chemistry, only: nspecies, naux
     use eos_module
     use meth_params_module, only: URHO, UEINT, UTEMP, UFS, UFX
     use amrex_constants_module
@@ -584,7 +584,7 @@ contains
                               domhi,dx,xlo,time,dt,bc,level,grid_no) &
                               bind(C, name="pc_dermachnumber")
 
-    use network, only: nspecies, naux
+    use fuego_chemistry, only: nspecies, naux
     use eos_module
     use meth_params_module, only: URHO, UMX, UMZ, UEINT, UTEMP, UFS, UFX
     use amrex_constants_module
@@ -636,7 +636,7 @@ contains
                            domhi,dx,xlo,time,dt,bc,level,grid_no) &
                            bind(C, name="pc_derentropy")
 
-    use network, only: nspecies, naux
+    use fuego_chemistry, only: nspecies, naux
     use eos_module
     use meth_params_module, only: URHO, UEINT, UTEMP, UFS, UFX
     use amrex_constants_module
@@ -690,7 +690,7 @@ contains
 
     use amrex_constants_module, only: ZERO, ONE
     use meth_params_module, only: URHO, UEINT, UTEMP, UFS, UFX
-    use network, only: nspecies, naux
+    use fuego_chemistry, only: nspecies, naux
     use prob_params_module, only: dim
     use eos_module
 
@@ -762,7 +762,7 @@ contains
                         bind(C, name="pc_derspec")
 
     use meth_params_module, only: URHO, UEINT, UTEMP, UFS, UFX
-    use network, only: nspecies
+    use fuego_chemistry, only: nspecies
     !
     ! This routine derives the mass fractions of the species.
     !
@@ -798,7 +798,7 @@ contains
     ! This routine derives the mole fractions of the species.
     !
     use meth_params_module, only: URHO, UEINT, UTEMP, UFS, UFX
-    use network, only: nspecies, naux
+    use fuego_chemistry, only: nspecies, naux
     use eos_module
     use amrex_constants_module
     
@@ -853,7 +853,7 @@ contains
     ! This routine derives the mole fractions of the species.
     !
     use meth_params_module, only: URHO, UFX
-    use network, only: naux
+    use fuego_chemistry, only: naux
     use eos_module
     use amrex_constants_module
     

--- a/Source/Src_nd/Diffusion_nd.f90
+++ b/Source/Src_nd/Diffusion_nd.f90
@@ -418,7 +418,7 @@ contains
                          D,   Dlo,   Dhi,&
                          deltax, dir) bind(C, name = "pc_diffterm_aux")
 
-    use network, only : naux
+    use fuego_chemistry, only : naux
     use meth_params_module, only : NVAR, UFX, QVAR, QFX
     use amrex_constants_module
     use prob_params_module, only : physbc_lo, physbc_hi

--- a/Source/Src_nd/PeleC_nd.F90
+++ b/Source/Src_nd/PeleC_nd.F90
@@ -1,6 +1,6 @@
 subroutine pc_network_init() bind(C, name="pc_network_init")
 
-  use network, only: network_init
+  use fuego_chemistry, only: network_init
   implicit none
 
   call network_init()
@@ -14,7 +14,7 @@ end subroutine pc_network_init
 
 subroutine pc_network_close() bind(C, name="pc_network_close")
 
-  use network, only: network_close
+  use fuego_chemistry, only: network_close
   implicit none
 
   call network_close()
@@ -28,10 +28,10 @@ end subroutine pc_network_close
 
 subroutine pc_transport_init() bind(C, name="pc_transport_init")
 
-  use transport_module, only: transport_init
+  use transport_module, only: transport_init_F
   implicit none
 
-  call transport_init()
+  call transport_init_F()
 
 end subroutine pc_transport_init
 
@@ -42,10 +42,10 @@ end subroutine pc_transport_init
 
 subroutine pc_transport_close() bind(C, name="pc_transport_close")
 
-  use transport_module, only: transport_close
+  use transport_module, only: transport_close_F
   implicit none
 
-  call transport_close()
+  call transport_close_F()
 
 end subroutine pc_transport_close
 
@@ -75,7 +75,7 @@ end subroutine pc_extern_init
 ! :::
 
   subroutine pc_les_init() bind(C, name = "pc_les_init")
-    use network, only   : nspecies
+    use fuego_chemistry, only   : nspecies
     use eos_module, only : eos_name
     implicit none
     
@@ -151,7 +151,7 @@ end subroutine pc_reactor_close
 
 subroutine get_num_spec(nspecies_out) bind(C, name="get_num_spec")
 
-  use network, only : nspecies
+  use fuego_chemistry, only : nspecies
 
   implicit none
 
@@ -167,7 +167,7 @@ end subroutine get_num_spec
 
 subroutine get_num_aux(naux_out) bind(C, name="get_num_aux")
 
-  use network, only : naux
+  use fuego_chemistry, only : naux
 
   implicit none
 
@@ -184,7 +184,7 @@ end subroutine get_num_aux
 subroutine get_spec_names(spec_names_out,ispec,len) &
      bind(C, name="get_spec_names")
 
-  use network, only : spec_names
+  use fuego_chemistry, only : spec_names
 
   implicit none
 
@@ -210,7 +210,7 @@ end subroutine get_spec_names
 subroutine get_aux_names(aux_names_out,iaux,len) &
      bind(C, name="get_aux_names")
 
-  use network, only : aux_names
+  use fuego_chemistry, only : aux_names
 
   implicit none
 
@@ -427,9 +427,8 @@ subroutine set_method_params(dm,Density,Xmom,Eden,Eint,Temp, &
      bind(C, name="set_method_params")
 
   use meth_params_module
-  use network, only : nspecies, naux
+  use fuego_chemistry, only : nspecies, naux
   use eos_module, only : eos_init, eos_get_small_dens, eos_get_small_temp
-  use transport_module, only : transport_init
   use amrex_constants_module, only : ZERO, ONE
 
   implicit none

--- a/Source/Src_nd/PeleC_util.F90
+++ b/Source/Src_nd/PeleC_util.F90
@@ -122,7 +122,7 @@ contains
 
     use eos_module
     use eos_type_module
-    use network, only : nspecies, naux
+    use fuego_chemistry, only : nspecies, naux
     use meth_params_module, only : NVAR, URHO, UMX, UMY, UMZ, UEDEN, UEINT, UFS, UFX, &
          UTEMP, small_temp, allow_negative_energy, allow_small_energy, &
          dual_energy_eta2, dual_energy_update_E_from_e
@@ -332,7 +332,7 @@ contains
   subroutine compute_temp(lo,hi,state,s_lo,s_hi) &
        bind(C, name="compute_temp")
 
-    use network, only : nspecies, naux
+    use fuego_chemistry, only : nspecies, naux
     use eos_type_module
     use eos_module
     use meth_params_module, only : NVAR, URHO, UEDEN, UEINT, UTEMP, &
@@ -406,7 +406,7 @@ contains
   subroutine pc_check_initial_species(lo,hi,state,state_lo,state_hi) &
                                       bind(C, name="pc_check_initial_species")
 
-    use network, only : nspecies
+    use fuego_chemistry, only : nspecies
     use meth_params_module, only : NVAR, URHO, UFS
     use amrex_constants_module
 

--- a/Source/Src_nd/React_nd.F90
+++ b/Source/Src_nd/React_nd.F90
@@ -22,7 +22,7 @@ contains
 use amrex_ebcellflag_module, only : is_covered_cell
 #endif
 
-    use network, only : nspecies
+    use fuego_chemistry, only : nspecies
     use meth_params_module, only : NVAR, URHO, UMX, UMZ, UEDEN, UEINT, UTEMP, &
                                    UFS
 #ifdef USE_SUNDIALS_PP
@@ -164,9 +164,7 @@ use amrex_ebcellflag_module, only : is_covered_cell
                             time,dt_react,do_update,&
                             nsubsteps_min,nsubsteps_max,nsubsteps_guess,errtol) bind(C, name="pc_react_state_expl")
 
-    use network, only : nspecies
-    use chemistry_module  , only : molecular_weight
-    use fuego_chemistry, only : CKWC,CKCVBS,CKUMS,CKYTCR
+    use fuego_chemistry, only : nspecies, molecular_weight, CKWC,CKCVBS,CKUMS,CKYTCR
     use meth_params_module, only : NVAR, URHO, UMX, UMZ, UEDEN, UEINT, UTEMP, UFS
     use amrex_fort_module, only : amrex_real
     use amrex_constants_module, only : HALF

--- a/Source/Src_nd/advection_util_nd.F90
+++ b/Source/Src_nd/advection_util_nd.F90
@@ -202,7 +202,7 @@ contains
   subroutine reset_to_small_state(old_state, new_state, idx, lo, hi, verbose)
 
     use amrex_constants_module, only: ZERO
-    use network, only: nspecies, naux
+    use fuego_chemistry, only: nspecies, naux
     use meth_params_module, only: NVAR, URHO, UMX, UMY, UMZ, UTEMP, UEINT, UEDEN, UFS, small_temp, small_dens, npassive, upass_map
     use eos_type_module
     use eos_module, only: eos_rt
@@ -393,7 +393,7 @@ contains
                      qaux, qa_lo,  qa_hi) bind(C, name = "ctoprim")
 
     use fundamental_constants_module, only: k_B, n_A
-    use network, only : nspecies, naux
+    use fuego_chemistry, only : nspecies, naux
     use eos_module, only : eos_re
     use eos_type_module
     use meth_params_module, only : NVAR, URHO, UMX, UMZ, UEDEN, UTEMP, &
@@ -647,7 +647,7 @@ contains
                                   allow_small_energy, allow_negative_energy
     use prob_params_module, only: dim, coord_type, dg
     use amrex_mempool_module, only: bl_allocate, bl_deallocate
-    use network, only: nspecies, naux
+    use fuego_chemistry, only: nspecies, naux
     use eos_type_module
     use eos_module, only: eos_rt
 

--- a/Source/Src_nd/bc_fill_nd.F90
+++ b/Source/Src_nd/bc_fill_nd.F90
@@ -172,7 +172,7 @@ contains
     use eos_type_module
     use eos_module
     use meth_params_module, only : URHO, UMX, UMY, UMZ, UTEMP, UEDEN, UEINT, UFS
-    use network, only: nspecies, naux
+    use fuego_chemistry, only: nspecies, naux
     use prob_params_module, only : Interior, Inflow, Outflow, SlipWall, NoSlipWall, &
                                    problo, probhi
     use amrex_constants_module, only: M_PI

--- a/Source/Src_nd/mms_src_nd.F90
+++ b/Source/Src_nd/mms_src_nd.F90
@@ -18,7 +18,7 @@ contains
     use meth_params_module, only : NVAR
 
 #ifdef USE_MASA
-    use network, only : nspecies
+    use fuego_chemistry, only : nspecies
     use amrex_constants_module, only: HALF
     use meth_params_module, only : URHO, UMX, UMY, UMZ, UEDEN, UEINT, UFS
     use prob_params_module, only: dim

--- a/Source/Src_nd/timestep.F90
+++ b/Source/Src_nd/timestep.F90
@@ -10,7 +10,7 @@ contains
 
   subroutine pc_estdt(lo,hi,u,u_lo,u_hi,dx,dt) bind(C, name="pc_estdt")
 
-    use network, only: nspecies, naux
+    use fuego_chemistry, only: nspecies, naux
     use eos_module
     use meth_params_module, only: NVAR, URHO, UMX, UMY, UMZ, UEINT, UTEMP, UFS, UFX
     use prob_params_module, only: dim
@@ -80,7 +80,7 @@ contains
   subroutine pc_estdt_vel_diffusion(lo,hi,state,s_lo,s_hi,dx,dt) &
        bind(C, name="pc_estdt_vel_diffusion")
 
-    use network, only: nspecies, naux
+    use fuego_chemistry, only: nspecies, naux
     use eos_module
     use eos_type_module
     use meth_params_module, only: NVAR, URHO, UTEMP, UFS
@@ -124,7 +124,7 @@ contains
           coeff%eos_state(1:np)%T   = state(lo(1):hi(1),j,k,UTEMP)
           coeff%eos_state(1:np)%rho = state(lo(1):hi(1),j,k,URHO) 
 
-          call transport(which_trans, coeff)
+          call transport_F(which_trans, coeff)
 
           D(:) = coeff%mu(:) * rho_inv(:)
 
@@ -153,7 +153,7 @@ contains
   subroutine pc_estdt_temp_diffusion(lo,hi,state,s_lo,s_hi,dx,dt) &
        bind(C, name="pc_estdt_temp_diffusion")
 
-    use network, only: nspecies, naux
+    use fuego_chemistry, only: nspecies, naux
     use eos_module
     use eos_type_module
     use meth_params_module, only: NVAR, URHO, UTEMP, UFS
@@ -203,7 +203,7 @@ contains
              coeff%eos_state(i)%rho = state(lo(1)+i-1,j,k,URHO) ! Note: Assumes this is a good T!
           end do
 
-          call transport(which_trans, coeff)
+          call transport_F(which_trans, coeff)
 
           do i=1,np
              call eos_cv(coeff % eos_state(i))
@@ -236,7 +236,7 @@ contains
   subroutine pc_estdt_enth_diffusion(lo,hi,state,s_lo,s_hi,dx,dt) &
        bind(C, name="pc_estdt_enth_diffusion")
 
-    use network, only: nspecies, naux
+    use fuego_chemistry, only: nspecies, naux
     use eos_module
     use eos_type_module
     use meth_params_module, only: NVAR, URHO, UEINT, UTEMP, UFS, UFX, &
@@ -288,7 +288,7 @@ contains
 
                 ! we also need the conductivity
                 if (coeff%eos_state(1)%rho > diffuse_cutoff_density) then
-                   call transport(which_trans, coeff)
+                   call transport_F(which_trans, coeff)
                    cond = coeff % lam(1)
                 else
                    cond = ZERO
@@ -336,7 +336,7 @@ contains
     use meth_params_module, only: NVAR, URHO, UTEMP, UEINT, UFS, UFX, UMX, UMZ, &
                                   cfl, do_hydro
     use prob_params_module, only: dim
-    use network, only: nspecies, naux
+    use fuego_chemistry, only: nspecies, naux
     use eos_module
 
     implicit none


### PR DESCRIPTION
Modifs contains:
- replace calls to network module by fuego_chemistry module in Src and Exec/RegTest/PMF
- replace calls to chemistry_module by fuego_chemistry module in Src  and Exec/RegTest/PMF
- modifs to the Makefile to comply with reorganizing of PelePhysics