### PR TITLE
Use thrust for sorting during EB init

### DIFF
--- a/SourceCpp/EBStencilTypes.H
+++ b/SourceCpp/EBStencilTypes.H
@@ -41,10 +41,12 @@ struct EBBndryGeom
 
 #ifdef AMREX_USE_GPU
 // Comparison operator for thrust sort
-struct EBBndryGeomCmp {
+struct EBBndryGeomCmp
+{
   AMREX_GPU_HOST_DEVICE
-  bool operator()(const EBBndryGeom& a, const EBBndryGeom& b) {
-      return a.iv < b.iv;
+  bool operator()(const EBBndryGeom& a, const EBBndryGeom& b)
+  {
+    return a.iv < b.iv;
   }
 };
 #endif

--- a/SourceCpp/EBStencilTypes.H
+++ b/SourceCpp/EBStencilTypes.H
@@ -39,4 +39,14 @@ struct EBBndryGeom
   bool operator<(const EBBndryGeom& rhs) const { return iv < rhs.iv; }
 };
 
+#ifdef AMREX_USE_GPU
+// Comparison operator for thrust sort
+struct EBBndryGeomCmp {
+  AMREX_GPU_HOST_DEVICE
+  bool operator()(const EBBndryGeom& a, const EBBndryGeom& b) {
+      return a.iv < b.iv;
+  }
+};
+#endif
+
 #endif

--- a/SourceCpp/Hydro.cpp
+++ b/SourceCpp/Hydro.cpp
@@ -286,8 +286,9 @@ PeleC::construct_hydro_source(
     }
 
     if (print_energy_diagnostics) {
-      amrex::Real foo[5] = {E_added_flux, xmom_added_flux, ymom_added_flux,
-                            zmom_added_flux, mass_added_flux};
+      amrex::Real foo[5] = {
+        E_added_flux, xmom_added_flux, ymom_added_flux, zmom_added_flux,
+        mass_added_flux};
 
 #ifdef AMREX_LAZY
       Lazy::QueueReduction([=]() mutable {

--- a/SourceCpp/InitEB.cpp
+++ b/SourceCpp/InitEB.cpp
@@ -156,12 +156,15 @@ PeleC::initialize_eb2_structs()
 
       // Fill in boundary gradient for cut cells in this grown tile
       const amrex::Real dx = geom.CellSize()[0];
-      #ifdef AMREX_USE_GPU
+#ifdef AMREX_USE_GPU
       const int sv_eb_bndry_geom_size = sv_eb_bndry_geom[iLocal].size();
-      thrust::sort(thrust::device, sv_eb_bndry_geom[iLocal].data(), sv_eb_bndry_geom[iLocal].data() + sv_eb_bndry_geom_size, EBBndryGeomCmp());
-      #else
+      thrust::sort(
+        thrust::device, sv_eb_bndry_geom[iLocal].data(),
+        sv_eb_bndry_geom[iLocal].data() + sv_eb_bndry_geom_size,
+        EBBndryGeomCmp());
+#else
       sort<amrex::Gpu::DeviceVector<EBBndryGeom>>(sv_eb_bndry_geom[iLocal]);
-      #endif
+#endif
 
       if (bgs == 0) {
         pc_fill_bndry_grad_stencil(
@@ -281,9 +284,14 @@ PeleC::initialize_eb2_structs()
         });
 #ifdef AMREX_USE_GPU
         const int v_all_cut_faces_size = v_all_cut_faces.size();
-        thrust::sort(thrust::device, v_all_cut_faces.data(), v_all_cut_faces.data() + v_all_cut_faces_size);
-        amrex::IntVect *unique_result_end = thrust::unique(v_all_cut_faces.data(), v_all_cut_faces.data() + v_all_cut_faces_size, thrust::equal_to<amrex::IntVect>());
-        const int count_result = thrust::count(v_all_cut_faces.data(), unique_result_end, 1);
+        thrust::sort(
+          thrust::device, v_all_cut_faces.data(),
+          v_all_cut_faces.data() + v_all_cut_faces_size);
+        amrex::IntVect* unique_result_end = thrust::unique(
+          v_all_cut_faces.data(), v_all_cut_faces.data() + v_all_cut_faces_size,
+          thrust::equal_to<amrex::IntVect>());
+        const int count_result =
+          thrust::count(v_all_cut_faces.data(), unique_result_end, 1);
         amrex::Gpu::DeviceVector<amrex::IntVect> v_cut_faces(count_result);
         amrex::IntVect* d_all_cut_faces = v_all_cut_faces.data();
         amrex::IntVect* d_cut_faces = v_cut_faces.data();

--- a/SourceCpp/InitEB.cpp
+++ b/SourceCpp/InitEB.cpp
@@ -2,6 +2,12 @@
 #include "prob.H"
 #include "Utilities.H"
 
+#ifdef AMREX_USE_GPU
+#include <thrust/unique.h>
+#include <thrust/sort.h>
+#include <thrust/execution_policy.h>
+#endif
+
 inline bool
 PeleC::ebInitialized()
 {
@@ -146,12 +152,16 @@ PeleC::initialize_eb2_structs()
         tbox, Ncut, vfrac_arr, bndrycent_arr,
         AMREX_D_DECL(eb2areafrac_arr_0, eb2areafrac_arr_1, eb2areafrac_arr_2),
         sv_eb_bndry_geom[iLocal].data());
-
       sv_eb_bndry_grad_stencil[iLocal].resize(Ncut);
 
       // Fill in boundary gradient for cut cells in this grown tile
       const amrex::Real dx = geom.CellSize()[0];
+      #ifdef AMREX_USE_GPU
+      const int sv_eb_bndry_geom_size = sv_eb_bndry_geom[iLocal].size();
+      thrust::sort(thrust::device, sv_eb_bndry_geom[iLocal].data(), sv_eb_bndry_geom[iLocal].data() + sv_eb_bndry_geom_size, EBBndryGeomCmp());
+      #else
       sort<amrex::Gpu::DeviceVector<EBBndryGeom>>(sv_eb_bndry_geom[iLocal]);
+      #endif
 
       if (bgs == 0) {
         pc_fill_bndry_grad_stencil(
@@ -269,11 +279,23 @@ PeleC::initialize_eb2_structs()
             }
           }
         });
+#ifdef AMREX_USE_GPU
+        const int v_all_cut_faces_size = v_all_cut_faces.size();
+        thrust::sort(thrust::device, v_all_cut_faces.data(), v_all_cut_faces.data() + v_all_cut_faces_size);
+        amrex::IntVect *unique_result_end = thrust::unique(v_all_cut_faces.data(), v_all_cut_faces.data() + v_all_cut_faces_size, thrust::equal_to<amrex::IntVect>());
+        const int count_result = thrust::count(v_all_cut_faces.data(), unique_result_end, 1);
+        amrex::Gpu::DeviceVector<amrex::IntVect> v_cut_faces(count_result);
+        amrex::IntVect* d_all_cut_faces = v_all_cut_faces.data();
+        amrex::IntVect* d_cut_faces = v_cut_faces.data();
+        amrex::ParallelFor(
+          v_cut_faces.size(), [=] AMREX_GPU_DEVICE(int i) noexcept {
+            d_cut_faces[i] = d_all_cut_faces[i];
+          });
+#else
         sort<amrex::Gpu::DeviceVector<amrex::IntVect>>(v_all_cut_faces);
-        // ensure uniqueness
         amrex::Gpu::DeviceVector<amrex::IntVect> v_cut_faces =
           unique<amrex::Gpu::DeviceVector<amrex::IntVect>>(v_all_cut_faces);
-
+#endif
         const int Nsten = v_cut_faces.size();
         if (Nsten > 0) {
           flux_interp_stencil[dir][iLocal].resize(Nsten);

--- a/SourceCpp/InitEB.cpp
+++ b/SourceCpp/InitEB.cpp
@@ -152,6 +152,7 @@ PeleC::initialize_eb2_structs()
         tbox, Ncut, vfrac_arr, bndrycent_arr,
         AMREX_D_DECL(eb2areafrac_arr_0, eb2areafrac_arr_1, eb2areafrac_arr_2),
         sv_eb_bndry_geom[iLocal].data());
+
       sv_eb_bndry_grad_stencil[iLocal].resize(Ncut);
 
       // Fill in boundary gradient for cut cells in this grown tile

--- a/SourceCpp/InitEB.cpp
+++ b/SourceCpp/InitEB.cpp
@@ -283,6 +283,7 @@ PeleC::initialize_eb2_structs()
             }
           }
         });
+
 #ifdef AMREX_USE_GPU
         const int v_all_cut_faces_size = v_all_cut_faces.size();
         thrust::sort(
@@ -305,6 +306,7 @@ PeleC::initialize_eb2_structs()
         amrex::Gpu::DeviceVector<amrex::IntVect> v_cut_faces =
           unique<amrex::Gpu::DeviceVector<amrex::IntVect>>(v_all_cut_faces);
 #endif
+
         const int Nsten = v_cut_faces.size();
         if (Nsten > 0) {
           flux_interp_stencil[dir][iLocal].resize(Nsten);

--- a/SourceCpp/PPM.cpp
+++ b/SourceCpp/PPM.cpp
@@ -78,371 +78,370 @@ trace_ppm(
   }
 
   // Trace to left and right edges using upwind PPM
-  amrex::ParallelFor(
-    bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-      amrex::Real rho = q_arr(i, j, k, QRHO);
+  amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+    amrex::Real rho = q_arr(i, j, k, QRHO);
 
-      amrex::Real massfrac[NUM_SPECIES];
-      for (int sp = 0; sp < NUM_SPECIES; ++sp)
-        massfrac[sp] = q_arr(i, j, k, sp + QFS);
+    amrex::Real massfrac[NUM_SPECIES];
+    for (int sp = 0; sp < NUM_SPECIES; ++sp)
+      massfrac[sp] = q_arr(i, j, k, sp + QFS);
 
-      amrex::Real cc = 0;
-      EOS::RPY2Cs(q_arr(i, j, k, QRHO), q_arr(i, j, k, QPRES), massfrac, cc);
+    amrex::Real cc = 0;
+    EOS::RPY2Cs(q_arr(i, j, k, QRHO), q_arr(i, j, k, QPRES), massfrac, cc);
 
-      amrex::Real un = q_arr(i, j, k, QUN);
+    amrex::Real un = q_arr(i, j, k, QUN);
 
-      // do the parabolic reconstruction and compute the
-      // integrals under the characteristic waves
-      amrex::Real s[5];
+    // do the parabolic reconstruction and compute the
+    // integrals under the characteristic waves
+    amrex::Real s[5];
 
-      amrex::Real flat = 1.0;
-      // Calculate flattening in-place
-      if (use_flattening == 1) {
-        for (int dir_flat = 0; dir_flat < AMREX_SPACEDIM; dir_flat++) {
-          flat = amrex::min(flat, flatten(i, j, k, dir_flat, q_arr));
-        }
+    amrex::Real flat = 1.0;
+    // Calculate flattening in-place
+    if (use_flattening == 1) {
+      for (int dir_flat = 0; dir_flat < AMREX_SPACEDIM; dir_flat++) {
+        flat = amrex::min(flat, flatten(i, j, k, dir_flat, q_arr));
+      }
+    }
+
+    amrex::Real sm;
+    amrex::Real sp;
+
+    amrex::Real Ip[QVAR][3];
+    amrex::Real Im[QVAR][3];
+
+    for (int n = 0; n < QVAR; n++) {
+
+      if (idir == 0) {
+        s[im2] = q_arr(i - 2, j, k, n);
+        s[im1] = q_arr(i - 1, j, k, n);
+        s[i0] = q_arr(i, j, k, n);
+        s[ip1] = q_arr(i + 1, j, k, n);
+        s[ip2] = q_arr(i + 2, j, k, n);
+
+      } else if (idir == 1) {
+        s[im2] = q_arr(i, j - 2, k, n);
+        s[im1] = q_arr(i, j - 1, k, n);
+        s[i0] = q_arr(i, j, k, n);
+        s[ip1] = q_arr(i, j + 1, k, n);
+        s[ip2] = q_arr(i, j + 2, k, n);
+
+      } else {
+        s[im2] = q_arr(i, j, k - 2, n);
+        s[im1] = q_arr(i, j, k - 1, n);
+        s[i0] = q_arr(i, j, k, n);
+        s[ip1] = q_arr(i, j, k + 1, n);
+        s[ip2] = q_arr(i, j, k + 2, n);
       }
 
-      amrex::Real sm;
-      amrex::Real sp;
+      ppm_reconstruct(s, flat, sm, sp);
+      ppm_int_profile(sm, sp, s[i0], un, cc, dtdx, Ip[n], Im[n]);
+    }
 
-      amrex::Real Ip[QVAR][3];
-      amrex::Real Im[QVAR][3];
+    // PeleC does source term tracing in pc_transx, pc_transy, and
+    // pc_transz. So to be consistent we remove the source term
+    // tracing here. However, Nyx and Castro do the source term
+    // tracing here instead of in the trans routines. If we wanted
+    // to do the tracing here, we would have to 1) remove the tracing
+    // in the trans routines AND 2) add the tracing in the pc_plm_x,
+    // pc_plm_y, pc_plm_z routines.
+    //
+    // To do the tracing here: Uncomment the chunk below and
+    // anything that uses Im_src and Ip_src.
 
-      for (int n = 0; n < QVAR; n++) {
+    // // source terms
+    // amrex::Real Ip_src[QVAR][3];
+    // amrex::Real Im_src[QVAR][3];
 
-        if (idir == 0) {
-          s[im2] = q_arr(i - 2, j, k, n);
-          s[im1] = q_arr(i - 1, j, k, n);
-          s[i0] = q_arr(i, j, k, n);
-          s[ip1] = q_arr(i + 1, j, k, n);
-          s[ip2] = q_arr(i + 2, j, k, n);
+    // for (int n = 0; n < QVAR; n++) {
+    //   if (idir == 0) {
+    //     s[im2] = srcQ(i - 2, j, k, n);
+    //     s[im1] = srcQ(i - 1, j, k, n);
+    //     s[i0] = srcQ(i, j, k, n);
+    //     s[ip1] = srcQ(i + 1, j, k, n);
+    //     s[ip2] = srcQ(i + 2, j, k, n);
 
-        } else if (idir == 1) {
-          s[im2] = q_arr(i, j - 2, k, n);
-          s[im1] = q_arr(i, j - 1, k, n);
-          s[i0] = q_arr(i, j, k, n);
-          s[ip1] = q_arr(i, j + 1, k, n);
-          s[ip2] = q_arr(i, j + 2, k, n);
+    //   } else if (idir == 1) {
+    //     s[im2] = srcQ(i, j - 2, k, n);
+    //     s[im1] = srcQ(i, j - 1, k, n);
+    //     s[i0] = srcQ(i, j, k, n);
+    //     s[ip1] = srcQ(i, j + 1, k, n);
+    //     s[ip2] = srcQ(i, j + 2, k, n);
 
-        } else {
-          s[im2] = q_arr(i, j, k - 2, n);
-          s[im1] = q_arr(i, j, k - 1, n);
-          s[i0] = q_arr(i, j, k, n);
-          s[ip1] = q_arr(i, j, k + 1, n);
-          s[ip2] = q_arr(i, j, k + 2, n);
-        }
+    //   } else {
+    //     s[im2] = srcQ(i, j, k - 2, n);
+    //     s[im1] = srcQ(i, j, k - 1, n);
+    //     s[i0] = srcQ(i, j, k, n);
+    //     s[ip1] = srcQ(i, j, k + 1, n);
+    //     s[ip2] = srcQ(i, j, k + 2, n);
+    //   }
 
-        ppm_reconstruct(s, flat, sm, sp);
-        ppm_int_profile(sm, sp, s[i0], un, cc, dtdx, Ip[n], Im[n]);
-      }
+    //   ppm_reconstruct(s, flat, sm, sp);
+    //   ppm_int_profile(sm, sp, s[i0], un, cc, dtdx, Ip_src[n], Im_src[n]);
+    // }
 
-      // PeleC does source term tracing in pc_transx, pc_transy, and
-      // pc_transz. So to be consistent we remove the source term
-      // tracing here. However, Nyx and Castro do the source term
-      // tracing here instead of in the trans routines. If we wanted
-      // to do the tracing here, we would have to 1) remove the tracing
-      // in the trans routines AND 2) add the tracing in the pc_plm_x,
-      // pc_plm_y, pc_plm_z routines.
-      //
-      // To do the tracing here: Uncomment the chunk below and
-      // anything that uses Im_src and Ip_src.
+    for (int n = QFS; n < NUM_SPECIES + QFS; n++) {
 
-      // // source terms
-      // amrex::Real Ip_src[QVAR][3];
-      // amrex::Real Im_src[QVAR][3];
-
-      // for (int n = 0; n < QVAR; n++) {
-      //   if (idir == 0) {
-      //     s[im2] = srcQ(i - 2, j, k, n);
-      //     s[im1] = srcQ(i - 1, j, k, n);
-      //     s[i0] = srcQ(i, j, k, n);
-      //     s[ip1] = srcQ(i + 1, j, k, n);
-      //     s[ip2] = srcQ(i + 2, j, k, n);
-
-      //   } else if (idir == 1) {
-      //     s[im2] = srcQ(i, j - 2, k, n);
-      //     s[im1] = srcQ(i, j - 1, k, n);
-      //     s[i0] = srcQ(i, j, k, n);
-      //     s[ip1] = srcQ(i, j + 1, k, n);
-      //     s[ip2] = srcQ(i, j + 2, k, n);
-
-      //   } else {
-      //     s[im2] = srcQ(i, j, k - 2, n);
-      //     s[im1] = srcQ(i, j, k - 1, n);
-      //     s[i0] = srcQ(i, j, k, n);
-      //     s[ip1] = srcQ(i, j, k + 1, n);
-      //     s[ip2] = srcQ(i, j, k + 2, n);
-      //   }
-
-      //   ppm_reconstruct(s, flat, sm, sp);
-      //   ppm_int_profile(sm, sp, s[i0], un, cc, dtdx, Ip_src[n], Im_src[n]);
-      // }
-
-      for (int n = QFS; n < NUM_SPECIES + QFS; n++) {
-
-        // Plus state on face i
-        if (
-          (idir == 0 && i >= vlo[0]) || (idir == 1 && j >= vlo[1]) ||
-          (idir == 2 && k >= vlo[2])) {
-
-          // We have
-          //
-          // q_l = q_ref - Proj{(q_ref - I)}
-          //
-          // and Proj{} represents the characteristic projection.
-          // But for these, there is only 1-wave that matters, the u
-          // wave, so no projection is needed.  Since we are not
-          // projecting, the reference state doesn't matter
-
-          qp(i, j, k, n) = Im[n][1];
-        }
-
-        // Minus state on face i+1
-        if (idir == 0 && i <= vhi[0]) {
-          qm(i + 1, j, k, n) = Ip[n][1];
-
-        } else if (idir == 1 && j <= vhi[1]) {
-          qm(i, j + 1, k, n) = Ip[n][1];
-
-        } else if (idir == 2 && k <= vhi[2]) {
-          qm(i, j, k + 1, n) = Ip[n][1];
-        }
-      }
-
-      // plus state on face i
-
+      // Plus state on face i
       if (
         (idir == 0 && i >= vlo[0]) || (idir == 1 && j >= vlo[1]) ||
         (idir == 2 && k >= vlo[2])) {
 
-        // Set the reference state
-        // This will be the fastest moving state to the left --
-        // this is the method that Miller & Colella and Colella &
-        // Woodward use
-        amrex::Real rho_ref = Im[QRHO][0];
-        amrex::Real un_ref = Im[QUN][0];
+        // We have
+        //
+        // q_l = q_ref - Proj{(q_ref - I)}
+        //
+        // and Proj{} represents the characteristic projection.
+        // But for these, there is only 1-wave that matters, the u
+        // wave, so no projection is needed.  Since we are not
+        // projecting, the reference state doesn't matter
 
-        amrex::Real p_ref = Im[QPRES][0];
-        amrex::Real rhoe_g_ref = Im[QREINT][0];
+        qp(i, j, k, n) = Im[n][1];
+      }
 
-        rho_ref = amrex::max(rho_ref, SMALL_DENS);
-        amrex::Real rho_ref_inv = 1.0 / rho_ref;
-        p_ref = amrex::max(p_ref, SMALL_PRES);
+      // Minus state on face i+1
+      if (idir == 0 && i <= vhi[0]) {
+        qm(i + 1, j, k, n) = Ip[n][1];
 
-        amrex::Real massfrac_ref[NUM_SPECIES];
-        for (int sp = 0; sp < NUM_SPECIES; ++sp)
-          massfrac_ref[sp] = Im[sp + QFS][0];
+      } else if (idir == 1 && j <= vhi[1]) {
+        qm(i, j + 1, k, n) = Ip[n][1];
 
-        // For tracing
-        amrex::Real cc_ref = 0;
-        EOS::RPY2Cs(rho_ref, p_ref, massfrac_ref, cc_ref);
-        amrex::Real csq_ref = cc_ref * cc_ref;
-        amrex::Real cc_ref_inv = 1.0 / cc_ref;
-        amrex::Real h_g_ref = (p_ref + rhoe_g_ref) * rho_ref_inv;
+      } else if (idir == 2 && k <= vhi[2]) {
+        qm(i, j, k + 1, n) = Ip[n][1];
+      }
+    }
 
-        // *m are the jumps carried by un-c
-        // *p are the jumps carried by un+c
+    // plus state on face i
 
-        // Note: for the transverse velocities, the jump is carried
-        //       only by the u wave (the contact)
+    if (
+      (idir == 0 && i >= vlo[0]) || (idir == 1 && j >= vlo[1]) ||
+      (idir == 2 && k >= vlo[2])) {
 
-        // we also add the sources here so they participate in the tracing
-        amrex::Real dum = un_ref - Im[QUN][0] /*- hdt * Im_src[QUN][0]*/;
-        amrex::Real dptotm = p_ref - Im[QPRES][0] /*- hdt * Im_src[QPRES][0]*/;
+      // Set the reference state
+      // This will be the fastest moving state to the left --
+      // this is the method that Miller & Colella and Colella &
+      // Woodward use
+      amrex::Real rho_ref = Im[QRHO][0];
+      amrex::Real un_ref = Im[QUN][0];
 
-        amrex::Real drho = rho_ref - Im[QRHO][1] /*- hdt * Im_src[QRHO][1]*/;
-        amrex::Real dptot = p_ref - Im[QPRES][1] /*- hdt * Im_src[QPRES][1]*/;
-        amrex::Real drhoe_g =
-          rhoe_g_ref - Im[QREINT][1] /*- hdt * Im_src[QREINT][1]*/;
+      amrex::Real p_ref = Im[QPRES][0];
+      amrex::Real rhoe_g_ref = Im[QREINT][0];
 
-        amrex::Real dup = un_ref - Im[QUN][2] /*- hdt * Im_src[QUN][2]*/;
-        amrex::Real dptotp = p_ref - Im[QPRES][2] /*- hdt * Im_src[QPRES][2]*/;
+      rho_ref = amrex::max(rho_ref, SMALL_DENS);
+      amrex::Real rho_ref_inv = 1.0 / rho_ref;
+      p_ref = amrex::max(p_ref, SMALL_PRES);
 
-        // {rho, u, p, (rho e)} eigensystem
+      amrex::Real massfrac_ref[NUM_SPECIES];
+      for (int sp = 0; sp < NUM_SPECIES; ++sp)
+        massfrac_ref[sp] = Im[sp + QFS][0];
 
-        // These are analogous to the beta's from the original PPM
-        // paper (except we work with rho instead of tau).  This is
-        // simply (l . dq), where dq = qref - I(q)
+      // For tracing
+      amrex::Real cc_ref = 0;
+      EOS::RPY2Cs(rho_ref, p_ref, massfrac_ref, cc_ref);
+      amrex::Real csq_ref = cc_ref * cc_ref;
+      amrex::Real cc_ref_inv = 1.0 / cc_ref;
+      amrex::Real h_g_ref = (p_ref + rhoe_g_ref) * rho_ref_inv;
 
-        amrex::Real alpham = 0.5 * (dptotm * rho_ref_inv * cc_ref_inv - dum) *
-                             rho_ref * cc_ref_inv;
-        amrex::Real alphap = 0.5 * (dptotp * rho_ref_inv * cc_ref_inv + dup) *
-                             rho_ref * cc_ref_inv;
-        amrex::Real alpha0r = drho - dptot / csq_ref;
-        amrex::Real alpha0e_g = drhoe_g - dptot * h_g_ref / csq_ref;
+      // *m are the jumps carried by un-c
+      // *p are the jumps carried by un+c
 
-        alpham = un - cc > 0.0 ? 0.0 : -alpham;
-        alphap = un + cc > 0.0 ? 0.0 : -alphap;
-        alpha0r = un > 0.0 ? 0.0 : -alpha0r;
-        alpha0e_g = un > 0.0 ? 0.0 : -alpha0e_g;
+      // Note: for the transverse velocities, the jump is carried
+      //       only by the u wave (the contact)
 
-        // The final interface states are just
-        // q_s = q_ref - sum(l . dq) r
-        // note that the a{mpz}right as defined above have the minus already
-        qp(i, j, k, QRHO) =
+      // we also add the sources here so they participate in the tracing
+      amrex::Real dum = un_ref - Im[QUN][0] /*- hdt * Im_src[QUN][0]*/;
+      amrex::Real dptotm = p_ref - Im[QPRES][0] /*- hdt * Im_src[QPRES][0]*/;
+
+      amrex::Real drho = rho_ref - Im[QRHO][1] /*- hdt * Im_src[QRHO][1]*/;
+      amrex::Real dptot = p_ref - Im[QPRES][1] /*- hdt * Im_src[QPRES][1]*/;
+      amrex::Real drhoe_g =
+        rhoe_g_ref - Im[QREINT][1] /*- hdt * Im_src[QREINT][1]*/;
+
+      amrex::Real dup = un_ref - Im[QUN][2] /*- hdt * Im_src[QUN][2]*/;
+      amrex::Real dptotp = p_ref - Im[QPRES][2] /*- hdt * Im_src[QPRES][2]*/;
+
+      // {rho, u, p, (rho e)} eigensystem
+
+      // These are analogous to the beta's from the original PPM
+      // paper (except we work with rho instead of tau).  This is
+      // simply (l . dq), where dq = qref - I(q)
+
+      amrex::Real alpham =
+        0.5 * (dptotm * rho_ref_inv * cc_ref_inv - dum) * rho_ref * cc_ref_inv;
+      amrex::Real alphap =
+        0.5 * (dptotp * rho_ref_inv * cc_ref_inv + dup) * rho_ref * cc_ref_inv;
+      amrex::Real alpha0r = drho - dptot / csq_ref;
+      amrex::Real alpha0e_g = drhoe_g - dptot * h_g_ref / csq_ref;
+
+      alpham = un - cc > 0.0 ? 0.0 : -alpham;
+      alphap = un + cc > 0.0 ? 0.0 : -alphap;
+      alpha0r = un > 0.0 ? 0.0 : -alpha0r;
+      alpha0e_g = un > 0.0 ? 0.0 : -alpha0e_g;
+
+      // The final interface states are just
+      // q_s = q_ref - sum(l . dq) r
+      // note that the a{mpz}right as defined above have the minus already
+      qp(i, j, k, QRHO) =
+        amrex::max(SMALL_DENS, rho_ref + alphap + alpham + alpha0r);
+      qp(i, j, k, QUN) = un_ref + (alphap - alpham) * cc_ref * rho_ref_inv;
+      // qp(i,j,k,QREINT) = rhoe_g_ref + (alphap + alpham)*h_g_ref +
+      // alpha0e_g;
+      qp(i, j, k, QPRES) =
+        amrex::max(SMALL_PRES, p_ref + (alphap + alpham) * csq_ref);
+
+      // Transverse velocities -- there's no projection here, so we
+      // don't need a reference state.  We only care about the state
+      // traced under the middle wave
+
+      // Recall that I already takes the limit of the parabola
+      // in the event that the wave is not moving toward the
+      // interface
+      qp(i, j, k, QUT) = Im[QUT][1] /*+ hdt * Im_src[QUT][1]*/;
+      qp(i, j, k, QUTT) = Im[QUTT][1] /*+ hdt * Im_src[QUTT][1]*/;
+
+      // This allows the (rho e) to take advantage of (pressure > small_pres)
+      amrex::Real eint = 0;
+      amrex::Real massfrac_p[NUM_SPECIES];
+      for (int sp = 0; sp < NUM_SPECIES; ++sp)
+        massfrac_p[sp] = qp(i, j, k, sp + QFS);
+      EOS::RYP2E(qp(i, j, k, QRHO), massfrac_p, qp(i, j, k, QPRES), eint);
+      qp(i, j, k, QREINT) = qp(i, j, k, QRHO) * eint;
+    }
+
+    // minus state on face i + 1
+
+    if (
+      (idir == 0 && i <= vhi[0]) || (idir == 1 && j <= vhi[1]) ||
+      (idir == 2 && k <= vhi[2])) {
+
+      // Set the reference state
+      // This will be the fastest moving state to the right
+      amrex::Real rho_ref = Ip[QRHO][2];
+      amrex::Real un_ref = Ip[QUN][2];
+
+      amrex::Real p_ref = Ip[QPRES][2];
+      amrex::Real rhoe_g_ref = Ip[QREINT][2];
+
+      rho_ref = amrex::max(rho_ref, SMALL_DENS);
+      amrex::Real rho_ref_inv = 1.0 / rho_ref;
+      p_ref = amrex::max(p_ref, SMALL_PRES);
+
+      amrex::Real massfrac_ref[NUM_SPECIES];
+      for (int sp = 0; sp < NUM_SPECIES; ++sp)
+        massfrac_ref[sp] = Ip[sp + QFS][2];
+
+      // For tracing
+      amrex::Real cc_ref = 0;
+      EOS::RPY2Cs(rho_ref, p_ref, massfrac_ref, cc_ref);
+      amrex::Real csq_ref = cc_ref * cc_ref;
+      amrex::Real cc_ref_inv = 1.0 / cc_ref;
+      amrex::Real h_g_ref = (p_ref + rhoe_g_ref) * rho_ref_inv;
+
+      // *m are the jumps carried by u-c
+      // *p are the jumps carried by u+c
+
+      amrex::Real dum = un_ref - Ip[QUN][0] /*- hdt * Ip_src[QUN][0]*/;
+      amrex::Real dptotm = p_ref - Ip[QPRES][0] /*- hdt * Ip_src[QPRES][0]*/;
+
+      amrex::Real drho = rho_ref - Ip[QRHO][1] /*- hdt * Ip_src[QRHO][1]*/;
+      amrex::Real dptot = p_ref - Ip[QPRES][1] /*- hdt * Ip_src[QPRES][1]*/;
+      amrex::Real drhoe_g =
+        rhoe_g_ref - Ip[QREINT][1] /*- hdt * Ip_src[QREINT][1]*/;
+
+      amrex::Real dup = un_ref - Ip[QUN][2] /*- hdt * Ip_src[QUN][2]*/;
+      amrex::Real dptotp = p_ref - Ip[QPRES][2] /*- hdt * Ip_src[QPRES][2]*/;
+
+      // {rho, u, p, (rho e)} eigensystem
+
+      // These are analogous to the beta's from the original PPM
+      // paper (except we work with rho instead of tau).  This is
+      // simply (l . dq), where dq = qref - I(q)
+
+      amrex::Real alpham =
+        0.5 * (dptotm * rho_ref_inv * cc_ref_inv - dum) * rho_ref * cc_ref_inv;
+      amrex::Real alphap =
+        0.5 * (dptotp * rho_ref_inv * cc_ref_inv + dup) * rho_ref * cc_ref_inv;
+      amrex::Real alpha0r = drho - dptot / csq_ref;
+      amrex::Real alpha0e_g = drhoe_g - dptot * h_g_ref / csq_ref;
+
+      alpham = un - cc > 0.0 ? -alpham : 0.0;
+      alphap = un + cc > 0.0 ? -alphap : 0.0;
+      alpha0r = un > 0.0 ? -alpha0r : 0.0;
+      alpha0e_g = un > 0.0 ? -alpha0e_g : 0.0;
+
+      // The final interface states are just
+      // q_s = q_ref - sum (l . dq) r
+      // note that the a{mpz}left as defined above have the minus already
+      if (idir == 0) {
+        qm(i + 1, j, k, QRHO) =
           amrex::max(SMALL_DENS, rho_ref + alphap + alpham + alpha0r);
-        qp(i, j, k, QUN) = un_ref + (alphap - alpham) * cc_ref * rho_ref_inv;
-        // qp(i,j,k,QREINT) = rhoe_g_ref + (alphap + alpham)*h_g_ref +
+        qm(i + 1, j, k, QUN) =
+          un_ref + (alphap - alpham) * cc_ref * rho_ref_inv;
+        // qm(i+1,j,k,QREINT) = rhoe_g_ref + (alphap + alpham)*h_g_ref +
         // alpha0e_g;
-        qp(i, j, k, QPRES) =
+        qm(i + 1, j, k, QPRES) =
           amrex::max(SMALL_PRES, p_ref + (alphap + alpham) * csq_ref);
 
-        // Transverse velocities -- there's no projection here, so we
-        // don't need a reference state.  We only care about the state
-        // traced under the middle wave
+        // transverse velocities
+        qm(i + 1, j, k, QUT) = Ip[QUT][1] /*+ hdt * Ip_src[QUT][1]*/;
+        qm(i + 1, j, k, QUTT) = Ip[QUTT][1] /*+ hdt * Ip_src[QUTT][1]*/;
 
-        // Recall that I already takes the limit of the parabola
-        // in the event that the wave is not moving toward the
-        // interface
-        qp(i, j, k, QUT) = Im[QUT][1] /*+ hdt * Im_src[QUT][1]*/;
-        qp(i, j, k, QUTT) = Im[QUTT][1] /*+ hdt * Im_src[QUTT][1]*/;
-
-        // This allows the (rho e) to take advantage of (pressure > small_pres)
+        // This allows the (rho e) to take advantage of (pressure >
+        // small_pres)
         amrex::Real eint = 0;
-        amrex::Real massfrac_p[NUM_SPECIES];
+        amrex::Real massfrac_m[NUM_SPECIES];
         for (int sp = 0; sp < NUM_SPECIES; ++sp)
-          massfrac_p[sp] = qp(i, j, k, sp + QFS);
-        EOS::RYP2E(qp(i, j, k, QRHO), massfrac_p, qp(i, j, k, QPRES), eint);
-        qp(i, j, k, QREINT) = qp(i, j, k, QRHO) * eint;
-      }
+          massfrac_m[sp] = qm(i + 1, j, k, sp + QFS);
+        EOS::RYP2E(
+          qm(i + 1, j, k, QRHO), massfrac_m, qm(i + 1, j, k, QPRES), eint);
+        qm(i + 1, j, k, QREINT) = qm(i + 1, j, k, QRHO) * eint;
 
-      // minus state on face i + 1
+      } else if (idir == 1) {
+        qm(i, j + 1, k, QRHO) =
+          amrex::max(SMALL_DENS, rho_ref + alphap + alpham + alpha0r);
+        qm(i, j + 1, k, QUN) =
+          un_ref + (alphap - alpham) * cc_ref * rho_ref_inv;
+        // qm(i,j+1,k,QREINT) = rhoe_g_ref + (alphap + alpham)*h_g_ref +
+        // alpha0e_g;
+        qm(i, j + 1, k, QPRES) =
+          amrex::max(SMALL_PRES, p_ref + (alphap + alpham) * csq_ref);
 
-      if (
-        (idir == 0 && i <= vhi[0]) || (idir == 1 && j <= vhi[1]) ||
-        (idir == 2 && k <= vhi[2])) {
+        // transverse velocities
+        qm(i, j + 1, k, QUT) = Ip[QUT][1] /*+ hdt * Ip_src[QUT][1]*/;
+        qm(i, j + 1, k, QUTT) = Ip[QUTT][1] /*+ hdt * Ip_src[QUTT][1]*/;
 
-        // Set the reference state
-        // This will be the fastest moving state to the right
-        amrex::Real rho_ref = Ip[QRHO][2];
-        amrex::Real un_ref = Ip[QUN][2];
-
-        amrex::Real p_ref = Ip[QPRES][2];
-        amrex::Real rhoe_g_ref = Ip[QREINT][2];
-
-        rho_ref = amrex::max(rho_ref, SMALL_DENS);
-        amrex::Real rho_ref_inv = 1.0 / rho_ref;
-        p_ref = amrex::max(p_ref, SMALL_PRES);
-
-        amrex::Real massfrac_ref[NUM_SPECIES];
+        // This allows the (rho e) to take advantage of (pressure >
+        // small_pres)
+        amrex::Real eint = 0;
+        amrex::Real massfrac_m[NUM_SPECIES];
         for (int sp = 0; sp < NUM_SPECIES; ++sp)
-          massfrac_ref[sp] = Ip[sp + QFS][2];
+          massfrac_m[sp] = qm(i, j + 1, k, sp + QFS);
+        EOS::RYP2E(
+          qm(i, j + 1, k, QRHO), massfrac_m, qm(i, j + 1, k, QPRES), eint);
+        qm(i, j + 1, k, QREINT) = qm(i, j + 1, k, QRHO) * eint;
 
-        // For tracing
-        amrex::Real cc_ref = 0;
-        EOS::RPY2Cs(rho_ref, p_ref, massfrac_ref, cc_ref);
-        amrex::Real csq_ref = cc_ref * cc_ref;
-        amrex::Real cc_ref_inv = 1.0 / cc_ref;
-        amrex::Real h_g_ref = (p_ref + rhoe_g_ref) * rho_ref_inv;
+      } else if (idir == 2) {
+        qm(i, j, k + 1, QRHO) =
+          amrex::max(SMALL_DENS, rho_ref + alphap + alpham + alpha0r);
+        qm(i, j, k + 1, QUN) =
+          un_ref + (alphap - alpham) * cc_ref * rho_ref_inv;
+        // qm(i,j,k+1,QREINT) = rhoe_g_ref + (alphap + alpham)*h_g_ref +
+        // alpha0e_g;
+        qm(i, j, k + 1, QPRES) =
+          amrex::max(SMALL_PRES, p_ref + (alphap + alpham) * csq_ref);
 
-        // *m are the jumps carried by u-c
-        // *p are the jumps carried by u+c
+        // transverse velocities
+        qm(i, j, k + 1, QUT) = Ip[QUT][1] /*+ hdt * Ip_src[QUT][1]*/;
+        qm(i, j, k + 1, QUTT) = Ip[QUTT][1] /*+ hdt * Ip_src[QUTT][1]*/;
 
-        amrex::Real dum = un_ref - Ip[QUN][0] /*- hdt * Ip_src[QUN][0]*/;
-        amrex::Real dptotm = p_ref - Ip[QPRES][0] /*- hdt * Ip_src[QPRES][0]*/;
-
-        amrex::Real drho = rho_ref - Ip[QRHO][1] /*- hdt * Ip_src[QRHO][1]*/;
-        amrex::Real dptot = p_ref - Ip[QPRES][1] /*- hdt * Ip_src[QPRES][1]*/;
-        amrex::Real drhoe_g =
-          rhoe_g_ref - Ip[QREINT][1] /*- hdt * Ip_src[QREINT][1]*/;
-
-        amrex::Real dup = un_ref - Ip[QUN][2] /*- hdt * Ip_src[QUN][2]*/;
-        amrex::Real dptotp = p_ref - Ip[QPRES][2] /*- hdt * Ip_src[QPRES][2]*/;
-
-        // {rho, u, p, (rho e)} eigensystem
-
-        // These are analogous to the beta's from the original PPM
-        // paper (except we work with rho instead of tau).  This is
-        // simply (l . dq), where dq = qref - I(q)
-
-        amrex::Real alpham = 0.5 * (dptotm * rho_ref_inv * cc_ref_inv - dum) *
-                             rho_ref * cc_ref_inv;
-        amrex::Real alphap = 0.5 * (dptotp * rho_ref_inv * cc_ref_inv + dup) *
-                             rho_ref * cc_ref_inv;
-        amrex::Real alpha0r = drho - dptot / csq_ref;
-        amrex::Real alpha0e_g = drhoe_g - dptot * h_g_ref / csq_ref;
-
-        alpham = un - cc > 0.0 ? -alpham : 0.0;
-        alphap = un + cc > 0.0 ? -alphap : 0.0;
-        alpha0r = un > 0.0 ? -alpha0r : 0.0;
-        alpha0e_g = un > 0.0 ? -alpha0e_g : 0.0;
-
-        // The final interface states are just
-        // q_s = q_ref - sum (l . dq) r
-        // note that the a{mpz}left as defined above have the minus already
-        if (idir == 0) {
-          qm(i + 1, j, k, QRHO) =
-            amrex::max(SMALL_DENS, rho_ref + alphap + alpham + alpha0r);
-          qm(i + 1, j, k, QUN) =
-            un_ref + (alphap - alpham) * cc_ref * rho_ref_inv;
-          // qm(i+1,j,k,QREINT) = rhoe_g_ref + (alphap + alpham)*h_g_ref +
-          // alpha0e_g;
-          qm(i + 1, j, k, QPRES) =
-            amrex::max(SMALL_PRES, p_ref + (alphap + alpham) * csq_ref);
-
-          // transverse velocities
-          qm(i + 1, j, k, QUT) = Ip[QUT][1] /*+ hdt * Ip_src[QUT][1]*/;
-          qm(i + 1, j, k, QUTT) = Ip[QUTT][1] /*+ hdt * Ip_src[QUTT][1]*/;
-
-          // This allows the (rho e) to take advantage of (pressure >
-          // small_pres)
-          amrex::Real eint = 0;
-          amrex::Real massfrac_m[NUM_SPECIES];
-          for (int sp = 0; sp < NUM_SPECIES; ++sp)
-            massfrac_m[sp] = qm(i + 1, j, k, sp + QFS);
-          EOS::RYP2E(
-            qm(i + 1, j, k, QRHO), massfrac_m, qm(i + 1, j, k, QPRES), eint);
-          qm(i + 1, j, k, QREINT) = qm(i + 1, j, k, QRHO) * eint;
-
-        } else if (idir == 1) {
-          qm(i, j + 1, k, QRHO) =
-            amrex::max(SMALL_DENS, rho_ref + alphap + alpham + alpha0r);
-          qm(i, j + 1, k, QUN) =
-            un_ref + (alphap - alpham) * cc_ref * rho_ref_inv;
-          // qm(i,j+1,k,QREINT) = rhoe_g_ref + (alphap + alpham)*h_g_ref +
-          // alpha0e_g;
-          qm(i, j + 1, k, QPRES) =
-            amrex::max(SMALL_PRES, p_ref + (alphap + alpham) * csq_ref);
-
-          // transverse velocities
-          qm(i, j + 1, k, QUT) = Ip[QUT][1] /*+ hdt * Ip_src[QUT][1]*/;
-          qm(i, j + 1, k, QUTT) = Ip[QUTT][1] /*+ hdt * Ip_src[QUTT][1]*/;
-
-          // This allows the (rho e) to take advantage of (pressure >
-          // small_pres)
-          amrex::Real eint = 0;
-          amrex::Real massfrac_m[NUM_SPECIES];
-          for (int sp = 0; sp < NUM_SPECIES; ++sp)
-            massfrac_m[sp] = qm(i, j + 1, k, sp + QFS);
-          EOS::RYP2E(
-            qm(i, j + 1, k, QRHO), massfrac_m, qm(i, j + 1, k, QPRES), eint);
-          qm(i, j + 1, k, QREINT) = qm(i, j + 1, k, QRHO) * eint;
-
-        } else if (idir == 2) {
-          qm(i, j, k + 1, QRHO) =
-            amrex::max(SMALL_DENS, rho_ref + alphap + alpham + alpha0r);
-          qm(i, j, k + 1, QUN) =
-            un_ref + (alphap - alpham) * cc_ref * rho_ref_inv;
-          // qm(i,j,k+1,QREINT) = rhoe_g_ref + (alphap + alpham)*h_g_ref +
-          // alpha0e_g;
-          qm(i, j, k + 1, QPRES) =
-            amrex::max(SMALL_PRES, p_ref + (alphap + alpham) * csq_ref);
-
-          // transverse velocities
-          qm(i, j, k + 1, QUT) = Ip[QUT][1] /*+ hdt * Ip_src[QUT][1]*/;
-          qm(i, j, k + 1, QUTT) = Ip[QUTT][1] /*+ hdt * Ip_src[QUTT][1]*/;
-
-          // This allows the (rho e) to take advantage of (pressure >
-          // small_pres)
-          amrex::Real eint = 0;
-          amrex::Real massfrac_m[NUM_SPECIES];
-          for (int sp = 0; sp < NUM_SPECIES; ++sp)
-            massfrac_m[sp] = qm(i, j, k + 1, sp + QFS);
-          EOS::RYP2E(
-            qm(i, j, k + 1, QRHO), massfrac_m, qm(i, j, k + 1, QPRES), eint);
-          qm(i, j, k + 1, QREINT) = qm(i, j, k + 1, QRHO) * eint;
-        }
+        // This allows the (rho e) to take advantage of (pressure >
+        // small_pres)
+        amrex::Real eint = 0;
+        amrex::Real massfrac_m[NUM_SPECIES];
+        for (int sp = 0; sp < NUM_SPECIES; ++sp)
+          massfrac_m[sp] = qm(i, j, k + 1, sp + QFS);
+        EOS::RYP2E(
+          qm(i, j, k + 1, QRHO), massfrac_m, qm(i, j, k + 1, QPRES), eint);
+        qm(i, j, k + 1, QREINT) = qm(i, j, k + 1, QRHO) * eint;
       }
-    });
+    }
+  });
 }


### PR DESCRIPTION
`PPM.cpp` and `Hydro.cpp` also required a `clang-format` using the latest llvm.