### PR TITLE
Pistonbowl fix by clipping/normalizing reaction mass fractions

### DIFF
--- a/SourceCpp/Params/_cpp_parameters
+++ b/SourceCpp/Params/_cpp_parameters
@@ -380,7 +380,7 @@ adaptrk_nsubsteps_guess      int           50                 n
 adaptrk_errtol               Real          1e-16              n
 
 #flag to clean the state for the reactions
-do_clean_react_state         int           1                  n
+clean_react_massfrac         int           1                  n
 
 #-----------------------------------------------------------------------------
 # category: parallelization

--- a/SourceCpp/Params/_cpp_parameters
+++ b/SourceCpp/Params/_cpp_parameters
@@ -368,16 +368,19 @@ disable_shock_burning        int           0
 chem_integrator              int           1                  n
 
 #explict RK chemistry integrator options (minimum substeps)
-adaptrk_nsubsteps_min        int          20                  n
+adaptrk_nsubsteps_min        int           20                 n
 
 #explict RK chemistry integrator options (maximum substeps)
-adaptrk_nsubsteps_max        int          300                 n
+adaptrk_nsubsteps_max        int           300                n
 
 #explict RK chemistry integrator options (guess substeps)
-adaptrk_nsubsteps_guess      int          50                  n
+adaptrk_nsubsteps_guess      int           50                 n
 
 #explict RK chemistry integrator options (absolute error tol.)
 adaptrk_errtol               Real          1e-16              n
+
+#flag to clean the state for the reactions
+do_clean_react_state         int           1                  n
 
 #-----------------------------------------------------------------------------
 # category: parallelization

--- a/SourceCpp/Params/param_includes/pelec_defaults.H
+++ b/SourceCpp/Params/param_includes/pelec_defaults.H
@@ -103,7 +103,7 @@ int PeleC::adaptrk_nsubsteps_min = 20;
 int PeleC::adaptrk_nsubsteps_max = 300;
 int PeleC::adaptrk_nsubsteps_guess = 50;
 amrex::Real PeleC::adaptrk_errtol = 1e-16;
-int PeleC::do_clean_react_state = 1;
+int PeleC::clean_react_massfrac = 1;
 int PeleC::bndry_func_thread_safe = 1;
 #ifdef AMREX_DEBUG
 int PeleC::print_energy_diagnostics = 1;

--- a/SourceCpp/Params/param_includes/pelec_defaults.H
+++ b/SourceCpp/Params/param_includes/pelec_defaults.H
@@ -103,6 +103,7 @@ int PeleC::adaptrk_nsubsteps_min = 20;
 int PeleC::adaptrk_nsubsteps_max = 300;
 int PeleC::adaptrk_nsubsteps_guess = 50;
 amrex::Real PeleC::adaptrk_errtol = 1e-16;
+int PeleC::do_clean_react_state = 1;
 int PeleC::bndry_func_thread_safe = 1;
 #ifdef AMREX_DEBUG
 int PeleC::print_energy_diagnostics = 1;

--- a/SourceCpp/Params/param_includes/pelec_params.H
+++ b/SourceCpp/Params/param_includes/pelec_params.H
@@ -99,7 +99,7 @@ static int adaptrk_nsubsteps_min;
 static int adaptrk_nsubsteps_max;
 static int adaptrk_nsubsteps_guess;
 static amrex::Real adaptrk_errtol;
-static int do_clean_react_state;
+static int clean_react_massfrac;
 static int bndry_func_thread_safe;
 static int print_energy_diagnostics;
 static int track_grid_losses;

--- a/SourceCpp/Params/param_includes/pelec_params.H
+++ b/SourceCpp/Params/param_includes/pelec_params.H
@@ -99,6 +99,7 @@ static int adaptrk_nsubsteps_min;
 static int adaptrk_nsubsteps_max;
 static int adaptrk_nsubsteps_guess;
 static amrex::Real adaptrk_errtol;
+static int do_clean_react_state;
 static int bndry_func_thread_safe;
 static int print_energy_diagnostics;
 static int track_grid_losses;

--- a/SourceCpp/Params/param_includes/pelec_queries.H
+++ b/SourceCpp/Params/param_includes/pelec_queries.H
@@ -99,7 +99,7 @@ pp.query("adaptrk_nsubsteps_min", adaptrk_nsubsteps_min);
 pp.query("adaptrk_nsubsteps_max", adaptrk_nsubsteps_max);
 pp.query("adaptrk_nsubsteps_guess", adaptrk_nsubsteps_guess);
 pp.query("adaptrk_errtol", adaptrk_errtol);
-pp.query("do_clean_react_state", do_clean_react_state);
+pp.query("clean_react_massfrac", clean_react_massfrac);
 pp.query("bndry_func_thread_safe", bndry_func_thread_safe);
 pp.query("print_energy_diagnostics", print_energy_diagnostics);
 pp.query("track_grid_losses", track_grid_losses);

--- a/SourceCpp/Params/param_includes/pelec_queries.H
+++ b/SourceCpp/Params/param_includes/pelec_queries.H
@@ -99,6 +99,7 @@ pp.query("adaptrk_nsubsteps_min", adaptrk_nsubsteps_min);
 pp.query("adaptrk_nsubsteps_max", adaptrk_nsubsteps_max);
 pp.query("adaptrk_nsubsteps_guess", adaptrk_nsubsteps_guess);
 pp.query("adaptrk_errtol", adaptrk_errtol);
+pp.query("do_clean_react_state", do_clean_react_state);
 pp.query("bndry_func_thread_safe", bndry_func_thread_safe);
 pp.query("print_energy_diagnostics", print_energy_diagnostics);
 pp.query("track_grid_losses", track_grid_losses);

--- a/SourceCpp/Params/parse_pelec_params.py
+++ b/SourceCpp/Params/parse_pelec_params.py
@@ -105,7 +105,7 @@ class Param(object):
         # into PeleC.cpp
 
         if self.dtype == "int":
-            tstr = "int         {}::{}".format(self.cpp_class, self.cpp_var_name)
+            tstr = "int {}::{}".format(self.cpp_class, self.cpp_var_name)
         elif self.dtype == "Real":
             tstr = "amrex::Real {}::{}".format(self.cpp_class, self.cpp_var_name)
         elif self.dtype == "string":

--- a/SourceCpp/React.H
+++ b/SourceCpp/React.H
@@ -41,7 +41,8 @@ clean_react_state(
   const amrex::Real temp,
   const amrex::Real rho,
   amrex::Real* rY,
-  amrex::Real & eint){
+  amrex::Real& eint)
+{
 
   amrex::Real Y_old[NUM_SPECIES];
   for (int n = 0; n < NUM_SPECIES; n++) {

--- a/SourceCpp/React.H
+++ b/SourceCpp/React.H
@@ -37,7 +37,7 @@ const amrex::Real err_rk64[6] = {
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-react_clean_state(
+clean_react_state(
   const amrex::Real temp,
   const amrex::Real rho,
   amrex::Real* rY,

--- a/SourceCpp/React.H
+++ b/SourceCpp/React.H
@@ -38,10 +38,10 @@ AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
 clean_react_state(
-  const amrex::Real temp,
+  const amrex::Real /*temp*/,
   const amrex::Real rho,
   amrex::Real* rY,
-  amrex::Real& eint)
+  amrex::Real& /*eint*/)
 {
 
   amrex::Real Y_old[NUM_SPECIES];

--- a/SourceCpp/React.H
+++ b/SourceCpp/React.H
@@ -117,7 +117,8 @@ pc_expl_reactions(
   const int nsteps_max,
   const int nsteps_guess,
   const amrex::Real errtol,
-  const int do_update)
+  const int do_update,
+  const int clean_react_massfrac)
 {
 #ifdef AMREX_USE_GPU
   // having a global __constant__ variable is slower than having this in local
@@ -193,6 +194,9 @@ pc_expl_reactions(
   amrex::Real urk_carryover[NVAR] = {};
   for (int n = 0; n < NVAR; ++n)
     urk[n] = sold(i, j, k, n);
+  if (clean_react_massfrac == 1) {
+    clip_normalize_rY(urk[URHO], &urk[UFS]);
+  }
   amrex::Real urk_err[NVAR] = {};
 
   // using rho instead of rho_old for

--- a/SourceCpp/React.H
+++ b/SourceCpp/React.H
@@ -37,32 +37,38 @@ const amrex::Real err_rk64[6] = {
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-clean_react_state(
-  const amrex::Real /*temp*/,
-  const amrex::Real rho,
-  amrex::Real* rY,
-  amrex::Real& /*eint*/)
+clip_normalize_Y(amrex::Real* Y)
 {
-
-  amrex::Real Y_old[NUM_SPECIES];
-  for (int n = 0; n < NUM_SPECIES; n++) {
-    Y_old[n] = rY[n] / rho;
-  }
 
   // Clip
   amrex::Real sum = 0.0;
   for (int n = 0; n < NUM_SPECIES; n++) {
-    Y_old[n] = amrex::max(amrex::min(Y_old[n], 1.0), 0.0);
-    sum += Y_old[n];
+    Y[n] = amrex::max(amrex::min(Y[n], 1.0), 0.0);
+    sum += Y[n];
   }
 
   // Normalize
   for (int n = 0; n < NUM_SPECIES; n++) {
-    Y_old[n] /= sum;
+    Y[n] /= sum;
+  }
+}
+
+AMREX_GPU_DEVICE
+AMREX_FORCE_INLINE
+void
+clip_normalize_rY(const amrex::Real rho, amrex::Real* rY)
+{
+
+  amrex::Real Y[NUM_SPECIES];
+  const amrex::Real rhoInv = 1.0 / rho;
+  for (int n = 0; n < NUM_SPECIES; n++) {
+    Y[n] = rY[n] * rhoInv;
   }
 
+  clip_normalize_Y(Y);
+
   for (int n = 0; n < NUM_SPECIES; n++) {
-    rY[n] = Y_old[n] * rho;
+    rY[n] = Y[n] * rho;
   }
 }
 

--- a/SourceCpp/React.H
+++ b/SourceCpp/React.H
@@ -34,6 +34,37 @@ const amrex::Real err_rk64[6] = {
 };
 #endif
 
+AMREX_GPU_DEVICE
+AMREX_FORCE_INLINE
+void
+react_clean_state(
+  const amrex::Real temp,
+  const amrex::Real rho,
+  amrex::Real* rY,
+  amrex::Real & eint){
+
+  amrex::Real Y_old[NUM_SPECIES];
+  for (int n = 0; n < NUM_SPECIES; n++) {
+    Y_old[n] = rY[n] / rho;
+  }
+
+  // Clip
+  amrex::Real sum = 0.0;
+  for (int n = 0; n < NUM_SPECIES; n++) {
+    Y_old[n] = amrex::max(amrex::min(Y_old[n], 1.0), 0.0);
+    sum += Y_old[n];
+  }
+
+  // Normalize
+  for (int n = 0; n < NUM_SPECIES; n++) {
+    Y_old[n] /= sum;
+  }
+
+  for (int n = 0; n < NUM_SPECIES; n++) {
+    rY[n] = Y_old[n] * rho;
+  }
+}
+
 // Timestep adapter
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE

--- a/SourceCpp/React.cpp
+++ b/SourceCpp/React.cpp
@@ -102,6 +102,8 @@ PeleC::react_state(
       // TODO: Update here? Or just get reaction source?
       const int do_update = react_init ? 0 : 1;
 
+      const int captured_clean_react_massfrac = clean_react_massfrac;
+
 #ifdef PELEC_USE_EB
       const auto& flag_fab = flags[mfi];
       amrex::FabType typ = flag_fab.getType(bx);
@@ -130,7 +132,8 @@ PeleC::react_state(
             bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
               pc_expl_reactions(
                 i, j, k, sold_arr, snew_arr, nonrs_arr, I_R, dt, nsubsteps_min,
-                nsubsteps_max, nsubsteps_guess, errtol, do_update);
+                nsubsteps_max, nsubsteps_guess, errtol, do_update,
+                captured_clean_react_massfrac);
             });
         } else if (chem_integrator == 2) {
 #ifdef USE_SUNDIALS_PP
@@ -148,8 +151,6 @@ PeleC::react_state(
           amrex::Real* rY_src_in;
           amrex::Real* re_in;
           amrex::Real* re_src_in;
-
-          const int captured_clean_react_massfrac = clean_react_massfrac;
 
 #ifdef AMREX_USE_CUDA
           cudaError_t cuda_status = cudaSuccess;

--- a/SourceCpp/React.cpp
+++ b/SourceCpp/React.cpp
@@ -208,8 +208,10 @@ PeleC::react_state(
               rY_in[offset * (NUM_SPECIES + 1) + NUM_SPECIES] =
                 sold_arr(i, j, k, UTEMP);
 
-              if(captured_clean_react_state == 1){
-                clean_react_state(sold_arr(i, j, k, UTEMP), sold_arr(i, j, k, URHO), &rY_in[offset * (NUM_SPECIES + 1)], e_old);
+              if (captured_clean_react_state == 1) {
+                clean_react_state(
+                  sold_arr(i, j, k, UTEMP), sold_arr(i, j, k, URHO),
+                  &rY_in[offset * (NUM_SPECIES + 1)], e_old);
               }
 
               re_in[offset] = rho_old * e_old;

--- a/SourceCpp/React.cpp
+++ b/SourceCpp/React.cpp
@@ -74,8 +74,6 @@ PeleC::react_state(
   react_src.setVal(0.0);
   prefetchToDevice(react_src);
 
-  const int captured_clean_react_state = do_clean_react_state;
-
 #ifdef PELEC_USE_EB
   auto const& fact =
     dynamic_cast<amrex::EBFArrayBoxFactory const&>(S_new.Factory());
@@ -150,6 +148,8 @@ PeleC::react_state(
           amrex::Real* rY_src_in;
           amrex::Real* re_in;
           amrex::Real* re_src_in;
+
+          const int captured_clean_react_state = do_clean_react_state;
 
 #ifdef AMREX_USE_CUDA
           cudaError_t cuda_status = cudaSuccess;

--- a/SourceCpp/React.cpp
+++ b/SourceCpp/React.cpp
@@ -149,7 +149,7 @@ PeleC::react_state(
           amrex::Real* re_in;
           amrex::Real* re_src_in;
 
-          const int captured_clean_react_state = do_clean_react_state;
+          const int captured_clean_react_massfrac = clean_react_massfrac;
 
 #ifdef AMREX_USE_CUDA
           cudaError_t cuda_status = cudaSuccess;
@@ -208,10 +208,9 @@ PeleC::react_state(
               rY_in[offset * (NUM_SPECIES + 1) + NUM_SPECIES] =
                 sold_arr(i, j, k, UTEMP);
 
-              if (captured_clean_react_state == 1) {
-                clean_react_state(
-                  sold_arr(i, j, k, UTEMP), sold_arr(i, j, k, URHO),
-                  &rY_in[offset * (NUM_SPECIES + 1)], e_old);
+              if (captured_clean_react_massfrac == 1) {
+                clip_normalize_rY(
+                  sold_arr(i, j, k, URHO), &rY_in[offset * (NUM_SPECIES + 1)]);
               }
 
               re_in[offset] = rho_old * e_old;

--- a/SourceCpp/React.cpp
+++ b/SourceCpp/React.cpp
@@ -74,6 +74,8 @@ PeleC::react_state(
   react_src.setVal(0.0);
   prefetchToDevice(react_src);
 
+  const int captured_clean_react_state = do_clean_react_state;
+
 #ifdef PELEC_USE_EB
   auto const& fact =
     dynamic_cast<amrex::EBFArrayBoxFactory const&>(S_new.Factory());
@@ -206,7 +208,9 @@ PeleC::react_state(
               rY_in[offset * (NUM_SPECIES + 1) + NUM_SPECIES] =
                 sold_arr(i, j, k, UTEMP);
 
-              react_clean_state(sold_arr(i, j, k, UTEMP), sold_arr(i, j, k, URHO), &rY_in[offset * (NUM_SPECIES + 1)], e_old);
+              if(captured_clean_react_state == 1){
+                clean_react_state(sold_arr(i, j, k, UTEMP), sold_arr(i, j, k, URHO), &rY_in[offset * (NUM_SPECIES + 1)], e_old);
+              }
 
               re_in[offset] = rho_old * e_old;
               re_src_in[offset] = rhoedot_ext;

--- a/SourceCpp/React.cpp
+++ b/SourceCpp/React.cpp
@@ -205,6 +205,9 @@ PeleC::react_state(
               }
               rY_in[offset * (NUM_SPECIES + 1) + NUM_SPECIES] =
                 sold_arr(i, j, k, UTEMP);
+
+              react_clean_state(sold_arr(i, j, k, UTEMP), sold_arr(i, j, k, URHO), &rY_in[offset * (NUM_SPECIES + 1)], e_old);
+
               re_in[offset] = rho_old * e_old;
               re_src_in[offset] = rhoedot_ext;
             });


### PR DESCRIPTION
This PR introduces an optional clipping and renormalizing of the mass fractions that are used to compute the reactions. It does not clip/renormalize the mass fraction state so negative mass fractions will still be observed in the state. However these negative mass fractions will not negatively affect the reaction computations. 

This PR fixes the pistonbowl failures we were observing, arising from the creation of negative mass fractions. The attached [input file](https://github.com/AMReX-Combustion/PeleC/files/5725198/inputs-3d.txt) was used for this simulation (note the increased background temperature to get the flow to burn quicker) and can be used with`pelec.do_clean_react_state=0` or `1` to observe failure or success of the simulation, respectively. The resulting temperature field looks like: 
![movie](https://user-images.githubusercontent.com/15038415/102795252-c921e180-4369-11eb-9fab-98667b6bfc73.gif)

Negative mass fractions are observed in the flow field and these reach a minimum of `-1e-5` for CH4 and `-1e-6` for HO2 mass fractions.

I am not going to argue that this is the right long term fix. That would require furthering Bruce and Mahesh's work in understanding the specifics of the discretization scheme that lead to negative mass fractions. Specifically, it would require a modification of the discretization scheme to improve scalar boundedness (a thing we know is not part of the discretization specs). However, this fix improves robustness of the code and allows us to proceed with simulations such as the pistonbowl. Happy to engage in discussion on how we want to proceed in the near term/long term.

One thing to note is that this is only implemented for the implicit chem integrator. I can do it for the explicit as well if desired.

Thanks to @hsitaram for suggesting this specific version of the fix. Thanks to @baperry2 and @nataraj2 for trying initial simulations of this case indicating that this may be a way to proceed.


