### PR TITLE
Fix one of the clang tidy issues

### DIFF
--- a/SourceCpp/Diffusion.cpp
+++ b/SourceCpp/Diffusion.cpp
@@ -133,7 +133,7 @@ PeleC::getMOLSrcTerm(
       amrex::FabType typ = flag_fab.getType(vbox);
       if (typ == amrex::FabType::covered) {
         setV(vbox, NVAR, MOLSrc, 0);
-        if (do_mol_load_balance) {
+        if (do_mol_load_balance && cost) {
           wt = (amrex::ParallelDescriptor::second() - wt) / vbox.d_numPts();
           (*cost)[mfi].plus<amrex::RunOn::Device>(wt, vbox);
         }
@@ -637,7 +637,7 @@ PeleC::getMOLSrcTerm(
       copy_array4(vbox, NVAR, Dterm, MOLSrc);
 
 #ifdef PELEC_USE_EB
-      if (do_mol_load_balance) {
+      if (do_mol_load_balance && cost) {
         amrex::Gpu::streamSynchronize();
         wt = (amrex::ParallelDescriptor::second() - wt) / vbox.d_numPts();
         (*cost)[mfi].plus<amrex::RunOn::Device>(wt, vbox);


### PR DESCRIPTION
This should fix:

```
Warning: /home/runner/work/PeleC/PeleC/SourceCpp/Diffusion.cpp:643:9: warning: Called C++ object pointer is null [clang-analyzer-core.CallAndMessage]
Warning: /home/runner/work/PeleC/PeleC/SourceCpp/Diffusion.cpp:138:11: warning: Called C++ object pointer is null [clang-analyzer-core.CallAndMessage]
```