### PR TITLE
Achieve CPU-GPU parity with explicit reaction and PMF problem

### DIFF
--- a/SourceCpp/Params/_cpp_parameters
+++ b/SourceCpp/Params/_cpp_parameters
@@ -377,7 +377,7 @@ adaptrk_nsubsteps_max        int           300                n
 adaptrk_nsubsteps_guess      int           50                 n
 
 #explict RK chemistry integrator options (absolute error tol.)
-adaptrk_errtol               Real          1e-16              n
+adaptrk_errtol               Real          1e-12              n
 
 #flag to clean the state for the reactions
 clean_react_massfrac         int           1                  n

--- a/SourceCpp/Params/param_includes/pelec_defaults.H
+++ b/SourceCpp/Params/param_includes/pelec_defaults.H
@@ -102,7 +102,7 @@ int PeleC::chem_integrator = 1;
 int PeleC::adaptrk_nsubsteps_min = 20;
 int PeleC::adaptrk_nsubsteps_max = 300;
 int PeleC::adaptrk_nsubsteps_guess = 50;
-amrex::Real PeleC::adaptrk_errtol = 1e-16;
+amrex::Real PeleC::adaptrk_errtol = 1e-12;
 int PeleC::clean_react_massfrac = 1;
 int PeleC::bndry_func_thread_safe = 1;
 #ifdef AMREX_DEBUG

--- a/SourceCpp/React.H
+++ b/SourceCpp/React.H
@@ -175,7 +175,7 @@ pc_expl_reactions(
   while (updt_time < dt_react) {
     for (int n = 0; n < NVAR; n++) {
       urk_carryover[n] = urk[n];
-      urk_err[n] = errtol * 1e-2;
+      urk_err[n] = 0.0;
     }
     amrex::Real rhoe_carryover = rhoe_rk;
 

--- a/SourceCpp/React.H
+++ b/SourceCpp/React.H
@@ -6,34 +6,6 @@
 #include "IndexDefines.H"
 #include "EOS.H"
 
-#ifndef AMREX_USE_GPU
-const amrex::Real alpha_rk64[6] = {
-  0.218150805229859,  // 3296351145737.0/15110423921029.0,
-  0.256702469801519,  // 1879360555526.0/ 7321162733569.0,
-  0.527402592007520,  // 10797097731880.0/20472212111779.0,
-  0.0484864267224467, // 754636544611.0/15563872110659.0,
-  1.24517071533530,   // 3260218886217.0/ 2618290685819.0,
-  0.412366034843237,  // 5069185909380.0/12292927838509.0
-};
-
-const amrex::Real beta_rk64[6] = {
-  -0.113554138044166,  // -1204558336989.0/10607789004752.0,
-  -0.215118587818400,  // -3028468927040.0/14078136890693.0,
-  -0.0510152146250577, // -455570672869.0/ 8930094212428.0,
-  -1.07992686223881,   // -17275898420483.0/15997285579755.0,
-  -0.248664241213447,  // -2453906524165.0/ 9868353053862.0,
-  0.0};
-
-const amrex::Real err_rk64[6] = {
-  -0.0554699315064507, // -530312978447.0/ 9560368366154.0,
-  0.158481845574980,   //  473021958881.0/ 2984707536468.0,
-  -0.0905918835751907, // -947229622805.0/10456009803779.0,
-  -0.219084567203338,  // -2921473878215.0/13334914072261.0,
-  0.164022338959433,   //  1519535112975.0/ 9264196100452.0,
-  0.0426421977505659   //  167623581683.0/ 3930932046784.0
-};
-#endif
-
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
@@ -77,24 +49,22 @@ AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
 adapt_timestep(
-  const amrex::Real rk_err[],
+  const amrex::Real rk_err[NVAR],
   const amrex::Real dt_rk4max,
   amrex::Real& dt,
   const amrex::Real dt_rk4min,
   const amrex::Real tol)
 {
-  amrex::Real change_factor;
-  amrex::Real err = amrex::max<amrex::Real>(rk_err[0], rk_err[1]);
-  for (int n = 2; n < NVAR; n++)
-    err = amrex::max<amrex::Real>(rk_err[n], err);
+  amrex::Real err = amrex::Math::abs(rk_err[0]);
+  for (int n = 0; n < NVAR; n++)
+    err = amrex::max<amrex::Real>(amrex::Math::abs(rk_err[n]), err);
 
   if (err < tol) {
     err = amrex::max<amrex::Real>(err, tol * 1.e-4);
-    change_factor = std::sqrt(
-      std::sqrt(tol / err)); // sqrt sqrt is faster than pow(var, 0.25)
+    const amrex::Real change_factor = std::pow(tol / err, 0.25);
     dt = amrex::min<amrex::Real>(dt_rk4max, dt * change_factor);
   } else {
-    change_factor = std::pow(tol / err, 0.2);
+    const amrex::Real change_factor = std::pow(tol / err, 0.2);
     dt = amrex::max<amrex::Real>(dt_rk4min, dt * change_factor);
   }
 }
@@ -120,9 +90,6 @@ pc_expl_reactions(
   const int do_update,
   const int clean_react_massfrac)
 {
-#ifdef AMREX_USE_GPU
-  // having a global __constant__ variable is slower than having this in local
-  // memory.
   const amrex::Real alpha_rk64[6] = {
     0.218150805229859,  // 3296351145737.0/15110423921029.0,
     0.256702469801519,  // 1879360555526.0/ 7321162733569.0,
@@ -148,7 +115,6 @@ pc_expl_reactions(
     0.164022338959433,   //  1519535112975.0/ 9264196100452.0,
     0.0426421977505659   //  167623581683.0/ 3930932046784.0
   };
-#endif
 
   // compute rhoe_ext/rhoy_ext
 
@@ -209,7 +175,7 @@ pc_expl_reactions(
   while (updt_time < dt_react) {
     for (int n = 0; n < NVAR; n++) {
       urk_carryover[n] = urk[n];
-      urk_err[n] = 0.0;
+      urk_err[n] = errtol * 1e-2;
     }
     amrex::Real rhoe_carryover = rhoe_rk;
 


### PR DESCRIPTION
With these changes (the only one that counts really is the change in RK absolute tolerances, the rest is cleanup) the diffs of the PMF problem CPU to GPU are:

Initial condition:
```
            variable name            absolute error            relative error
                                        (||A - B||)         (||A - B||/||A||)
 ----------------------------------------------------------------------------
 level = 0
 density                             4.33680869e-19            4.21183456e-16
 xmom                                             0                         0
 ymom                                             0                         0
 zmom                               1.040834086e-17           4.466071004e-16
 rho_E                               6.98491931e-10           5.215030949e-16
 rho_e                               6.98491931e-10           5.215028934e-16
 Temp                                             0                         0
 rho_omega_H2                       9.834540885e-13           1.298592188e-10
 rho_omega_O2                       2.098035389e-11           3.626062174e-10
 rho_omega_H2O                      1.966908177e-12           3.224471924e-11
 rho_omega_H                        3.201377965e-16           4.673620731e-13
 rho_omega_O                         1.53664516e-14           4.883701626e-12
 rho_omega_OH                       2.048862924e-14           8.239606388e-12
 rho_omega_HO2                      2.561102372e-15           2.823496975e-12
 rho_omega_H2O2                      1.28053848e-15           6.769570394e-12
 rho_omega_N2                       4.196070778e-11           0.0006482982172
 rhoe_dot                                         0                         0
 pressure                           8.149072528e-10            8.04250928e-16
 magvort                             4.97379915e-13           1.319437391e-15
 Y(H2)                               8.67361738e-19           7.475377539e-17
 Y(O2)                              2.775557562e-17           1.204489215e-16
 Y(H2O)                             1.387778781e-17           1.338630307e-16
 Y(H)                               1.694065895e-21           3.426118276e-17
 Y(O)                               2.710505431e-20           2.705701189e-17
 Y(OH)                              2.168404345e-19           1.569769492e-16
 Y(HO2)                             5.421010862e-20           2.323648591e-16
 Y(H2O2)                            6.776263578e-21           8.976222246e-17
 Y(N2)                              1.110223025e-16           1.461335507e-16
 x_velocity                                       0                         0
 y_velocity                                       0                         0
 z_velocity                         1.421085472e-14           1.403011656e-16
```

1 step later:
```
            variable name            absolute error            relative error
                                        (||A - B||)         (||A - B||/||A||)
 ----------------------------------------------------------------------------
 level = 0
 density                            2.168404345e-18           2.105917318e-15
 xmom                               1.182787755e-16           5.993876791e-10
 ymom                               9.856552657e-17           5.028021679e-10
 zmom                               1.179611964e-16           5.056366459e-15
 rho_E                               6.98491931e-10           5.215003414e-16
 rho_e                               6.98491931e-10           5.215001396e-16
 Temp                               9.094947018e-13           6.377939921e-16
 rho_omega_H2                       6.555893773e-12           8.668956974e-10
 rho_omega_O2                       2.087914127e-11           3.623392633e-10
 rho_omega_H2O                      2.589307241e-12           4.275644343e-11
 rho_omega_H                        6.279563458e-16           9.248315948e-13
 rho_omega_O                        1.558789989e-14           4.996603897e-12
 rho_omega_OH                       2.546769219e-14           1.035468579e-11
 rho_omega_HO2                      2.581593793e-15           2.856029955e-12
 rho_omega_H2O2                     1.284955757e-15           6.825995697e-12
 rho_omega_N2                       4.194557856e-10           1.870018745e-07
 rhoe_dot                           0.0002062320709           1.777518253e-05
 pressure                           2.095475793e-09           2.068060027e-15
 magvort                            8.751978593e-12           2.329410926e-14
 Y(H2)                              3.469446952e-17           2.990151016e-15
 Y(O2)                              4.718447855e-16           2.047631685e-15
 Y(H2O)                             2.220446049e-16           2.141808488e-15
 Y(H)                               2.032879073e-20           4.110892279e-16
 Y(O)                               6.505213035e-19           6.493630812e-16
 Y(OH)                              6.505213035e-19           4.709364354e-16
 Y(HO2)                             5.421010862e-20           2.323586984e-16
 Y(H2O2)                            2.710505431e-20           3.590470459e-16
 Y(N2)                              5.551115123e-16           7.306677503e-16
 x_velocity                         4.283282074e-13           5.542076476e-10
 y_velocity                         4.282032496e-13           5.642188829e-10
 z_velocity                         4.263256415e-13           4.209034967e-15
```

Without this commit, the diffs after one step are:
```
            variable name            absolute error            relative error
                                        (||A - B||)         (||A - B||/||A||)
 ----------------------------------------------------------------------------
 level = 0
 density                            1.520688241e-11           1.476866485e-08
 xmom                               1.380101067e-13           6.993778653e-07
 ymom                               1.258066365e-13           6.417644361e-07
 zmom                               1.081600087e-13           4.636241893e-12
 rho_E                              6.014714018e-06            4.49063944e-12
 rho_e                              6.034737453e-06           4.505587373e-12
 Temp                               0.0001911326829           1.340340703e-07
 rho_omega_H2                       0.0001533345783             0.02027566199
 rho_omega_O2                       0.0008531177928             0.01480511428
 rho_omega_H2O                      0.0008571324046             0.01415356687
 rho_omega_H                        8.598588834e-06             0.01266369339
 rho_omega_O                        4.031883118e-05             0.01292394937
 rho_omega_OH                       3.634566823e-05             0.01477746675
 rho_omega_HO2                      1.393561585e-05              0.0154170406
 rho_omega_H2O2                     2.925360588e-06             0.01554022282
 rho_omega_N2                        0.002268734603               1.011447781
 rhoe_dot                               11.07240033              0.9543323504
 pressure                               0.158856728           1.567783557e-07
 magvort                            0.0001117558455            2.97447354e-07
 Y(H2)                              2.517525558e-09           2.169735323e-07
 Y(O2)                              1.272404995e-08           5.521766617e-08
 Y(H2O)                             1.483822513e-08           1.431272628e-07
 Y(H)                               1.246133647e-10           2.519934045e-06
 Y(O)                               8.045068734e-10           8.030744871e-07
 Y(OH)                              7.304769265e-10           5.288192685e-07
 Y(HO2)                             1.451402296e-10           6.221089698e-07
 Y(H2O2)                            4.217577166e-11           5.586812722e-07
 Y(N2)                              1.208244949e-09            1.59035725e-09
 x_velocity                         4.235459726e-10           5.480199835e-07
 y_velocity                         3.173157914e-10           4.181088338e-07
 z_velocity                         4.918854671e-06           4.856295117e-08
 ```
