### PR TITLE
Use thrust for CUDA builds, and custom function for other builds

### DIFF
--- a/SourceCpp/EBStencilTypes.H
+++ b/SourceCpp/EBStencilTypes.H
@@ -39,7 +39,7 @@ struct EBBndryGeom
   bool operator<(const EBBndryGeom& rhs) const { return iv < rhs.iv; }
 };
 
-#ifdef AMREX_USE_GPU
+#ifdef AMREX_USE_CUDA
 // Comparison operator for thrust sort
 struct EBBndryGeomCmp
 {

--- a/SourceCpp/InitEB.cpp
+++ b/SourceCpp/InitEB.cpp
@@ -4,7 +4,7 @@
 #include "prob.H"
 #include "Utilities.H"
 
-#ifdef AMREX_USE_GPU
+#ifdef AMREX_USE_CUDA
 #include <thrust/unique.h>
 #include <thrust/sort.h>
 #include <thrust/execution_policy.h>
@@ -160,7 +160,7 @@ PeleC::initialize_eb2_structs()
 
       // Fill in boundary gradient for cut cells in this grown tile
       const amrex::Real dx = geom.CellSize()[0];
-#ifdef AMREX_USE_GPU
+#ifdef AMREX_USE_CUDA
       const int sv_eb_bndry_geom_size = sv_eb_bndry_geom[iLocal].size();
       thrust::sort(
         thrust::device, sv_eb_bndry_geom[iLocal].data(),
@@ -288,7 +288,7 @@ PeleC::initialize_eb2_structs()
           }
         });
 
-#ifdef AMREX_USE_GPU
+#ifdef AMREX_USE_CUDA
         const int v_all_cut_faces_size = v_all_cut_faces.size();
         thrust::sort(
           thrust::device, v_all_cut_faces.data(),


### PR DESCRIPTION
Non CUDA GPU builds should use the custom functions since thrust may not be available. 