### PR TITLE
added sundials chemistry integration in pelec

### DIFF
--- a/ExecCpp/Make.PeleC
+++ b/ExecCpp/Make.PeleC
@@ -20,6 +20,15 @@ ifneq ($(USE_MASA), TRUE)
   BL_NO_FORT = TRUE
 endif
 
+#sundials stuff
+ifeq ($(USE_SUNDIALS_PP), TRUE)
+  USE_ARKODE_PP=TRUE
+  ifeq ($(USE_CUDA), TRUE)
+    USE_CUDA_SUNDIALS_PP = TRUE
+  endif
+  include $(PELE_PHYSICS_HOME)/ThirdParty/Make.ThirdParty
+endif
+
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 
 # PeleC uses a coarse grained OMP approach
@@ -66,6 +75,13 @@ endif
 VPATH_LOCATIONS += $(CHEM_HOME)
 Bpack += $(CHEM_HOME)/Make.package
 Blocs += $(CHEM_HOME)
+
+#sundials stuff
+ifeq ($(USE_SUNDIALS_PP), TRUE)
+  Blocs += $(REACTIONS_HOME)/Fuego
+  Bpack += $(REACTIONS_HOME)/Fuego/Make.package
+endif
+
 
 # Transport
 ifeq ($(Transport_dir), Simple)

--- a/ExecCpp/RegTests/zeroD/GNUmakefile
+++ b/ExecCpp/RegTests/zeroD/GNUmakefile
@@ -30,6 +30,7 @@ Eos_dir := Fuego
 Reactions_dir := Fuego
 Chemistry_Model := LiDryer
 Transport_dir := Simple
+USE_SUNDIALS_PP = TRUE
 
 # GNU Make
 Bpack := ./Make.package

--- a/SourceCpp/PeleC.cpp
+++ b/SourceCpp/PeleC.cpp
@@ -31,6 +31,13 @@ using namespace MASA;
 #include "Utilities.H"
 #include "Tagging.H"
 #include "IndexDefines.H"
+#if defined(USE_SUNDIALS_PP)
+    #ifdef USE_ARKODE_PP
+        #include <actual_CARKODE.h>
+    #else
+        #include <actual_Creactor.h>
+    #endif
+#endif
 
 bool PeleC::signalStopJob = false;
 bool PeleC::dump_old = false;
@@ -1890,6 +1897,17 @@ void
 PeleC::init_reactor()
 {
   CKINIT();
+
+#if defined(USE_SUNDIALS_PP)
+    int reactor_type=1;
+    int ode_ncells=1;
+    #ifndef USE_CUDA_SUNDIALS_PP
+        reactor_init(&reactor_type, &ode_ncells);
+    #else
+        reactor_info(&reactor_type, &ode_ncells);
+    #endif
+#endif
+        
 }
 
 void


### PR DESCRIPTION
This PR adds the Sundials CPU/GPU integrators from pelephysics into pelec. 
1) By default, USE_SUNDIALS_PP is set to false. So people can still use pelec without sundials shared-libraries. Moving forward we need to see how sundials build and CI/CD will have to work together?
2) SUNDIALS ARKODE explicit is ~ 5X faster than PeleC explicit RK64 on single core CPU

3) This is the disappointing part - SUNDIALS ARKODE is 2X slower the explicit RK64 on a single GPU. I think I know what is causing this. Have to work with Anne from PelePhysics side to eliminate some cudamemcpy s in the integrators. can we have nvec point to the vectors already on GPU?