### PR TITLE
Remove flattening from PLM as this caused an out-of-bounds

### DIFF
--- a/SourceCpp/Godunov.cpp
+++ b/SourceCpp/Godunov.cpp
@@ -31,7 +31,6 @@ pc_umeth_3D(
   const int ppm_type,
   const int use_flattening)
 {
-  const int use_flattening_loc = use_flattening;
   amrex::Real const dx = del[0];
   amrex::Real const dy = del[1];
   amrex::Real const dz = del[2];
@@ -101,17 +100,17 @@ pc_umeth_3D(
         amrex::Real slope[QVAR];
         // X slopes and interp
         for (int n = 0; n < QVAR; ++n)
-          slope[n] = plm_slope(i, j, k, n, 0, use_flattening_loc, q);
+          slope[n] = plm_slope(i, j, k, n, 0, q);
         pc_plm_x(i, j, k, qxmarr, qxparr, slope, q, qaux(i, j, k, QC), dx, dt);
 
         // Y slopes and interp
         for (int n = 0; n < QVAR; n++)
-          slope[n] = plm_slope(i, j, k, n, 1, use_flattening_loc, q);
+          slope[n] = plm_slope(i, j, k, n, 1, q);
         pc_plm_y(i, j, k, qymarr, qyparr, slope, q, qaux(i, j, k, QC), dy, dt);
 
         // Z slopes and interp
         for (int n = 0; n < QVAR; ++n)
-          slope[n] = plm_slope(i, j, k, n, 2, use_flattening_loc, q);
+          slope[n] = plm_slope(i, j, k, n, 2, q);
         pc_plm_z(i, j, k, qzmarr, qzparr, slope, q, qaux(i, j, k, QC), dz, dt);
       });
   } else if (ppm_type == 1) {
@@ -505,7 +504,7 @@ pc_umeth_2D(
         amrex::Real slope[QVAR];
         // X slopes and interp
         for (int n = 0; n < QVAR; ++n)
-          slope[n] = plm_slope(i, j, k, n, 0, use_flattening_loc, q);
+          slope[n] = plm_slope(i, j, k, n, 0, q);
         pc_plm_x(i, j, k, qxmarr, qxparr, slope, q, qaux(i, j, k, QC), dx, dt);
       });
 
@@ -514,7 +513,7 @@ pc_umeth_2D(
         amrex::Real slope[QVAR];
         // Y slopes and interp
         for (int n = 0; n < QVAR; n++)
-          slope[n] = plm_slope(i, j, k, n, 1, use_flattening_loc, q);
+          slope[n] = plm_slope(i, j, k, n, 1, q);
         pc_plm_y(i, j, k, qymarr, qyparr, slope, q, qaux(i, j, k, QC), dy, dt);
       });
 

--- a/SourceCpp/PLM.H
+++ b/SourceCpp/PLM.H
@@ -24,7 +24,6 @@ plm_slope(
   const int k,
   const int n,
   const int dir,
-  const int use_flattening,
   amrex::Array4<const amrex::Real> const& q)
 {
   const int bdim[3] = {dir == 0, dir == 1, dir == 2};
@@ -65,15 +64,8 @@ plm_slope(
 
   dtemp = 4.0 / 3.0 * dcen - 1.0 / 6.0 * (dfp + dfm);
 
-  // Calculate flattening in-place
-  amrex::Real flatn = 1.0;
-  /* FIXME: Flattening disabled due to arrays going out of bounds; needs further investigation
-  if (use_flattening == 1) {
-    for (int dir_flat = 0; dir_flat < AMREX_SPACEDIM; dir_flat++)
-      flatn = amrex::min(flatn, flatten(i, j, k, dir_flat, q));
-  }*/
-
-  return flatn * dsgn * amrex::min(dlim, amrex::Math::abs(dtemp));
+  // Flattening could be done here (see Nyx if we want to do it)
+  return dsgn * amrex::min(dlim, amrex::Math::abs(dtemp));
 }
 
 AMREX_GPU_DEVICE


### PR DESCRIPTION
We could go back to Nyx and grab this if we wanted and figure out how
to get the boxes correctly. Nyx uses bxg1 and we use bxg2. I dont want
to switch that without understanding the ramefications first...