### PR TITLE
Fix memory leak in ckinit

### DIFF
--- a/SourceCpp/PeleC.H
+++ b/SourceCpp/PeleC.H
@@ -636,23 +636,12 @@ protected:
   amrex::Vector<std::unique_ptr<amrex::MultiFab>> old_sources;
   amrex::Vector<std::unique_ptr<amrex::MultiFab>> new_sources;
 
-  ///
-  ///  Call extern/networks/.../network.f90::network_init()
-  ///
-  static void init_extern();
-
-  static void init_network();
-  static void close_network();
-
 #ifdef PELEC_USE_REACTIONS
   static void init_reactor();
   static void close_reactor();
 #endif
 
-  static void init_eos();
-
   static void init_transport();
-  static void close_transport();
 
   void init_les();
   void init_filters();

--- a/SourceCpp/PeleC.cpp
+++ b/SourceCpp/PeleC.cpp
@@ -40,28 +40,6 @@ bool PeleC::dump_old = false;
 int PeleC::verbose = 0;
 int PeleC::radius_grow = 1;
 amrex::BCRec PeleC::phys_bc;
-// int PeleC::NUM_GROW = -1;
-// int PeleC::NVAR = -1;
-// int          PeleC::QTHERM        = -1;
-// int          PeleC::QVAR          = -1;
-// int          PeleC::cQRHO         = -1;
-// int          PeleC::cQU           = -1;
-// int          PeleC::cQV           = -1;
-// int          PeleC::cQW           = -1;
-// int          PeleC::cQGAME        = -1;
-// int          PeleC::cQPRES        = -1;
-// int          PeleC::cQREINT       = -1;
-// int          PeleC::cQTEMP        = -1;
-// int          PeleC::cQFA          = -1;
-// int          PeleC::cQFS          = -1;
-// int          PeleC::cQFX          = -1;
-// int          PeleC::NQAUX         = -1;
-// int          PeleC::cQGAMC        = -1;
-// int          PeleC::cQC           = -1;
-// int          PeleC::cQCSML        = -1;
-// int          PeleC::cQDPDR        = -1;
-// int          PeleC::cQDPDE        = -1;
-// int          PeleC::cQRSPEC        = -1;
 amrex::Real PeleC::frac_change = 1.e200;
 int PeleC::Density = -1;
 int PeleC::Eden = -1;
@@ -139,24 +117,17 @@ ebInitialized(bool eb_init_val)
 void
 PeleC::variableCleanUp()
 {
-
   desc_lst.clear();
 
-  // Don't need this in pure C++?
-  // clear_method_params();
-
   transport_close();
+
+  EOS::close();
 
 #ifdef PELEC_USE_REACTIONS
   if (do_react == 1) {
     close_reactor();
   }
 #endif
-
-  close_network();
-
-  // Don't need this in pure C++?
-  // clear_grid_info();
 
   clear_prob();
 
@@ -1847,43 +1818,15 @@ PeleC::derive(
 }
 
 void
-PeleC::init_network()
-{
-  // pc_network_init();
-  //__network_MOD_network_init();
-}
-
-void
-PeleC::close_network()
-{
-  // pc_network_close();
-  //__network_MOD_network_close();
-}
-
-void
 PeleC::clear_prob()
 {
   pc_prob_close();
-}
-
-void
-PeleC::init_extern()
-{
-  // initialize the external runtime parameters -- these will
-  // live in the probin
-
-  amrex::Print() << "reading extern runtime parameters ..." << std::endl;
-
-  // Disabled for CUDA
-  // pc_extern_init();
 }
 
 #ifdef PELEC_USE_REACTIONS
 void
 PeleC::init_reactor()
 {
-  CKINIT();
-
 #ifdef USE_SUNDIALS_PP
   int reactor_type = 1;
   int ode_ncells = 1;
@@ -1902,27 +1845,13 @@ PeleC::init_reactor()
 
 void
 PeleC::close_reactor()
-{
-  CKFINALIZE();
-}
+{ }
 #endif
-
-void
-PeleC::init_eos()
-{
-  EOS::init();
-}
 
 void
 PeleC::init_transport()
 {
   transport_init();
-}
-
-void
-PeleC::close_transport()
-{
-  transport_close();
 }
 
 void

--- a/SourceCpp/PeleC.cpp
+++ b/SourceCpp/PeleC.cpp
@@ -1845,7 +1845,8 @@ PeleC::init_reactor()
 
 void
 PeleC::close_reactor()
-{ }
+{
+}
 #endif
 
 void

--- a/SourceCpp/Setup.cpp
+++ b/SourceCpp/Setup.cpp
@@ -91,7 +91,6 @@ set_z_vel_bc(amrex::BCRec& bc, const amrex::BCRec& phys_bc)
 void
 PeleC::variableSetUp()
 {
-
   // PeleC::variableSetUp is called in the constructor of Amr.cpp, so
   // it should get called every time we start or restart a job
 
@@ -129,12 +128,6 @@ PeleC::variableSetUp()
   // Get options, set phys_bc
   read_params();
 
-  // Initialize the runtime parameters for any of the external code
-  init_extern();
-
-  // Initialize the network
-  init_network();
-
 #ifdef PELEC_USE_REACTIONS
   // Initialize the reactor
   if (do_react == 1) {
@@ -142,7 +135,7 @@ PeleC::variableSetUp()
   }
 #endif
 
-  init_eos();
+  EOS::init();
 
   init_transport();
 
@@ -212,8 +205,7 @@ PeleC::variableSetUp()
   //    std::cout << "\nTime in set_method_params: " << run_stop << '\n' ;
 
   if (nscbc_adv == 1 && amrex::ParallelDescriptor::IOProcessor())
-    amrex::Print() << '\n'
-                   << "Using Ghost-Cells Navier-Stokes Characteristic BCs for "
+    amrex::Print() << "Using Ghost-Cells Navier-Stokes Characteristic BCs for "
                       "advection: nscbc_adv = "
                    << nscbc_adv << '\n'
                    << '\n';

--- a/SourceCpp/Setup.cpp
+++ b/SourceCpp/Setup.cpp
@@ -128,16 +128,16 @@ PeleC::variableSetUp()
   // Get options, set phys_bc
   read_params();
 
+  EOS::init();
+
+  init_transport();
+
 #ifdef PELEC_USE_REACTIONS
   // Initialize the reactor
   if (do_react == 1) {
     init_reactor();
   }
 #endif
-
-  EOS::init();
-
-  init_transport();
 
   indxmap::init();
 


### PR DESCRIPTION
`CKINIT` was being called twice, once with `EOS::init` and also in `reactor_init` when reactions are enabled. This was causing a memory leak since the `TB*` arrays in `mechanism.cpp` were being allocated twice without being freed. This removes the `CKINIT` and `CKFINALIZE` calls from the reactor init and close and only uses the EOS init and close routines. I also removed some unnecessary function wrappers and commented out code that was used for fortran initializations that have gone away.