### PR TITLE
Solve loophole static analysis found where non_react_src could be uninitialized

### DIFF
--- a/SourceCpp/React.cpp
+++ b/SourceCpp/React.cpp
@@ -36,20 +36,21 @@ PeleC::react_state(
   prefetchToDevice(S_new);
 
   // Create a MultiFab with all of the non-reacting source terms.
-
   amrex::MultiFab non_react_src_tmp, *non_react_src;
 
-  if (aux_src == nullptr || react_init) {
+  if (react_init) {
     non_react_src_tmp.define(grids, dmap, NVAR, ng, amrex::MFInfo(), Factory());
     non_react_src_tmp.setVal(0);
     non_react_src = &non_react_src_tmp;
-  }
-
-  // only do this if we are not at the first step
-  if (!react_init) {
+  } else {
+    // Only do this if we are not at the first step
     // Build non-reacting source term, and an S_new that does not include
     // reactions
     if (aux_src == nullptr) {
+      non_react_src_tmp.define(
+        grids, dmap, NVAR, ng, amrex::MFInfo(), Factory());
+      non_react_src_tmp.setVal(0);
+      non_react_src = &non_react_src_tmp;
       for (int n = 0; n < src_list.size(); ++n) {
         amrex::MultiFab::Saxpy(
           non_react_src_tmp, 0.5, *new_sources[src_list[n]], 0, 0, NVAR, ng);

--- a/SourceCpp/React.cpp
+++ b/SourceCpp/React.cpp
@@ -36,9 +36,10 @@ PeleC::react_state(
   prefetchToDevice(S_new);
 
   // Create a MultiFab with all of the non-reacting source terms.
-  amrex::MultiFab non_react_src_tmp, *non_react_src;
+  amrex::MultiFab* non_react_src = NULL;
 
   if (react_init) {
+    amrex::MultiFab non_react_src_tmp;
     non_react_src_tmp.define(grids, dmap, NVAR, ng, amrex::MFInfo(), Factory());
     non_react_src_tmp.setVal(0);
     non_react_src = &non_react_src_tmp;
@@ -47,6 +48,7 @@ PeleC::react_state(
     // Build non-reacting source term, and an S_new that does not include
     // reactions
     if (aux_src == nullptr) {
+      amrex::MultiFab non_react_src_tmp;
       non_react_src_tmp.define(
         grids, dmap, NVAR, ng, amrex::MFInfo(), Factory());
       non_react_src_tmp.setVal(0);

--- a/SourceCpp/React.cpp
+++ b/SourceCpp/React.cpp
@@ -36,10 +36,10 @@ PeleC::react_state(
   prefetchToDevice(S_new);
 
   // Create a MultiFab with all of the non-reacting source terms.
+  amrex::MultiFab non_react_src_tmp;
   amrex::MultiFab* non_react_src = NULL;
 
   if (react_init) {
-    amrex::MultiFab non_react_src_tmp;
     non_react_src_tmp.define(grids, dmap, NVAR, ng, amrex::MFInfo(), Factory());
     non_react_src_tmp.setVal(0);
     non_react_src = &non_react_src_tmp;
@@ -48,7 +48,6 @@ PeleC::react_state(
     // Build non-reacting source term, and an S_new that does not include
     // reactions
     if (aux_src == nullptr) {
-      amrex::MultiFab non_react_src_tmp;
       non_react_src_tmp.define(
         grids, dmap, NVAR, ng, amrex::MFInfo(), Factory());
       non_react_src_tmp.setVal(0);


### PR DESCRIPTION
I think this was a false positive from my analysis and I don't think `non_react_src` could have ever been uninitialized, but I think fusing the `if` condition should solve this. @hsitaram Please verify the change in logic still makes sense.