### PR TITLE
The index mapping need to account for auxiliary variables.

### DIFF
--- a/SourceCpp/IndexDefines.cpp
+++ b/SourceCpp/IndexDefines.cpp
@@ -21,5 +21,10 @@ init()
     qpassMap[curMapIndx] = i + QFS;
     curMapIndx++;
   }
+  for (int i = 0; i != NUM_AUX; ++i) {
+    upassMap[curMapIndx] = i + UFX;
+    qpassMap[curMapIndx] = i + QFX;
+    curMapIndx++;
+  }
 }
 } // namespace indxmap


### PR DESCRIPTION
The option to add auxiliary variables failed in weird ways because the `qpassMap` and `upassMap` were not accounting for `AUX_VAR`.