### PR TITLE
Bugfix: Updating Exec/RegTest/PMF_NSCBC to work with latest PelePhysics

### DIFF
--- a/Exec/RegTests/PMF_NSCBC/pmf_generic.f90
+++ b/Exec/RegTests/PMF_NSCBC/pmf_generic.f90
@@ -9,7 +9,6 @@ module pmf_module
 contains
 
   subroutine read_pmf()
-    implicit none
     character (len=20) :: ctmp1, ctmp2, fmt
     character (len=1) :: ctmp
     integer index, found, ist, reason, i, j, lsize, pos1, pos2, n
@@ -125,19 +124,16 @@ contains
   end subroutine read_pmf
 
   function pmf_ncomp() result(ncomp)
-    implicit none
     integer :: ncomp
     ncomp = pmf_M
   end function pmf_ncomp
 
   function pmf_npts() result(npts)
-    implicit none
     integer :: npts
     npts = pmf_N
   end function pmf_npts
 
   subroutine interp_pmf(xlo,xhi,y_vector,M_ret)
-    implicit none
     double precision xlo,xhi,y_vector(*)
     double precision sum,xmid
     integer i,j,k,lo_loside,lo_hiside       
@@ -291,8 +287,7 @@ end module pmf_module
 
 subroutine initialize_pmf(filename)
   use pmf_module
-  use chemistry_module, only : nspecies, get_species_index
-  implicit none
+  use fuego_chemistry, only : nspecies, get_species_index
   character (len=*) :: filename
   integer :: n
   pmf_filename = filename
@@ -315,7 +310,6 @@ end subroutine initialize_pmf
 
 subroutine pmf(xlo,xhi,y_vector,M)
   use pmf_module
-  implicit none
   double precision :: xlo,xhi,y_vector(*)
   integer :: M
   call interp_pmf(xlo,xhi,y_vector,M)

--- a/Exec/RegTests/PMF_NSCBC/probdata.f90
+++ b/Exec/RegTests/PMF_NSCBC/probdata.f90
@@ -33,9 +33,10 @@ contains
   subroutine init_bc
 
     use meth_params_module, only : NVAR, URHO, UMX, UMY, UMZ, UEINT, UEDEN, UTEMP, UFS
-    use chemistry_module, only : nspecies, get_species_index
+    use fuego_chemistry, only : nspecies, get_species_index
     use eos_type_module
 
+    implicit none
     integer :: iN2, iO2, iH2, nPMF
     double precision :: vt, ek, a, yl, yr, sumY
     double precision, allocatable :: pmf_vals(:)
@@ -98,6 +99,7 @@ contains
 
   subroutine clear_bc()
 
+    implicit none
     deallocate(fuel_state)
 
   end subroutine clear_bc


### PR DESCRIPTION
Small bugfix for the Exec/RegTest/PMF_NSCBC case to work with latest PelePhysics.
I literally just copy-pasted the files `pmf_generic.f90` and `probdata.f90` from Exec/RegTest/PMF, where this was already fixed.