### PR TITLE
Bug F90 and CPP: Fix mismatch btw EB tiling and no tiling.

### DIFF
--- a/Source/PeleC_MOL.cpp
+++ b/Source/PeleC_MOL.cpp
@@ -422,7 +422,7 @@ PeleC::getMOLSrcTerm(const amrex::MultiFab& S,
           // Compute heat flux at EB wall
           int nComp = 1;
 
-          Box box_to_apply = mfi.growntilebox(2);
+          Box box_to_apply = amrex::grow(vbox, 2);
           {
             BL_PROFILE("PeleC::pc_apply_eb_boundry_flux_stencil call");
             pc_apply_eb_boundry_flux_stencil(BL_TO_FORTRAN_BOX(box_to_apply),
@@ -440,7 +440,7 @@ PeleC::getMOLSrcTerm(const amrex::MultiFab& S,
         if (eb_noslip && diffuse_vel == 1) {
           int nComp = BL_SPACEDIM;
 
-          Box box_to_apply = mfi.growntilebox(2);
+          Box box_to_apply = amrex::grow(vbox, 2);
           {
             BL_PROFILE("PeleC::pc_apply_eb_boundry_visc_flux_stencil call");
             pc_apply_eb_boundry_visc_flux_stencil(BL_TO_FORTRAN_BOX(box_to_apply),

--- a/SourceCpp/Diffusion.cpp
+++ b/SourceCpp/Diffusion.cpp
@@ -310,7 +310,7 @@ PeleC::getMOLSrcTerm(
         AMREX_ASSERT(nFlux == Ncut);
 
         if (eb_isothermal && (diffuse_temp != 0 || diffuse_enth != 0)) {
-          amrex::Box box_to_apply = mfi.growntilebox(2);
+          amrex::Box box_to_apply = amrex::grow(vbox, 2);
           {
             BL_PROFILE("PeleC::pc_apply_eb_boundry_flux_stencil()");
             pc_apply_eb_boundry_flux_stencil(
@@ -321,7 +321,7 @@ PeleC::getMOLSrcTerm(
         }
         // Compute momentum transfer at no-slip EB wall
         if (eb_noslip && diffuse_vel == 1) {
-          amrex::Box box_to_apply = mfi.growntilebox(2);
+          amrex::Box box_to_apply = amrex::grow(vbox, 2);
           {
             BL_PROFILE("PeleC::pc_apply_eb_boundry_visc_flux_stencil()");
             pc_apply_eb_boundry_visc_flux_stencil(


### PR DESCRIPTION
Before this fix, if one ran the code with and without tiling and EB,
one would get different results (fcompare would show diffs of order 1e-4
after 1 time step of the EB MMS test case). This was present in the
F90 and CPP versions of the code: F90 without tiling = CPP without
tiling and F90 with tiling = CPP with tiling *BUT F90/CPP with tiling !=
F90/CPP without tiling*.

This was easy to test in the CPP version of the code as one only had
to try `fabarray.mfiter_tile_size = 1024 16 16` or
`fabarray.mfiter_tile_size = 1024 1024 1024`. For the F90 version, one
has to change `hydro_tile_size` and recompile.

With this change, one can run the 32^3 EB MMS test case in any tiling 
configuration and/or max grid size and get zero diffs.

This problem was also evident in the fact that with tiling on the EB
MMS test case was _not perfectly symmetric_ as it should have been. 

The bug leads to subtly incorrect diffusion fluxes. It was always present 
in the F90 code because the `hydro_tile_size` defaulted to `1024 16 16`.

The reason for this fix is that all the grow cells should be filled
when using EB (it is expected by the algorithm).