### PR TITLE
Energy Equation in Explicit Chemistry Integrator

### DIFF
--- a/SourceCpp/React.H
+++ b/SourceCpp/React.H
@@ -144,7 +144,7 @@ pc_expl_reactions(
   amrex::Real rhoydot_ext[NUM_SPECIES];
   for (int n = 0; n < NUM_SPECIES; n++)
     rhoydot_ext[n] = nr_src(i, j, k, UFS + n);
-
+         
   // RK dts
   amrex::Real dt_rk = dt_react / nsteps_guess;
   const amrex::Real dt_min = dt_react / nsteps_max;
@@ -173,40 +173,26 @@ pc_expl_reactions(
 
     amrex::Real wdot[NUM_SPECIES] = {};
     amrex::Real massfrac[NUM_SPECIES] = {};
-    amrex::Real ei[NUM_SPECIES] = {};
     for (int stage = 0; stage < 6; stage++) {
+      // Find up to date temperature and mass fractions
       rhoInv = 1.0 / urk[URHO];
       for (int n = 0; n < NUM_SPECIES; ++n) {
         massfrac[n] = urk[UFS + n] * rhoInv;
       }
-
-      EOS::RTY2WDOT(urk[URHO], urk[UTEMP], massfrac, wdot);
-
       amrex::Real Temp_rk;
       EOS::EY2T(rhoe_rk / urk[URHO], massfrac, Temp_rk);
 
+      // Compute species source terms
+      EOS::RTY2WDOT(urk[URHO], Temp_rk, massfrac, wdot);
       for (int n = 0; n < NUM_SPECIES; ++n)
         wdot[n] += rhoydot_ext[n];
-
-      // get mixture specific heat
-      amrex::Real cv;
-      EOS::TY2Cv(urk[UTEMP], massfrac, cv);
-
-      // get species internal energies
-      EOS::T2Ei(Temp_rk, ei);
-
-      // update temperature eqn source term
-      amrex::Real tempsrc = rhoedot_ext;
-      for (int n = 0; n < NUM_SPECIES; ++n)
-        tempsrc -= wdot[n] * ei[n];
-      tempsrc /= (urk[URHO] * cv);
 
       /*================== Update urk_err =================== */
       // Species
       for (int n = 0; n < NUM_SPECIES; ++n)
         urk_err[UFS + n] += err_rk64[stage] * dt_rk * wdot[n];
-      // Temperature
-      urk_err[UTEMP] += err_rk64[stage] * dt_rk * tempsrc;
+      // Energy
+      urk_err[UEDEN] += err_rk64[stage] * dt_rk * rhoedot_ext;
 
       /*================== Update Stage solution =================== */
       // Species
@@ -214,8 +200,6 @@ pc_expl_reactions(
         urk[UFS + n] =
           urk_carryover[UFS + n] + alpha_rk64[stage] * dt_rk * wdot[n];
       }
-      // Temperature
-      urk[UTEMP] = urk_carryover[UTEMP] + alpha_rk64[stage] * dt_rk * tempsrc;
       // update energy
       rhoe_rk = rhoe_carryover + alpha_rk64[stage] * dt_rk * rhoedot_ext;
 
@@ -225,8 +209,6 @@ pc_expl_reactions(
         urk_carryover[UFS + n] =
           urk[UFS + n] + beta_rk64[stage] * dt_rk * wdot[n];
       }
-      // Temperature
-      urk_carryover[UTEMP] = urk[UTEMP] + beta_rk64[stage] * dt_rk * tempsrc;
       // update energy
       rhoe_carryover = rhoe_rk + beta_rk64[stage] * dt_rk * rhoedot_ext;
 

--- a/SourceCpp/React.H
+++ b/SourceCpp/React.H
@@ -144,7 +144,7 @@ pc_expl_reactions(
   amrex::Real rhoydot_ext[NUM_SPECIES];
   for (int n = 0; n < NUM_SPECIES; n++)
     rhoydot_ext[n] = nr_src(i, j, k, UFS + n);
-         
+    
   // RK dts
   amrex::Real dt_rk = dt_react / nsteps_guess;
   const amrex::Real dt_min = dt_react / nsteps_max;

--- a/SourceCpp/React.H
+++ b/SourceCpp/React.H
@@ -164,6 +164,12 @@ pc_expl_reactions(
 
   // Do RK time-stepping
   // int steps = 0;
+  amrex::Real massfrac[NUM_SPECIES] = {};
+  rhoInv = 1.0 / urk[URHO];
+  for (int n = 0; n < NUM_SPECIES; ++n) {
+    massfrac[n] = urk[UFS + n] * rhoInv;
+  }
+
   while (updt_time < dt_react) {
     for (int n = 0; n < NVAR; n++) {
       urk_carryover[n] = urk[n];
@@ -172,18 +178,9 @@ pc_expl_reactions(
     amrex::Real rhoe_carryover = rhoe_rk;
 
     amrex::Real wdot[NUM_SPECIES] = {};
-    amrex::Real massfrac[NUM_SPECIES] = {};
     for (int stage = 0; stage < 6; stage++) {
-      // Find up to date temperature and mass fractions
-      rhoInv = 1.0 / urk[URHO];
-      for (int n = 0; n < NUM_SPECIES; ++n) {
-        massfrac[n] = urk[UFS + n] * rhoInv;
-      }
-      amrex::Real Temp_rk;
-      EOS::EY2T(rhoe_rk / urk[URHO], massfrac, Temp_rk);
-
       // Compute species source terms
-      EOS::RTY2WDOT(urk[URHO], Temp_rk, massfrac, wdot);
+      EOS::RTY2WDOT(urk[URHO], urk[UTEMP], massfrac, wdot);
       for (int n = 0; n < NUM_SPECIES; ++n)
         wdot[n] += rhoydot_ext[n];
 
@@ -212,10 +209,15 @@ pc_expl_reactions(
       // update energy
       rhoe_carryover = rhoe_rk + beta_rk64[stage] * dt_rk * rhoedot_ext;
 
-      /*================= Update urk[rho] ========================= */
+      /*================= Update urk[rho] and urk[temp] =================== */
       urk[URHO] = 0.0;
       for (int n = 0; n < NUM_SPECIES; ++n)
         urk[URHO] += urk[UFS + n];
+      rhoInv = 1.0 / urk[URHO];
+      for (int n = 0; n < NUM_SPECIES; ++n) {
+	massfrac[n] = urk[UFS + n] * rhoInv;
+      }
+      EOS::EY2T(rhoe_rk / urk[URHO], massfrac, urk[UTEMP]);
 
       /*================ Adapt Time step! ======================== */
     } // end rk stages

--- a/SourceCpp/React.H
+++ b/SourceCpp/React.H
@@ -144,7 +144,7 @@ pc_expl_reactions(
   amrex::Real rhoydot_ext[NUM_SPECIES];
   for (int n = 0; n < NUM_SPECIES; n++)
     rhoydot_ext[n] = nr_src(i, j, k, UFS + n);
-    
+  
   // RK dts
   amrex::Real dt_rk = dt_react / nsteps_guess;
   const amrex::Real dt_min = dt_react / nsteps_max;
@@ -215,7 +215,7 @@ pc_expl_reactions(
         urk[URHO] += urk[UFS + n];
       rhoInv = 1.0 / urk[URHO];
       for (int n = 0; n < NUM_SPECIES; ++n) {
-	massfrac[n] = urk[UFS + n] * rhoInv;
+        massfrac[n] = urk[UFS + n] * rhoInv;
       }
       EOS::EY2T(rhoe_rk / urk[URHO], massfrac, urk[UTEMP]);
 


### PR DESCRIPTION
This pull request updates the PeleC explicit chemistry integrator to solve the internal energy equation instead of the temperature equation. @hsitaram mentioned that solving the temperature equation is a historical artifact relating to Fuego having an analytical Jacobian based on temperature, but that is not relevant for the explicit solver. 

For a constant volume reactor, internal energy is the conserved quantity and its equation is simply `d/dt(rho e) = external forcing`. The present implementation recasts this to a temperature equation using `d/dt(rho e) = rho*cv*dT/dt + sum(wdot_i*e_i)`, which assumes ideal gas behavior.

There are a few advantages to switching to the internal energy equation:
- The simpler form of the equation allows for simpler code and eliminates the need for EOS calls to determine cv and e_i. 
- The current implementation tracks two temperatures that nominally should be equivalent. The revised implementation eliminates this as temperature is always obtained from internal energy through an EOS call. 
- The internal energy implementation does not assume ideal gas behavior and therefore can be used for real gas equations of state

I tested the revised code using the zeroD RegTest. The figure below shows that the autoignition calculation is essentially unchanged. However there are small quantitative differences that arise because of numerical differences in explicit integration of `rho*cv*dT` vs. `de`.

![image](https://user-images.githubusercontent.com/53018946/102944071-94e41900-446e-11eb-9e0f-39aa456417f6.png)

