### PR TITLE
Regain EB CPU to GPU parity

### DIFF
--- a/SourceCpp/InitEB.cpp
+++ b/SourceCpp/InitEB.cpp
@@ -296,7 +296,8 @@ PeleC::initialize_eb2_structs()
         amrex::IntVect* unique_result_end = thrust::unique(
           v_all_cut_faces.data(), v_all_cut_faces.data() + v_all_cut_faces_size,
           thrust::equal_to<amrex::IntVect>());
-        const int count_result = thrust::distance(v_all_cut_faces.data(), unique_result_end);
+        const int count_result =
+          thrust::distance(v_all_cut_faces.data(), unique_result_end);
         amrex::Gpu::DeviceVector<amrex::IntVect> v_cut_faces(count_result);
         amrex::IntVect* d_all_cut_faces = v_all_cut_faces.data();
         amrex::IntVect* d_cut_faces = v_cut_faces.data();

--- a/SourceCpp/InitEB.cpp
+++ b/SourceCpp/InitEB.cpp
@@ -160,15 +160,15 @@ PeleC::initialize_eb2_structs()
 
       // Fill in boundary gradient for cut cells in this grown tile
       const amrex::Real dx = geom.CellSize()[0];
-#ifdef AMREX_USE_GPU
-      const int sv_eb_bndry_geom_size = sv_eb_bndry_geom[iLocal].size();
-      thrust::sort(
-        thrust::device, sv_eb_bndry_geom[iLocal].data(),
-        sv_eb_bndry_geom[iLocal].data() + sv_eb_bndry_geom_size,
-        EBBndryGeomCmp());
-#else
+// #ifdef AMREX_USE_GPU
+//       const int sv_eb_bndry_geom_size = sv_eb_bndry_geom[iLocal].size();
+//       thrust::sort(
+//         thrust::device, sv_eb_bndry_geom[iLocal].data(),
+//         sv_eb_bndry_geom[iLocal].data() + sv_eb_bndry_geom_size,
+//         EBBndryGeomCmp());
+// #else
       sort<amrex::Gpu::DeviceVector<EBBndryGeom>>(sv_eb_bndry_geom[iLocal]);
-#endif
+// #endif
 
       if (bgs == 0) {
         pc_fill_bndry_grad_stencil(
@@ -288,28 +288,28 @@ PeleC::initialize_eb2_structs()
           }
         });
 
-#ifdef AMREX_USE_GPU
-        const int v_all_cut_faces_size = v_all_cut_faces.size();
-        thrust::sort(
-          thrust::device, v_all_cut_faces.data(),
-          v_all_cut_faces.data() + v_all_cut_faces_size);
-        amrex::IntVect* unique_result_end = thrust::unique(
-          v_all_cut_faces.data(), v_all_cut_faces.data() + v_all_cut_faces_size,
-          thrust::equal_to<amrex::IntVect>());
-        const int count_result =
-          thrust::count(v_all_cut_faces.data(), unique_result_end, 1);
-        amrex::Gpu::DeviceVector<amrex::IntVect> v_cut_faces(count_result);
-        amrex::IntVect* d_all_cut_faces = v_all_cut_faces.data();
-        amrex::IntVect* d_cut_faces = v_cut_faces.data();
-        amrex::ParallelFor(
-          v_cut_faces.size(), [=] AMREX_GPU_DEVICE(int i) noexcept {
-            d_cut_faces[i] = d_all_cut_faces[i];
-          });
-#else
+// #ifdef AMREX_USE_GPU
+//         const int v_all_cut_faces_size = v_all_cut_faces.size();
+//         thrust::sort(
+//           thrust::device, v_all_cut_faces.data(),
+//           v_all_cut_faces.data() + v_all_cut_faces_size);
+//         amrex::IntVect* unique_result_end = thrust::unique(
+//           v_all_cut_faces.data(), v_all_cut_faces.data() + v_all_cut_faces_size,
+//           thrust::equal_to<amrex::IntVect>());
+//         const int count_result =
+//           thrust::count(v_all_cut_faces.data(), unique_result_end, 1);
+//         amrex::Gpu::DeviceVector<amrex::IntVect> v_cut_faces(count_result);
+//         amrex::IntVect* d_all_cut_faces = v_all_cut_faces.data();
+//         amrex::IntVect* d_cut_faces = v_cut_faces.data();
+//         amrex::ParallelFor(
+//           v_cut_faces.size(), [=] AMREX_GPU_DEVICE(int i) noexcept {
+//             d_cut_faces[i] = d_all_cut_faces[i];
+//           });
+// #else
         sort<amrex::Gpu::DeviceVector<amrex::IntVect>>(v_all_cut_faces);
         amrex::Gpu::DeviceVector<amrex::IntVect> v_cut_faces =
           unique<amrex::Gpu::DeviceVector<amrex::IntVect>>(v_all_cut_faces);
-#endif
+//#endif
 
         const int Nsten = v_cut_faces.size();
         if (Nsten > 0) {

--- a/SourceCpp/InitEB.cpp
+++ b/SourceCpp/InitEB.cpp
@@ -160,15 +160,15 @@ PeleC::initialize_eb2_structs()
 
       // Fill in boundary gradient for cut cells in this grown tile
       const amrex::Real dx = geom.CellSize()[0];
-// #ifdef AMREX_USE_GPU
-//       const int sv_eb_bndry_geom_size = sv_eb_bndry_geom[iLocal].size();
-//       thrust::sort(
-//         thrust::device, sv_eb_bndry_geom[iLocal].data(),
-//         sv_eb_bndry_geom[iLocal].data() + sv_eb_bndry_geom_size,
-//         EBBndryGeomCmp());
-// #else
+#ifdef AMREX_USE_GPU
+      const int sv_eb_bndry_geom_size = sv_eb_bndry_geom[iLocal].size();
+      thrust::sort(
+        thrust::device, sv_eb_bndry_geom[iLocal].data(),
+        sv_eb_bndry_geom[iLocal].data() + sv_eb_bndry_geom_size,
+        EBBndryGeomCmp());
+#else
       sort<amrex::Gpu::DeviceVector<EBBndryGeom>>(sv_eb_bndry_geom[iLocal]);
-// #endif
+#endif
 
       if (bgs == 0) {
         pc_fill_bndry_grad_stencil(


### PR DESCRIPTION
Commit #171 introduced a bug in the initialization of the EB structs. Instead of counting the length of the array of uniques, it was counting how many of them were equal to 1. This led to `v_cut_faces` vector that had a size of 0 and therefore incorrect results. `distance` is the correct function to use to actually get the length difference between two pointers.

For the EB Bluff body regression case, the diffs after 100 steps is:

```
            variable name            absolute error            relative error
                                        (||A - B||)         (||A - B||/||A||)
 ----------------------------------------------------------------------------
 level = 0
 density                            1.577297321e-15            1.21531209e-12
 xmom                               4.866329562e-11           2.388627896e-12
 ymom                               6.205074627e-11           5.383829369e-12
 zmom                               5.908503781e-12                     1e+98
 rho_E                               5.14369458e-06           1.724718938e-12
 rho_e                              4.772096872e-06           1.609653973e-12
 Temp                               1.599005373e-10           5.022541688e-13
 rho_                               1.577297321e-15            1.21531209e-12
 pressure                           1.908862032e-06           1.609673606e-12
 kineng                             3.714085324e-07           1.784079545e-12
 enstrophy                          4.204410953e-08           2.902445188e-15
 soundspeed                         9.182258509e-09            2.56731682e-13
 MachNumber                         7.777112287e-13           1.276795928e-12
 entropy                                          0                         0
 magvort                            3.351536009e-07           1.864339575e-12
 divu                               5.361621334e-07            8.29102026e-12
 eint_E                               0.00114774704           5.024514571e-13
 eint_e                              0.001147270203           5.022427111e-13
 logden                             5.910827383e-13           1.885478363e-13
 x_velocity                         2.976412361e-08           1.456065888e-12
 y_velocity                         5.349384224e-08           4.912716068e-12
 z_velocity                         5.136834772e-09                     1e+98
 magvel                             2.955312084e-08           1.431040682e-12
 radvel                             5.748233889e-08           4.685234567e-12
 magmom                             4.841638201e-11           2.358979516e-12
 vfrac                                            0                         0
```

The previous, incorrect version of the code led to diffs like:
```
            variable name            absolute error            relative error
                                        (||A - B||)         (||A - B||/||A||)
 ----------------------------------------------------------------------------
 level = 0
 density                            0.0004863248457              0.3747146825
 xmom                                   16.93555397               0.831278197
 ymom                                   13.82806531               1.199791278
 zmom                               3.437327506e-13                     1e+98
 rho_E                                  1352613.982              0.4535414991
 rho_e                                  1358049.281              0.4580773355
 Temp                                   49.45328502              0.1553348037
 rho_                               0.0004863248457              0.3747146825
 pressure                               543219.7124              0.4580773355
 kineng                                 176415.6756              0.8474215608
 enstrophy                              14363259.38              0.9915437271
 soundspeed                             2950.236787             0.08248724996
 MachNumber                            0.5348926554              0.8781521199
 entropy                                          0                         0
 magvort                                165873.8718              0.9226970048
 divu                                   145109.8471                2.24392699
 eint_E                                 354830419.1              0.1553348037
 eint_e                                 354830419.1              0.1553348037
 logden                                0.2064571741              0.0658571989
 x_velocity                             17780.16202              0.8698084894
 y_velocity                             13207.78398                1.21296377
 z_velocity                         2.951308251e-10                     1e+98
 magvel                                  17020.9192              0.8241981604
 radvel                                 17088.03427               1.392800822
 magmom                                 16.60124045                0.80885817
 vfrac                                            0                         0
 ```