### PR TITLE
First step to removing global managed variables

### DIFF
--- a/CMake/BuildPeleCExe.cmake
+++ b/CMake/BuildPeleCExe.cmake
@@ -82,15 +82,18 @@ function(build_pelec_exe pelec_exe_name)
       endif()
       target_compile_definitions(${pelec_exe_name} PRIVATE USE_SUNDIALS_PP)
       target_sources(${pelec_exe_name} PRIVATE ${PELE_PHYSICS_SRC_DIR}/Reactions/Fuego/${DEVICE}/arkode/reactor.cpp
-                                               ${PELE_PHYSICS_SRC_DIR}/Reactions/Fuego/${DEVICE}/arkode/reactor.h)
+                                               ${PELE_PHYSICS_SRC_DIR}/Reactions/Fuego/${DEVICE}/arkode/reactor.h
+                                               ${PELE_PHYSICS_SRC_DIR}/Reactions/Fuego/${DEVICE}/AMREX_misc.H)
       set_source_files_properties(${PELE_PHYSICS_SRC_DIR}/Reactions/Fuego/${DEVICE}/arkode/reactor.cpp PROPERTIES COMPILE_OPTIONS "${MY_CXX_FLAGS}")
       set_source_files_properties(${PELE_PHYSICS_SRC_DIR}/Reactions/Fuego/${DEVICE}/arkode/reactor.h PROPERTIES COMPILE_OPTIONS "${MY_CXX_FLAGS}")
       target_link_libraries(${pelec_exe_name} PRIVATE sundials_arkode)
-      if(PELEC_ENABLE_CUDA)
-        target_link_libraries(${pelec_exe_name} PRIVATE sundials_nveccuda)
-      endif()
       target_include_directories(${pelec_exe_name} PRIVATE ${PELE_PHYSICS_SRC_DIR}/Reactions/Fuego/${DEVICE})
       target_include_directories(${pelec_exe_name} PRIVATE ${PELE_PHYSICS_SRC_DIR}/Reactions/Fuego/${DEVICE}/arkode)
+      if(PELEC_ENABLE_CUDA)
+        target_sources(${pelec_exe_name} PRIVATE ${PELE_PHYSICS_SRC_DIR}/Reactions/Fuego/${DEVICE}/AMReX_SUNMemory.cpp
+                                                 ${PELE_PHYSICS_SRC_DIR}/Reactions/Fuego/${DEVICE}/AMReX_SUNMemory.H)
+        target_link_libraries(${pelec_exe_name} PRIVATE sundials_nveccuda)
+      endif()
     endif()
     target_compile_definitions(${pelec_exe_name} PRIVATE PELEC_USE_REACTIONS)
     target_sources(${pelec_exe_name} PRIVATE

--- a/CMake/BuildPeleCExe.cmake
+++ b/CMake/BuildPeleCExe.cmake
@@ -29,7 +29,6 @@ function(build_pelec_exe pelec_exe_name)
   target_sources(${pelec_exe_name} PRIVATE
                  ${PELEC_TRANSPORT_DIR}/Transport.H
                  ${PELEC_TRANSPORT_DIR}/Transport.cpp
-                 ${PELEC_TRANSPORT_DIR}/TransportParams.cpp
                  ${PELEC_TRANSPORT_DIR}/TransportParams.H)
   target_include_directories(${pelec_exe_name} SYSTEM PRIVATE ${PELEC_TRANSPORT_DIR})
 

--- a/CMake/BuildPeleCExe.cmake
+++ b/CMake/BuildPeleCExe.cmake
@@ -203,6 +203,7 @@ function(build_pelec_exe pelec_exe_name)
       set_source_files_properties(${PELEC_SOURCES} PROPERTIES LANGUAGE CUDA)
     endforeach()
     set_target_properties(${pelec_exe_name} PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
+    target_compile_options(${pelec_exe_name} PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-Xptxas --disable-optimizer-constants>)
   endif()
  
   #Define what we want to be installed during a make install 

--- a/ExecCpp/RegTests/EB-BluffBody/prob.H
+++ b/ExecCpp/RegTests/EB-BluffBody/prob.H
@@ -23,7 +23,8 @@ pc_initdata(
   int j,
   int k,
   amrex::Array4<amrex::Real> const& state,
-  amrex::GeometryData const& /*geomdata*/)
+  amrex::GeometryData const& /*geomdata*/,
+  ProbParmDevice const& /*prob_parm*/)
 {
   // Geometry
   // const amrex::Real* prob_lo = geomdata.ProbLo();
@@ -57,7 +58,8 @@ bcnormal(
   const int /*idir*/,
   const int /*sgn*/,
   const amrex::Real /*time*/,
-  amrex::GeometryData const& /*geomdata*/)
+  amrex::GeometryData const& /*geomdata*/,
+  ProbParmDevice const& /*prob_parm*/)
 {
   s_ext[URHO] = ProbParm::rho;
   s_ext[UMX] = ProbParm::rho * ProbParm::vx_in;

--- a/ExecCpp/RegTests/EB-BluffBody/prob.cpp
+++ b/ExecCpp/RegTests/EB-BluffBody/prob.cpp
@@ -28,13 +28,15 @@ amrex_probinit(
   const amrex_real* probhi)
 {
   // Parse params
-  amrex::ParmParse pp("prob");
-  pp.query("p", ProbParm::p);
-  pp.query("rho", ProbParm::rho);
-  pp.query("vx_in", ProbParm::vx_in);
-  pp.query("vy_in", ProbParm::vy_in);
-  pp.query("Re_L", ProbParm::Re_L);
-  pp.query("Pr", ProbParm::Pr);
+  {
+    amrex::ParmParse pp("prob");
+    pp.query("p", ProbParm::p);
+    pp.query("rho", ProbParm::rho);
+    pp.query("vx_in", ProbParm::vx_in);
+    pp.query("vy_in", ProbParm::vy_in);
+    pp.query("Re_L", ProbParm::Re_L);
+    pp.query("Pr", ProbParm::Pr);
+  }
 
   amrex::Real L = (probhi[0] - problo[0]) * 0.2;
 
@@ -45,12 +47,35 @@ amrex_probinit(
   EOS::EY2T(ProbParm::eint, ProbParm::massfrac.begin(), ProbParm::T);
   EOS::TY2Cp(ProbParm::T, ProbParm::massfrac.begin(), cp);
 
-  transport_params::const_bulk_viscosity = 0.0;
-  transport_params::const_diffusivity = 0.0;
-  transport_params::const_viscosity =
+  TransParm trans_parm;
+
+  // Default
+  trans_parm.const_viscosity = 0.0;
+  trans_parm.const_bulk_viscosity = 0.0;
+  trans_parm.const_conductivity = 0.0;
+  trans_parm.const_diffusivity = 0.0;
+
+  // User-specified
+  {
+    amrex::ParmParse pp("transport");
+    pp.query("const_viscosity", trans_parm.const_viscosity);
+    pp.query("const_bulk_viscosity", trans_parm.const_bulk_viscosity);
+    pp.query("const_conductivity", trans_parm.const_conductivity);
+    pp.query("const_diffusivity", trans_parm.const_diffusivity);
+  }
+
+  trans_parm.const_bulk_viscosity = 0.0;
+  trans_parm.const_diffusivity = 0.0;
+  trans_parm.const_viscosity =
     ProbParm::rho * ProbParm::vx_in * L / ProbParm::Re_L;
-  transport_params::const_conductivity =
-    transport_params::const_viscosity * cp / ProbParm::Pr;
+  trans_parm.const_conductivity =
+    trans_parm.const_viscosity * cp / ProbParm::Pr;
+
+#ifdef AMREX_USE_GPU
+  amrex::Gpu::htod_memcpy(trans_parm_g, &trans_parm, sizeof(trans_parm));
+#else
+  std::memcpy(trans_parm_g, &trans_parm, sizeof(trans_parm));
+#endif
 }
 }
 

--- a/ExecCpp/RegTests/EB-BluffBody/prob_parm.H
+++ b/ExecCpp/RegTests/EB-BluffBody/prob_parm.H
@@ -3,6 +3,15 @@
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>
+#include <AMReX_GpuMemory.H>
+
+struct ProbParmDevice : amrex::Gpu::Managed
+{
+};
+
+struct ProbParmHost : amrex::Gpu::Managed
+{
+};
 
 namespace ProbParm {
 extern AMREX_GPU_DEVICE_MANAGED amrex::Real p;

--- a/ExecCpp/RegTests/EB-C1/prob.H
+++ b/ExecCpp/RegTests/EB-C1/prob.H
@@ -30,7 +30,8 @@ pc_initdata(
   int j,
   int k,
   amrex::Array4<amrex::Real> const& state,
-  amrex::GeometryData const& geomdata)
+  amrex::GeometryData const& geomdata,
+  ProbParmDevice const& /*prob_parm*/)
 {
   // Geometry
   const amrex::Real* prob_lo = geomdata.ProbLo();
@@ -76,7 +77,8 @@ bcnormal(
   const int /*idir*/,
   const int /*sgn*/,
   const amrex::Real /*time*/,
-  amrex::GeometryData const& /*geomdata*/)
+  amrex::GeometryData const& /*geomdata*/,
+  ProbParmDevice const& /*prob_parm*/)
 {
   const amrex::Real rho = masa_eval_3d_exact_rho(x[0], x[1], x[2]);
   const amrex::Real u[3] = {

--- a/ExecCpp/RegTests/EB-C1/prob_parm.H
+++ b/ExecCpp/RegTests/EB-C1/prob_parm.H
@@ -3,6 +3,15 @@
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>
+#include <AMReX_GpuMemory.H>
+
+struct ProbParmDevice : amrex::Gpu::Managed
+{
+};
+
+struct ProbParmHost : amrex::Gpu::Managed
+{
+};
 
 namespace ProbParm {
 extern AMREX_GPU_DEVICE_MANAGED amrex::Real reynolds;

--- a/ExecCpp/RegTests/EB-C10/prob.H
+++ b/ExecCpp/RegTests/EB-C10/prob.H
@@ -23,7 +23,8 @@ pc_initdata(
   int j,
   int k,
   amrex::Array4<amrex::Real> const& state,
-  amrex::GeometryData const& geomdata)
+  amrex::GeometryData const& geomdata,
+  ProbParmDevice const& /*prob_parm*/)
 {
   // Geometry
   const amrex::Real* prob_lo = geomdata.ProbLo();
@@ -59,7 +60,8 @@ bcnormal(
   const int idir,
   const int sgn,
   const amrex::Real /*time*/,
-  amrex::GeometryData const& geomdata)
+  amrex::GeometryData const& geomdata,
+  ProbParmDevice const& /*prob_parm*/)
 {
   if (idir == 0) {
     amrex::Real rho = 0.0, u = 0.0, v = 0.0, w = 0.0, eint = 0.0, T = 0.0;

--- a/ExecCpp/RegTests/EB-C10/prob_parm.H
+++ b/ExecCpp/RegTests/EB-C10/prob_parm.H
@@ -3,6 +3,15 @@
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>
+#include <AMReX_GpuMemory.H>
+
+struct ProbParmDevice : amrex::Gpu::Managed
+{
+};
+
+struct ProbParmHost : amrex::Gpu::Managed
+{
+};
 
 namespace ProbParm {
 extern AMREX_GPU_DEVICE_MANAGED amrex::Real p;

--- a/ExecCpp/RegTests/EB-C11/prob.H
+++ b/ExecCpp/RegTests/EB-C11/prob.H
@@ -25,7 +25,8 @@ pc_initdata(
   int j,
   int k,
   amrex::Array4<amrex::Real> const& state,
-  amrex::GeometryData const& geomdata)
+  amrex::GeometryData const& geomdata,
+  ProbParmDevice const& /*prob_parm*/)
 {
   // Geometry
   const amrex::Real* prob_lo = geomdata.ProbLo();
@@ -128,7 +129,8 @@ bcnormal(
   const int /*idir*/,
   const int /*sgn*/,
   const amrex::Real /*time*/,
-  amrex::GeometryData const& /*geomdata*/)
+  amrex::GeometryData const& /*geomdata*/,
+  ProbParmDevice const& /*prob_parm*/)
 {
   for (int n = 0; n < NVAR; n++) {
     s_ext[n] = s_int[n];

--- a/ExecCpp/RegTests/EB-C11/prob_parm.H
+++ b/ExecCpp/RegTests/EB-C11/prob_parm.H
@@ -3,6 +3,15 @@
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>
+#include <AMReX_GpuMemory.H>
+
+struct ProbParmDevice : amrex::Gpu::Managed
+{
+};
+
+struct ProbParmHost : amrex::Gpu::Managed
+{
+};
 
 namespace ProbParm {
 extern AMREX_GPU_DEVICE_MANAGED amrex::Real p_l;

--- a/ExecCpp/RegTests/EB-C12/prob.H
+++ b/ExecCpp/RegTests/EB-C12/prob.H
@@ -22,7 +22,8 @@ pc_initdata(
   int j,
   int k,
   amrex::Array4<amrex::Real> const& state,
-  amrex::GeometryData const& geomdata)
+  amrex::GeometryData const& geomdata,
+  ProbParmDevice const& /*prob_parm*/)
 {
   // Geometry
   const amrex::Real* prob_lo = geomdata.ProbLo();
@@ -59,7 +60,8 @@ bcnormal(
   const int /*idir*/,
   const int /*sgn*/,
   const amrex::Real /*time*/,
-  amrex::GeometryData const& /*geomdata*/)
+  amrex::GeometryData const& /*geomdata*/,
+  ProbParmDevice const& /*prob_parm*/)
 {
 }
 

--- a/ExecCpp/RegTests/EB-C12/prob_parm.H
+++ b/ExecCpp/RegTests/EB-C12/prob_parm.H
@@ -3,6 +3,15 @@
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>
+#include <AMReX_GpuMemory.H>
+
+struct ProbParmDevice : amrex::Gpu::Managed
+{
+};
+
+struct ProbParmHost : amrex::Gpu::Managed
+{
+};
 
 namespace ProbParm {
 extern AMREX_GPU_DEVICE_MANAGED amrex::Real p0;

--- a/ExecCpp/RegTests/EB-C3/prob.H
+++ b/ExecCpp/RegTests/EB-C3/prob.H
@@ -24,7 +24,8 @@ pc_initdata(
   int j,
   int k,
   amrex::Array4<amrex::Real> const& state,
-  amrex::GeometryData const& /*geomdata*/)
+  amrex::GeometryData const& /*geomdata*/,
+  ProbParmDevice const& /*prob_parm*/)
 {
   // Set the state
   state(i, j, k, URHO) = ProbParm::rho_init;
@@ -48,7 +49,8 @@ bcnormal(
   const int /*idir*/,
   const int /*sgn*/,
   const amrex::Real /*time*/,
-  amrex::GeometryData const& /*geomdata*/)
+  amrex::GeometryData const& /*geomdata*/,
+  ProbParmDevice const& /*prob_parm*/)
 {
 }
 

--- a/ExecCpp/RegTests/EB-C3/prob_parm.H
+++ b/ExecCpp/RegTests/EB-C3/prob_parm.H
@@ -3,6 +3,15 @@
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>
+#include <AMReX_GpuMemory.H>
+
+struct ProbParmDevice : amrex::Gpu::Managed
+{
+};
+
+struct ProbParmHost : amrex::Gpu::Managed
+{
+};
 
 namespace ProbParm {
 extern AMREX_GPU_DEVICE_MANAGED amrex::Real p_init;

--- a/ExecCpp/RegTests/EB-C4-5/prob.H
+++ b/ExecCpp/RegTests/EB-C4-5/prob.H
@@ -24,7 +24,8 @@ pc_initdata(
   int j,
   int k,
   amrex::Array4<amrex::Real> const& state,
-  amrex::GeometryData const& /*geomdata*/)
+  amrex::GeometryData const& /*geomdata*/,
+  ProbParmDevice const& /*prob_parm*/)
 {
   // Set the state
   state(i, j, k, URHO) = ProbParm::rho_init;
@@ -48,7 +49,8 @@ bcnormal(
   const int /*idir*/,
   const int /*sgn*/,
   const amrex::Real /*time*/,
-  amrex::GeometryData const& /*geomdata*/)
+  amrex::GeometryData const& /*geomdata*/,
+  ProbParmDevice const& /*prob_parm*/)
 {
 }
 

--- a/ExecCpp/RegTests/EB-C4-5/prob_parm.H
+++ b/ExecCpp/RegTests/EB-C4-5/prob_parm.H
@@ -3,6 +3,15 @@
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>
+#include <AMReX_GpuMemory.H>
+
+struct ProbParmDevice : amrex::Gpu::Managed
+{
+};
+
+struct ProbParmHost : amrex::Gpu::Managed
+{
+};
 
 namespace ProbParm {
 extern AMREX_GPU_DEVICE_MANAGED amrex::Real p_init;

--- a/ExecCpp/RegTests/EB-C7/prob.H
+++ b/ExecCpp/RegTests/EB-C7/prob.H
@@ -22,7 +22,8 @@ pc_initdata(
   int j,
   int k,
   amrex::Array4<amrex::Real> const& state,
-  amrex::GeometryData const& geomdata)
+  amrex::GeometryData const& geomdata,
+  ProbParmDevice const& /*prob_parm*/)
 {
   // Geometry
   const amrex::Real* prob_lo = geomdata.ProbLo();
@@ -69,7 +70,8 @@ bcnormal(
   const int /*idir*/,
   const int /*sgn*/,
   const amrex::Real /*time*/,
-  amrex::GeometryData const& /*geomdata*/)
+  amrex::GeometryData const& /*geomdata*/,
+  ProbParmDevice const& /*prob_parm*/)
 {
 }
 

--- a/ExecCpp/RegTests/EB-C7/prob_parm.H
+++ b/ExecCpp/RegTests/EB-C7/prob_parm.H
@@ -3,6 +3,15 @@
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>
+#include <AMReX_GpuMemory.H>
+
+struct ProbParmDevice : amrex::Gpu::Managed
+{
+};
+
+struct ProbParmHost : amrex::Gpu::Managed
+{
+};
 
 namespace ProbParm {
 extern AMREX_GPU_DEVICE_MANAGED amrex::Real pl;

--- a/ExecCpp/RegTests/EB-C8/prob.H
+++ b/ExecCpp/RegTests/EB-C8/prob.H
@@ -25,7 +25,8 @@ pc_initdata(
   int j,
   int k,
   amrex::Array4<amrex::Real> const& state,
-  amrex::GeometryData const& geomdata)
+  amrex::GeometryData const& geomdata,
+  ProbParmDevice const& /*prob_parm*/)
 {
   // Geometry
   const amrex::Real* prob_lo = geomdata.ProbLo();
@@ -76,7 +77,8 @@ bcnormal(
   const int /*idir*/,
   const int /*sgn*/,
   const amrex::Real /*time*/,
-  amrex::GeometryData const& /*geomdata*/)
+  amrex::GeometryData const& /*geomdata*/,
+  ProbParmDevice const& /*prob_parm*/)
 {
 }
 

--- a/ExecCpp/RegTests/EB-C8/prob_parm.H
+++ b/ExecCpp/RegTests/EB-C8/prob_parm.H
@@ -3,6 +3,15 @@
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>
+#include <AMReX_GpuMemory.H>
+
+struct ProbParmDevice : amrex::Gpu::Managed
+{
+};
+
+struct ProbParmHost : amrex::Gpu::Managed
+{
+};
 
 namespace ProbParm {
 extern AMREX_GPU_DEVICE_MANAGED amrex::Real p_l;

--- a/ExecCpp/RegTests/EB-C9/prob.H
+++ b/ExecCpp/RegTests/EB-C9/prob.H
@@ -25,7 +25,8 @@ pc_initdata(
   int j,
   int k,
   amrex::Array4<amrex::Real> const& state,
-  amrex::GeometryData const& geomdata)
+  amrex::GeometryData const& geomdata,
+  ProbParmDevice const& /*prob_parm*/)
 {
   // Geometry
   const amrex::Real* prob_lo = geomdata.ProbLo();
@@ -66,7 +67,8 @@ bcnormal(
   const int /*idir*/,
   const int /*sgn*/,
   const amrex::Real /*time*/,
-  amrex::GeometryData const& /*geomdata*/)
+  amrex::GeometryData const& /*geomdata*/,
+  ProbParmDevice const& /*prob_parm*/)
 {
 }
 

--- a/ExecCpp/RegTests/EB-C9/prob_parm.H
+++ b/ExecCpp/RegTests/EB-C9/prob_parm.H
@@ -3,6 +3,15 @@
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>
+#include <AMReX_GpuMemory.H>
+
+struct ProbParmDevice : amrex::Gpu::Managed
+{
+};
+
+struct ProbParmHost : amrex::Gpu::Managed
+{
+};
 
 namespace ProbParm {
 extern AMREX_GPU_DEVICE_MANAGED amrex::Real alpha;

--- a/ExecCpp/RegTests/EB-Plane/prob.H
+++ b/ExecCpp/RegTests/EB-Plane/prob.H
@@ -23,7 +23,8 @@ pc_initdata(
   int j,
   int k,
   amrex::Array4<amrex::Real> const& state,
-  amrex::GeometryData const& /*geomdata*/)
+  amrex::GeometryData const& /*geomdata*/,
+  ProbParmDevice const& /*prob_parm*/)
 {
   // Geometry
   // const amrex::Real* prob_lo = geomdata.ProbLo();
@@ -57,7 +58,8 @@ bcnormal(
   const int /*idir*/,
   const int /*sgn*/,
   const amrex::Real /*time*/,
-  amrex::GeometryData const& /*geomdata*/)
+  amrex::GeometryData const& /*geomdata*/,
+  ProbParmDevice const& /*prob_parm*/)
 {
   s_ext[URHO] = ProbParm::rho;
   s_ext[UMX] = ProbParm::rho * ProbParm::vx_in;

--- a/ExecCpp/RegTests/EB-Plane/prob.cpp
+++ b/ExecCpp/RegTests/EB-Plane/prob.cpp
@@ -28,13 +28,15 @@ amrex_probinit(
   const amrex_real* probhi)
 {
   // Parse params
-  amrex::ParmParse pp("prob");
-  pp.query("p", ProbParm::p);
-  pp.query("rho", ProbParm::rho);
-  pp.query("vx_in", ProbParm::vx_in);
-  pp.query("vy_in", ProbParm::vy_in);
-  pp.query("Re_L", ProbParm::Re_L);
-  pp.query("Pr", ProbParm::Pr);
+  {
+    amrex::ParmParse pp("prob");
+    pp.query("p", ProbParm::p);
+    pp.query("rho", ProbParm::rho);
+    pp.query("vx_in", ProbParm::vx_in);
+    pp.query("vy_in", ProbParm::vy_in);
+    pp.query("Re_L", ProbParm::Re_L);
+    pp.query("Pr", ProbParm::Pr);
+  }
 
   amrex::Real L = (probhi[0] - problo[0]) * 0.2;
 
@@ -45,12 +47,35 @@ amrex_probinit(
   EOS::EY2T(ProbParm::eint, ProbParm::massfrac.begin(), ProbParm::T);
   EOS::TY2Cp(ProbParm::T, ProbParm::massfrac.begin(), cp);
 
-  transport_params::const_bulk_viscosity = 0.0;
-  transport_params::const_diffusivity = 0.0;
-  transport_params::const_viscosity =
+  TransParm trans_parm;
+
+  // Default
+  trans_parm.const_viscosity = 0.0;
+  trans_parm.const_bulk_viscosity = 0.0;
+  trans_parm.const_conductivity = 0.0;
+  trans_parm.const_diffusivity = 0.0;
+
+  // User-specified
+  {
+    amrex::ParmParse pp("transport");
+    pp.query("const_viscosity", trans_parm.const_viscosity);
+    pp.query("const_bulk_viscosity", trans_parm.const_bulk_viscosity);
+    pp.query("const_conductivity", trans_parm.const_conductivity);
+    pp.query("const_diffusivity", trans_parm.const_diffusivity);
+  }
+
+  trans_parm.const_bulk_viscosity = 0.0;
+  trans_parm.const_diffusivity = 0.0;
+  trans_parm.const_viscosity =
     ProbParm::rho * ProbParm::vx_in * L / ProbParm::Re_L;
-  transport_params::const_conductivity =
-    transport_params::const_viscosity * cp / ProbParm::Pr;
+  trans_parm.const_conductivity =
+    trans_parm.const_viscosity * cp / ProbParm::Pr;
+
+#ifdef AMREX_USE_GPU
+  amrex::Gpu::htod_memcpy(trans_parm_g, &trans_parm, sizeof(trans_parm));
+#else
+  std::memcpy(trans_parm_g, &trans_parm, sizeof(trans_parm));
+#endif
 }
 }
 

--- a/ExecCpp/RegTests/EB-Plane/prob_parm.H
+++ b/ExecCpp/RegTests/EB-Plane/prob_parm.H
@@ -3,6 +3,15 @@
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>
+#include <AMReX_GpuMemory.H>
+
+struct ProbParmDevice : amrex::Gpu::Managed
+{
+};
+
+struct ProbParmHost : amrex::Gpu::Managed
+{
+};
 
 namespace ProbParm {
 extern AMREX_GPU_DEVICE_MANAGED amrex::Real p;

--- a/ExecCpp/RegTests/HIT/prob.H
+++ b/ExecCpp/RegTests/HIT/prob.H
@@ -26,7 +26,8 @@ pc_initdata(
   int j,
   int k,
   amrex::Array4<amrex::Real> const& state,
-  amrex::GeometryData const& geomdata)
+  amrex::GeometryData const& geomdata,
+  ProbParmDevice const& /*prob_parm*/)
 {
 
   // Geometry
@@ -169,7 +170,8 @@ bcnormal(
   const int /*idir*/,
   const int /*sgn*/,
   const amrex::Real /*time*/,
-  amrex::GeometryData const& /*geomdata*/)
+  amrex::GeometryData const& /*geomdata*/,
+  ProbParmDevice const& /*prob_parm*/)
 {
 }
 

--- a/ExecCpp/RegTests/HIT/prob_parm.H
+++ b/ExecCpp/RegTests/HIT/prob_parm.H
@@ -3,6 +3,15 @@
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>
+#include <AMReX_GpuMemory.H>
+
+struct ProbParmDevice : amrex::Gpu::Managed
+{
+};
+
+struct ProbParmHost : amrex::Gpu::Managed
+{
+};
 
 namespace ProbParm {
 extern std::string iname;

--- a/ExecCpp/RegTests/MMS/prob.H
+++ b/ExecCpp/RegTests/MMS/prob.H
@@ -30,7 +30,8 @@ pc_initdata(
   int j,
   int k,
   amrex::Array4<amrex::Real> const& state,
-  amrex::GeometryData const& geomdata)
+  amrex::GeometryData const& geomdata,
+  ProbParmDevice const& /*prob_parm*/)
 {
   // Geometry
   const amrex::Real* prob_lo = geomdata.ProbLo();
@@ -83,7 +84,8 @@ bcnormal(
   const int /*idir*/,
   const int /*sgn*/,
   const amrex::Real /*time*/,
-  amrex::GeometryData const& /*geomdata*/)
+  amrex::GeometryData const& /*geomdata*/,
+  ProbParmDevice const& /*prob_parm*/)
 {
   amrex::Real x0 = 0.0, x1 = 0.0, x2 = 0.0;
 

--- a/ExecCpp/RegTests/MMS/prob.cpp
+++ b/ExecCpp/RegTests/MMS/prob.cpp
@@ -61,43 +61,45 @@ amrex_probinit(
   const amrex_real* probhi)
 {
   // Parse params
-  amrex::ParmParse pp("prob");
-  pp.query("reynolds", ProbParm::reynolds);
-  pp.query("mach", ProbParm::mach);
-  pp.query("prandtl", ProbParm::prandtl);
-  pp.query("rho_x_fact", ProbParm::rho_x_fact);
-  pp.query("rho_y_fact", ProbParm::rho_y_fact);
-  pp.query("rho_z_fact", ProbParm::rho_z_fact);
-  pp.query("u_0_fact", ProbParm::u_0_fact);
-  pp.query("u_x_fact", ProbParm::u_x_fact);
-  pp.query("u_y_fact", ProbParm::u_y_fact);
-  pp.query("u_z_fact", ProbParm::u_z_fact);
-  pp.query("v_0_fact", ProbParm::v_0_fact);
-  pp.query("v_x_fact", ProbParm::v_x_fact);
-  pp.query("v_y_fact", ProbParm::v_y_fact);
-  pp.query("v_z_fact", ProbParm::v_z_fact);
-  pp.query("w_0_fact", ProbParm::w_0_fact);
-  pp.query("w_x_fact", ProbParm::w_x_fact);
-  pp.query("w_y_fact", ProbParm::w_y_fact);
-  pp.query("w_z_fact", ProbParm::w_z_fact);
-  pp.query("p_x_fact", ProbParm::p_x_fact);
-  pp.query("p_y_fact", ProbParm::p_y_fact);
-  pp.query("p_z_fact", ProbParm::p_z_fact);
-  pp.query("a_rhox", ProbParm::a_rhox);
-  pp.query("a_rhoy", ProbParm::a_rhoy);
-  pp.query("a_rhoz", ProbParm::a_rhoz);
-  pp.query("a_ux", ProbParm::a_ux);
-  pp.query("a_uy", ProbParm::a_uy);
-  pp.query("a_uz", ProbParm::a_uz);
-  pp.query("a_vx", ProbParm::a_vx);
-  pp.query("a_vy", ProbParm::a_vy);
-  pp.query("a_vz", ProbParm::a_vz);
-  pp.query("a_wx", ProbParm::a_wx);
-  pp.query("a_wy", ProbParm::a_wy);
-  pp.query("a_wz", ProbParm::a_wz);
-  pp.query("a_px", ProbParm::a_px);
-  pp.query("a_py", ProbParm::a_py);
-  pp.query("a_pz", ProbParm::a_pz);
+  {
+    amrex::ParmParse pp("prob");
+    pp.query("reynolds", ProbParm::reynolds);
+    pp.query("mach", ProbParm::mach);
+    pp.query("prandtl", ProbParm::prandtl);
+    pp.query("rho_x_fact", ProbParm::rho_x_fact);
+    pp.query("rho_y_fact", ProbParm::rho_y_fact);
+    pp.query("rho_z_fact", ProbParm::rho_z_fact);
+    pp.query("u_0_fact", ProbParm::u_0_fact);
+    pp.query("u_x_fact", ProbParm::u_x_fact);
+    pp.query("u_y_fact", ProbParm::u_y_fact);
+    pp.query("u_z_fact", ProbParm::u_z_fact);
+    pp.query("v_0_fact", ProbParm::v_0_fact);
+    pp.query("v_x_fact", ProbParm::v_x_fact);
+    pp.query("v_y_fact", ProbParm::v_y_fact);
+    pp.query("v_z_fact", ProbParm::v_z_fact);
+    pp.query("w_0_fact", ProbParm::w_0_fact);
+    pp.query("w_x_fact", ProbParm::w_x_fact);
+    pp.query("w_y_fact", ProbParm::w_y_fact);
+    pp.query("w_z_fact", ProbParm::w_z_fact);
+    pp.query("p_x_fact", ProbParm::p_x_fact);
+    pp.query("p_y_fact", ProbParm::p_y_fact);
+    pp.query("p_z_fact", ProbParm::p_z_fact);
+    pp.query("a_rhox", ProbParm::a_rhox);
+    pp.query("a_rhoy", ProbParm::a_rhoy);
+    pp.query("a_rhoz", ProbParm::a_rhoz);
+    pp.query("a_ux", ProbParm::a_ux);
+    pp.query("a_uy", ProbParm::a_uy);
+    pp.query("a_uz", ProbParm::a_uz);
+    pp.query("a_vx", ProbParm::a_vx);
+    pp.query("a_vy", ProbParm::a_vy);
+    pp.query("a_vz", ProbParm::a_vz);
+    pp.query("a_wx", ProbParm::a_wx);
+    pp.query("a_wy", ProbParm::a_wy);
+    pp.query("a_wz", ProbParm::a_wz);
+    pp.query("a_px", ProbParm::a_px);
+    pp.query("a_py", ProbParm::a_py);
+    pp.query("a_pz", ProbParm::a_pz);
+  }
 
   // Define the length scale
   AMREX_D_TERM(ProbParm::L_x = probhi[0] - problo[0];
@@ -114,13 +116,37 @@ amrex_probinit(
   EOS::TY2Cp(ProbParm::T0, massfrac, cp);
 
   ProbParm::u0 = ProbParm::mach * cs;
-  transport_params::const_bulk_viscosity =
+
+  TransParm trans_parm;
+
+  // Default
+  trans_parm.const_viscosity = 0.0;
+  trans_parm.const_bulk_viscosity = 0.0;
+  trans_parm.const_conductivity = 0.0;
+  trans_parm.const_diffusivity = 0.0;
+
+  // User-specified
+  {
+    amrex::ParmParse pp("transport");
+    pp.query("const_viscosity", trans_parm.const_viscosity);
+    pp.query("const_bulk_viscosity", trans_parm.const_bulk_viscosity);
+    pp.query("const_conductivity", trans_parm.const_conductivity);
+    pp.query("const_diffusivity", trans_parm.const_diffusivity);
+  }
+
+  trans_parm.const_bulk_viscosity =
     ProbParm::rho0 * ProbParm::u0 * ProbParm::L_x / ProbParm::reynolds;
-  transport_params::const_diffusivity = 0.0;
-  transport_params::const_viscosity =
+  trans_parm.const_diffusivity = 0.0;
+  trans_parm.const_viscosity =
     ProbParm::rho0 * ProbParm::u0 * ProbParm::L_x / ProbParm::reynolds;
-  transport_params::const_conductivity =
-    transport_params::const_viscosity * cp / ProbParm::prandtl;
+  trans_parm.const_conductivity =
+    trans_parm.const_viscosity * cp / ProbParm::prandtl;
+
+#ifdef AMREX_USE_GPU
+  amrex::Gpu::htod_memcpy(trans_parm_g, &trans_parm, sizeof(trans_parm));
+#else
+  std::memcpy(trans_parm_g, &trans_parm, sizeof(trans_parm));
+#endif
 
   // clang-format off
   // MASA parameters for the following functions
@@ -132,10 +158,10 @@ amrex_probinit(
   // clang-format on
   masa_set_param("L", ProbParm::L_x);
   masa_set_param("R", EOS::RU / EOS::AIRMW);
-  masa_set_param("k", transport_params::const_conductivity);
+  masa_set_param("k", trans_parm.const_conductivity);
   masa_set_param("Gamma", EOS::gamma);
-  masa_set_param("mu", transport_params::const_viscosity);
-  masa_set_param("mu_bulk", transport_params::const_bulk_viscosity);
+  masa_set_param("mu", trans_parm.const_viscosity);
+  masa_set_param("mu_bulk", trans_parm.const_bulk_viscosity);
   masa_set_param("rho_0", ProbParm::rho0);
   masa_set_param("rho_x", ProbParm::rho_x_fact * ProbParm::rho0);
   masa_set_param("rho_y", ProbParm::rho_y_fact);

--- a/ExecCpp/RegTests/MMS/prob_parm.H
+++ b/ExecCpp/RegTests/MMS/prob_parm.H
@@ -3,6 +3,15 @@
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>
+#include <AMReX_GpuMemory.H>
+
+struct ProbParmDevice : amrex::Gpu::Managed
+{
+};
+
+struct ProbParmHost : amrex::Gpu::Managed
+{
+};
 
 namespace ProbParm {
 extern AMREX_GPU_DEVICE_MANAGED amrex::Real reynolds;

--- a/ExecCpp/RegTests/MultiSpecSod/prob.H
+++ b/ExecCpp/RegTests/MultiSpecSod/prob.H
@@ -25,7 +25,8 @@ pc_initdata(
   int j,
   int k,
   amrex::Array4<amrex::Real> const& state,
-  amrex::GeometryData const& geomdata)
+  amrex::GeometryData const& geomdata,
+  ProbParmDevice const& /*prob_parm*/)
 {
   // Geometry
   const amrex::Real* prob_lo = geomdata.ProbLo();
@@ -128,7 +129,8 @@ bcnormal(
   const int /*idir*/,
   const int /*sgn*/,
   const amrex::Real /*time*/,
-  amrex::GeometryData const& /*geomdata*/)
+  amrex::GeometryData const& /*geomdata*/,
+  ProbParmDevice const& /*prob_parm*/)
 {
   for (int n = 0; n < NVAR; n++) {
     s_ext[n] = s_int[n];

--- a/ExecCpp/RegTests/MultiSpecSod/prob_parm.H
+++ b/ExecCpp/RegTests/MultiSpecSod/prob_parm.H
@@ -3,6 +3,15 @@
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>
+#include <AMReX_GpuMemory.H>
+
+struct ProbParmDevice : amrex::Gpu::Managed
+{
+};
+
+struct ProbParmHost : amrex::Gpu::Managed
+{
+};
 
 namespace ProbParm {
 extern AMREX_GPU_DEVICE_MANAGED amrex::Real p_l;

--- a/ExecCpp/RegTests/PMF/inputs_ex
+++ b/ExecCpp/RegTests/PMF/inputs_ex
@@ -56,11 +56,7 @@ prob.pmf_datafile = "LiDryer_H2_p1_phi0_4000tu0300.dat"
 tagging.max_ftracerr_lev = 4
 tagging.ftracerr = 150.e-6
 
-extern.new_Jacobian_each_cell = 0
-
-amr.derive_plot_vars = magvort density xmom ymom zmom eden Temp pressure x_velocity y_velocity z_velocity
-pelec.plot_rhoy = 0
-pelec.plot_massfrac = 1
+#amr.derive_plot_vars = ALL
 pelec.do_react = 1
 pelec.diffuse_temp=1
 pelec.diffuse_enth=1

--- a/ExecCpp/RegTests/PMF/prob.H
+++ b/ExecCpp/RegTests/PMF/prob.H
@@ -19,50 +19,51 @@ void
 pmf(
   amrex::Real xlo,
   amrex::Real xhi,
-  amrex::GpuArray<amrex::Real, NUM_SPECIES + 4>& y_vector)
+  amrex::GpuArray<amrex::Real, NUM_SPECIES + 4>& y_vector,
+  ProbParmDevice const& prob_parm)
 {
-  if (ProbParm::pmf_do_average) {
+  if (prob_parm.pmf_do_average) {
     int lo_loside = 0;
     int lo_hiside = 0;
     int hi_loside = 0;
     int hi_hiside = 0;
-    if (xlo < ProbParm::d_pmf_X[0]) {
+    if (xlo < prob_parm.d_pmf_X[0]) {
       lo_loside = 0;
       lo_hiside = 0;
     }
-    if (xhi < ProbParm::d_pmf_X[0]) {
+    if (xhi < prob_parm.d_pmf_X[0]) {
       hi_loside = 0;
       hi_hiside = 0;
     }
-    if (xlo > ProbParm::d_pmf_X[ProbParm::pmf_N - 1]) {
-      lo_loside = ProbParm::pmf_N - 1;
-      lo_hiside = ProbParm::pmf_N - 1;
+    if (xlo > prob_parm.d_pmf_X[prob_parm.pmf_N - 1]) {
+      lo_loside = prob_parm.pmf_N - 1;
+      lo_hiside = prob_parm.pmf_N - 1;
     }
-    if (xhi > ProbParm::d_pmf_X[ProbParm::pmf_N - 1]) {
-      hi_loside = ProbParm::pmf_N - 1;
-      hi_hiside = ProbParm::pmf_N - 1;
+    if (xhi > prob_parm.d_pmf_X[prob_parm.pmf_N - 1]) {
+      hi_loside = prob_parm.pmf_N - 1;
+      hi_hiside = prob_parm.pmf_N - 1;
     }
     if (lo_loside == 0) {
-      for (unsigned int i = 0; i < ProbParm::pmf_N - 1; i++) {
-        if ((xlo > ProbParm::d_pmf_X[i]) && (xlo < ProbParm::d_pmf_X[i + 1])) {
+      for (unsigned int i = 0; i < prob_parm.pmf_N - 1; i++) {
+        if ((xlo > prob_parm.d_pmf_X[i]) && (xlo < prob_parm.d_pmf_X[i + 1])) {
           lo_loside = i;
           lo_hiside = i + 1;
         }
       }
     }
     if (hi_loside == 0) {
-      for (unsigned int i = 0; i < ProbParm::pmf_N - 1; i++) {
-        if ((xhi > ProbParm::d_pmf_X[i]) && (xhi < ProbParm::d_pmf_X[i + 1])) {
+      for (unsigned int i = 0; i < prob_parm.pmf_N - 1; i++) {
+        if ((xhi > prob_parm.d_pmf_X[i]) && (xhi < prob_parm.d_pmf_X[i + 1])) {
           hi_loside = i;
           hi_hiside = i + 1;
         }
       }
     }
-    for (unsigned int j = 0; j < ProbParm::pmf_M; j++) {
-      amrex::Real x1 = ProbParm::d_pmf_X[lo_loside];
-      amrex::Real y1 = ProbParm::d_pmf_Y[ProbParm::pmf_N * j + lo_loside];
-      amrex::Real x2 = ProbParm::d_pmf_X[lo_hiside];
-      amrex::Real y2 = ProbParm::d_pmf_Y[ProbParm::pmf_N * j + lo_hiside];
+    for (unsigned int j = 0; j < prob_parm.pmf_M; j++) {
+      amrex::Real x1 = prob_parm.d_pmf_X[lo_loside];
+      amrex::Real y1 = prob_parm.d_pmf_Y[prob_parm.pmf_N * j + lo_loside];
+      amrex::Real x2 = prob_parm.d_pmf_X[lo_hiside];
+      amrex::Real y2 = prob_parm.d_pmf_Y[prob_parm.pmf_N * j + lo_hiside];
       amrex::Real dydx = 0.0;
       if (lo_loside == lo_hiside)
         dydx = 0.0;
@@ -75,10 +76,10 @@ pmf(
         y_vector[j] = 0.5 * (ylo + yhi);
       } else {
         amrex::Real sum = (x2 - xlo) * 0.5 * (ylo + y2);
-        x1 = ProbParm::d_pmf_X[hi_loside];
-        y1 = ProbParm::d_pmf_Y[ProbParm::pmf_N * j + hi_loside];
-        x2 = ProbParm::d_pmf_X[hi_hiside];
-        y2 = ProbParm::d_pmf_Y[ProbParm::pmf_N * j + hi_hiside];
+        x1 = prob_parm.d_pmf_X[hi_loside];
+        y1 = prob_parm.d_pmf_Y[prob_parm.pmf_N * j + hi_loside];
+        x2 = prob_parm.d_pmf_X[hi_hiside];
+        y2 = prob_parm.d_pmf_Y[prob_parm.pmf_N * j + hi_hiside];
         if (hi_loside == hi_hiside)
           dydx = 0.0;
         else
@@ -86,9 +87,9 @@ pmf(
         yhi = y1 + dydx * (xhi - x1);
         sum += (xhi - x1) * 0.5 * (yhi + y1);
         for (int k = lo_hiside; k < hi_loside - 1; k++) {
-          sum += (ProbParm::d_pmf_X[k + 1] - ProbParm::d_pmf_X[k]) * 0.5 *
-                 (ProbParm::d_pmf_Y[ProbParm::pmf_N * j + k] +
-                  ProbParm::d_pmf_Y[ProbParm::pmf_N * j + k + 1]);
+          sum += (prob_parm.d_pmf_X[k + 1] - prob_parm.d_pmf_X[k]) * 0.5 *
+                 (prob_parm.d_pmf_Y[prob_parm.pmf_N * j + k] +
+                  prob_parm.d_pmf_Y[prob_parm.pmf_N * j + k + 1]);
         }
         y_vector[j] = sum / (xhi - xlo);
       }
@@ -97,29 +98,29 @@ pmf(
     amrex::Real xmid = 0.5 * (xlo + xhi);
     int loside = -1;
     int hiside = -1;
-    if (xmid < ProbParm::d_pmf_X[0]) {
+    if (xmid < prob_parm.d_pmf_X[0]) {
       loside = 0;
       hiside = 0;
     }
-    if (xmid > ProbParm::d_pmf_X[ProbParm::pmf_N - 1]) {
-      loside = ProbParm::pmf_N - 1;
-      hiside = ProbParm::pmf_N - 1;
+    if (xmid > prob_parm.d_pmf_X[prob_parm.pmf_N - 1]) {
+      loside = prob_parm.pmf_N - 1;
+      hiside = prob_parm.pmf_N - 1;
     }
     if (loside == -1) {
-      for (unsigned int i = 0; i < ProbParm::pmf_N - 1; i++) {
+      for (unsigned int i = 0; i < prob_parm.pmf_N - 1; i++) {
         if (
-          (xmid >= ProbParm::d_pmf_X[i]) &&
-          (xmid <= ProbParm::d_pmf_X[i + 1])) {
+          (xmid >= prob_parm.d_pmf_X[i]) &&
+          (xmid <= prob_parm.d_pmf_X[i + 1])) {
           loside = i;
           hiside = i + 1;
         }
       }
     }
-    for (unsigned int j = 0; j < ProbParm::pmf_M; j++) {
-      const amrex::Real x1 = ProbParm::d_pmf_X[loside];
-      const amrex::Real y1 = ProbParm::d_pmf_Y[ProbParm::pmf_N * j + loside];
-      const amrex::Real x2 = ProbParm::d_pmf_X[hiside];
-      const amrex::Real y2 = ProbParm::d_pmf_Y[ProbParm::pmf_N * j + hiside];
+    for (unsigned int j = 0; j < prob_parm.pmf_M; j++) {
+      const amrex::Real x1 = prob_parm.d_pmf_X[loside];
+      const amrex::Real y1 = prob_parm.d_pmf_Y[prob_parm.pmf_N * j + loside];
+      const amrex::Real x2 = prob_parm.d_pmf_X[hiside];
+      const amrex::Real y2 = prob_parm.d_pmf_Y[prob_parm.pmf_N * j + hiside];
       amrex::Real dydx = 0.0;
       if (loside == hiside)
         dydx = 0.0;
@@ -138,9 +139,10 @@ pc_initdata(
   int j,
   int k,
   amrex::Array4<amrex::Real> const& state,
-  amrex::GeometryData const& geomdata)
+  amrex::GeometryData const& geomdata,
+  ProbParmDevice const& prob_parm)
 {
-  if (ProbParm::phi_in < 0.0) {
+  if (prob_parm.phi_in < 0.0) {
     const amrex::Real* prob_lo = geomdata.ProbLo();
     // const amrex::Real* prob_hi = geomdata.ProbHi();
     const amrex::Real* dx = geomdata.CellSize();
@@ -149,24 +151,24 @@ pc_initdata(
     const amrex::Real z = prob_lo[2] + (k + 0.5) * dx[2];
     amrex::GpuArray<amrex::Real, NUM_SPECIES + 4> pmf_vals = {{0.0}};
     amrex::Real pert = 0.0;
-    if (ProbParm::pertmag > 0.0) {
-      pert = ProbParm::pertmag *
-             (1.0 * std::sin(2 * PI * 4 * x / ProbParm::L[0]) *
-                std::sin(2 * PI * 5 * y / ProbParm::L[1]) +
-              1.023 * std::sin(2 * PI * 2 * (x - 0.4598) / ProbParm::L[0]) *
-                std::sin(2 * PI * 4 * (y - 0.53765) / ProbParm::L[1]) +
-              0.945 * std::sin(2 * PI * 3 * (x - 0.712435) / ProbParm::L[0]) *
-                std::sin(2 * PI * 3 * (y - 2.137) / ProbParm::L[1]) +
-              1.017 * std::sin(2 * PI * 5 * (x - 0.33) / ProbParm::L[0]) *
-                std::sin(2 * PI * 6 * (y - 1.8) / ProbParm::L[1]) +
-              0.982 * std::sin(2 * PI * 5 * (x - 1.4234) / ProbParm::L[0]));
+    if (prob_parm.pertmag > 0.0) {
+      pert = prob_parm.pertmag *
+             (1.0 * std::sin(2 * PI * 4 * x / prob_parm.L[0]) *
+                std::sin(2 * PI * 5 * y / prob_parm.L[1]) +
+              1.023 * std::sin(2 * PI * 2 * (x - 0.4598) / prob_parm.L[0]) *
+                std::sin(2 * PI * 4 * (y - 0.53765) / prob_parm.L[1]) +
+              0.945 * std::sin(2 * PI * 3 * (x - 0.712435) / prob_parm.L[0]) *
+                std::sin(2 * PI * 3 * (y - 2.137) / prob_parm.L[1]) +
+              1.017 * std::sin(2 * PI * 5 * (x - 0.33) / prob_parm.L[0]) *
+                std::sin(2 * PI * 6 * (y - 1.8) / prob_parm.L[1]) +
+              0.982 * std::sin(2 * PI * 5 * (x - 1.4234) / prob_parm.L[0]));
     }
-    pmf(z + pert, z + pert, pmf_vals);
+    pmf(z + pert, z + pert, pmf_vals, prob_parm);
     amrex::Real molefrac[NUM_SPECIES] = {0.0};
     for (int n = 0; n < NUM_SPECIES; n++)
       molefrac[n] = pmf_vals[3 + n];
     const amrex::Real T = pmf_vals[0];
-    const amrex::Real pres = ProbParm::pamb;
+    const amrex::Real pres = prob_parm.pamb;
     amrex::Real u[3] = {0.0};
     u[AMREX_SPACEDIM - 1] = pmf_vals[1];
     amrex::Real massfrac[NUM_SPECIES] = {0.0};
@@ -186,7 +188,7 @@ pc_initdata(
       state(i, j, k, UFS + n) = rho * massfrac[n];
   } else {
     for (int n = 0; n < NVAR; n++)
-      state(i, j, k, n) = ProbParm::d_fuel_state[n];
+      state(i, j, k, n) = prob_parm.d_fuel_state[n];
   }
 }
 
@@ -200,7 +202,8 @@ bcnormal(
   const int idir,
   const int sgn,
   const amrex::Real /*time*/,
-  amrex::GeometryData const& geomdata)
+  amrex::GeometryData const& geomdata,
+  ProbParmDevice const& prob_parm)
 {
   const amrex::Real* prob_lo = geomdata.ProbLo();
   const amrex::Real* prob_hi = geomdata.ProbHi();
@@ -211,11 +214,11 @@ bcnormal(
   amrex::Real /* pert, */ rho, energy, T, pres;
 
   if (sgn == -1) {
-    pmf(prob_hi[idir], prob_hi[idir], pmf_vals);
+    pmf(prob_hi[idir], prob_hi[idir], pmf_vals, prob_parm);
     for (int n = 0; n < NUM_SPECIES; n++)
       molefrac[n] = pmf_vals[3 + n];
     T = pmf_vals[0];
-    pres = ProbParm::pamb;
+    pres = prob_parm.pamb;
     u[0] = 0.0;
     u[1] = 0.0;
     u[2] = 0.0;
@@ -234,11 +237,11 @@ bcnormal(
       s_ext[UFS + n] = rho * massfrac[n];
 
   } else {
-    pmf(prob_lo[idir], prob_lo[idir], pmf_vals);
+    pmf(prob_lo[idir], prob_lo[idir], pmf_vals, prob_parm);
     for (int n = 0; n < NUM_SPECIES; n++)
       molefrac[n] = pmf_vals[3 + n];
     T = pmf_vals[0];
-    pres = ProbParm::pamb;
+    pres = prob_parm.pamb;
     u[0] = 0.0;
     u[1] = 0.0;
     u[2] = 0.0;

--- a/ExecCpp/RegTests/PMF/prob.H
+++ b/ExecCpp/RegTests/PMF/prob.H
@@ -188,7 +188,7 @@ pc_initdata(
       state(i, j, k, UFS + n) = rho * massfrac[n];
   } else {
     for (int n = 0; n < NVAR; n++)
-      state(i, j, k, n) = prob_parm.d_fuel_state[n];
+      state(i, j, k, n) = prob_parm.fuel_state[n];
   }
 }
 

--- a/ExecCpp/RegTests/PMF/prob.cpp
+++ b/ExecCpp/RegTests/PMF/prob.cpp
@@ -165,8 +165,6 @@ init_bc()
 void
 pc_prob_close()
 {
-  PeleC::prob_parm_device->d_pmf_X = nullptr;
-  PeleC::prob_parm_device->d_pmf_Y = nullptr;
 }
 
 extern "C" {

--- a/ExecCpp/RegTests/PMF/prob.cpp
+++ b/ExecCpp/RegTests/PMF/prob.cpp
@@ -138,17 +138,16 @@ init_bc()
   vt = PeleC::prob_parm->vn_in;
   ek = 0.5 * (vt * vt);
 
-  (*PeleC::prob_parm->fuel_state)[URHO] = rho;
-  (*PeleC::prob_parm->fuel_state)[UMX] = 0.0;
-  (*PeleC::prob_parm->fuel_state)[UMY] = rho * vt;
-  (*PeleC::prob_parm->fuel_state)[UMZ] = 0.0;
-  (*PeleC::prob_parm->fuel_state)[UEINT] = rho * e;
-  (*PeleC::prob_parm->fuel_state)[UEDEN] = rho * (e + ek);
-  (*PeleC::prob_parm->fuel_state)[UTEMP] = T;
+  PeleC::prob_parm->fuel_state[URHO] = rho;
+  PeleC::prob_parm->fuel_state[UMX] = 0.0;
+  PeleC::prob_parm->fuel_state[UMY] = rho * vt;
+  PeleC::prob_parm->fuel_state[UMZ] = 0.0;
+  PeleC::prob_parm->fuel_state[UEINT] = rho * e;
+  PeleC::prob_parm->fuel_state[UEDEN] = rho * (e + ek);
+  PeleC::prob_parm->fuel_state[UTEMP] = T;
   for (int n = 0; n < NUM_SPECIES; n++) {
-    (*PeleC::prob_parm->fuel_state)[UFS + n - 1] = rho * massfrac[n];
+    PeleC::prob_parm->fuel_state[UFS + n - 1] = rho * massfrac[n];
   }
-  PeleC::prob_parm->d_fuel_state = PeleC::prob_parm->fuel_state->dataPtr();
 }
 
 void
@@ -156,14 +155,11 @@ pc_prob_close()
 {
   delete PeleC::prob_parm->pmf_X;
   delete PeleC::prob_parm->pmf_Y;
-  delete PeleC::prob_parm->fuel_state;
 
   PeleC::prob_parm->pmf_X = nullptr;
   PeleC::prob_parm->pmf_Y = nullptr;
-  PeleC::prob_parm->fuel_state = nullptr;
   PeleC::prob_parm->d_pmf_X = nullptr;
   PeleC::prob_parm->d_pmf_Y = nullptr;
-  PeleC::prob_parm->d_fuel_state = nullptr;
 }
 
 extern "C" {
@@ -191,8 +187,6 @@ amrex_probinit(
 
   PeleC::prob_parm->pmf_X = new amrex::Gpu::DeviceVector<amrex::Real>;
   PeleC::prob_parm->pmf_Y = new amrex::Gpu::DeviceVector<amrex::Real>;
-  PeleC::prob_parm->fuel_state = new amrex::Gpu::DeviceVector<amrex::Real>;
-  PeleC::prob_parm->fuel_state->resize(NVAR);
 
   read_pmf(pmf_datafile);
 

--- a/ExecCpp/RegTests/PMF/prob.cpp
+++ b/ExecCpp/RegTests/PMF/prob.cpp
@@ -1,29 +1,5 @@
 #include "prob.H"
 
-namespace ProbParm {
-AMREX_GPU_DEVICE_MANAGED amrex::Real pamb = 1013250.0 * 100.0;
-AMREX_GPU_DEVICE_MANAGED amrex::Real phi_in = -0.2;
-AMREX_GPU_DEVICE_MANAGED amrex::Real T_in = 298.0;
-AMREX_GPU_DEVICE_MANAGED amrex::Real vn_in = 0.2;
-AMREX_GPU_DEVICE_MANAGED amrex::Real pertmag = 0.0;
-AMREX_GPU_DEVICE_MANAGED amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> L = {
-  {1.0}};
-AMREX_GPU_DEVICE_MANAGED unsigned int pmf_N = 0;
-AMREX_GPU_DEVICE_MANAGED unsigned int pmf_M = 0;
-AMREX_GPU_DEVICE_MANAGED bool pmf_do_average = false;
-
-amrex::Gpu::ManagedVector<amrex::Real>* pmf_X = nullptr;
-amrex::Gpu::ManagedVector<amrex::Real>* pmf_Y = nullptr;
-amrex::Gpu::ManagedVector<amrex::Real>* fuel_state = nullptr;
-
-AMREX_GPU_DEVICE_MANAGED amrex::Real* d_pmf_X = nullptr;
-AMREX_GPU_DEVICE_MANAGED amrex::Real* d_pmf_Y = nullptr;
-AMREX_GPU_DEVICE_MANAGED amrex::Real* d_fuel_state = nullptr;
-
-std::string pmf_datafile;
-amrex::Vector<std::string> pmf_names;
-} // namespace ProbParm
-
 std::string
 read_pmf_file(std::ifstream& in)
 {
@@ -75,20 +51,21 @@ read_pmf(const std::string& myfile)
     pos1 = pos2 + 1;
   }
 
-  ProbParm::pmf_names.resize(variable_count);
+  amrex::Vector<std::string> pmf_names;
+  pmf_names.resize(variable_count);
   pos1 = 0;
   // pos2 = 0;
   for (int i = 0; i < variable_count; i++) {
     pos1 = firstline.find('"', pos1);
     pos2 = firstline.find('"', pos1 + 1);
-    ProbParm::pmf_names[i] = firstline.substr(pos1 + 1, pos2 - (pos1 + 1));
+    pmf_names[i] = firstline.substr(pos1 + 1, pos2 - (pos1 + 1));
     pos1 = pos2 + 1;
   }
 
   amrex::Print() << variable_count << " variables found in PMF file"
                  << std::endl;
   // for (int i = 0; i < variable_count; i++)
-  //  amrex::Print() << "Variable found: " << ProbParm::pmf_names[i] <<
+  //  amrex::Print() << "Variable found: " << pmf_names[i] <<
   //  std::endl;
 
   line_count = 0;
@@ -97,25 +74,26 @@ read_pmf(const std::string& myfile)
   }
   amrex::Print() << line_count << " data lines found in PMF file" << std::endl;
 
-  ProbParm::pmf_N = line_count;
-  ProbParm::pmf_M = variable_count - 1;
-  ProbParm::pmf_X->resize(ProbParm::pmf_N);
-  ProbParm::pmf_Y->resize(ProbParm::pmf_N * ProbParm::pmf_M);
+  PeleC::prob_parm->pmf_N = line_count;
+  PeleC::prob_parm->pmf_M = variable_count - 1;
+  PeleC::prob_parm->pmf_X->resize(PeleC::prob_parm->pmf_N);
+  PeleC::prob_parm->pmf_Y->resize(
+    PeleC::prob_parm->pmf_N * PeleC::prob_parm->pmf_M);
 
   iss.clear();
   iss.seekg(0, std::ios::beg);
   std::getline(iss, firstline);
   std::getline(iss, secondline);
-  for (unsigned int i = 0; i < ProbParm::pmf_N; i++) {
+  for (unsigned int i = 0; i < PeleC::prob_parm->pmf_N; i++) {
     std::getline(iss, remaininglines);
     std::istringstream sinput(remaininglines);
-    sinput >> (*ProbParm::pmf_X)[i];
-    for (unsigned int j = 0; j < ProbParm::pmf_M; j++) {
-      sinput >> (*ProbParm::pmf_Y)[j * ProbParm::pmf_N + i];
+    sinput >> (*PeleC::prob_parm->pmf_X)[i];
+    for (unsigned int j = 0; j < PeleC::prob_parm->pmf_M; j++) {
+      sinput >> (*PeleC::prob_parm->pmf_Y)[j * PeleC::prob_parm->pmf_N + i];
     }
   }
-  ProbParm::d_pmf_X = ProbParm::pmf_X->dataPtr();
-  ProbParm::d_pmf_Y = ProbParm::pmf_Y->dataPtr();
+  PeleC::prob_parm->d_pmf_X = PeleC::prob_parm->pmf_X->dataPtr();
+  PeleC::prob_parm->d_pmf_Y = PeleC::prob_parm->pmf_Y->dataPtr();
 }
 
 void
@@ -130,10 +108,10 @@ init_bc()
   amrex::Real massfrac[NUM_SPECIES];
   amrex::GpuArray<amrex::Real, NUM_SPECIES + 4> pmf_vals = {{0.0}};
 
-  if (ProbParm::phi_in < 0) {
+  if (PeleC::prob_parm->phi_in < 0) {
     const amrex::Real yl = 0.0;
     const amrex::Real yr = 0.0;
-    pmf(yl, yr, pmf_vals);
+    pmf(yl, yr, pmf_vals, *PeleC::prob_parm);
     amrex::Real mysum = 0.0;
     for (int n = 0; n < NUM_SPECIES; n++) {
       molefrac[n] = amrex::max<amrex::Real>(0.0, pmf_vals[3 + n]);
@@ -141,51 +119,51 @@ init_bc()
     }
     molefrac[N2_ID] = 1.0 - (mysum - molefrac[N2_ID]);
     T = pmf_vals[0];
-    ProbParm::vn_in = pmf_vals[1];
+    PeleC::prob_parm->vn_in = pmf_vals[1];
   } else {
     const amrex::Real a = 0.5;
     for (amrex::Real& n : molefrac) {
       n = 0.0;
     }
-    molefrac[O2_ID] = 1.0 / (1.0 + ProbParm::phi_in / a + 0.79 / 0.21);
-    molefrac[H2_ID] = ProbParm::phi_in * molefrac[O2_ID] / a;
+    molefrac[O2_ID] = 1.0 / (1.0 + PeleC::prob_parm->phi_in / a + 0.79 / 0.21);
+    molefrac[H2_ID] = PeleC::prob_parm->phi_in * molefrac[O2_ID] / a;
     molefrac[N2_ID] = 1.0 - molefrac[H2_ID] - molefrac[O2_ID];
-    T = ProbParm::T_in;
+    T = PeleC::prob_parm->T_in;
   }
-  const amrex::Real p = ProbParm::pamb;
+  const amrex::Real p = PeleC::prob_parm->pamb;
 
   EOS::X2Y(molefrac, massfrac);
   EOS::PYT2RE(p, massfrac, T, rho, e);
 
-  vt = ProbParm::vn_in;
+  vt = PeleC::prob_parm->vn_in;
   ek = 0.5 * (vt * vt);
 
-  (*ProbParm::fuel_state)[URHO] = rho;
-  (*ProbParm::fuel_state)[UMX] = 0.0;
-  (*ProbParm::fuel_state)[UMY] = rho * vt;
-  (*ProbParm::fuel_state)[UMZ] = 0.0;
-  (*ProbParm::fuel_state)[UEINT] = rho * e;
-  (*ProbParm::fuel_state)[UEDEN] = rho * (e + ek);
-  (*ProbParm::fuel_state)[UTEMP] = T;
+  (*PeleC::prob_parm->fuel_state)[URHO] = rho;
+  (*PeleC::prob_parm->fuel_state)[UMX] = 0.0;
+  (*PeleC::prob_parm->fuel_state)[UMY] = rho * vt;
+  (*PeleC::prob_parm->fuel_state)[UMZ] = 0.0;
+  (*PeleC::prob_parm->fuel_state)[UEINT] = rho * e;
+  (*PeleC::prob_parm->fuel_state)[UEDEN] = rho * (e + ek);
+  (*PeleC::prob_parm->fuel_state)[UTEMP] = T;
   for (int n = 0; n < NUM_SPECIES; n++) {
-    (*ProbParm::fuel_state)[UFS + n - 1] = rho * massfrac[n];
+    (*PeleC::prob_parm->fuel_state)[UFS + n - 1] = rho * massfrac[n];
   }
-  ProbParm::d_fuel_state = ProbParm::fuel_state->dataPtr();
+  PeleC::prob_parm->d_fuel_state = PeleC::prob_parm->fuel_state->dataPtr();
 }
 
 void
 pc_prob_close()
 {
-  delete ProbParm::pmf_X;
-  delete ProbParm::pmf_Y;
-  delete ProbParm::fuel_state;
+  delete PeleC::prob_parm->pmf_X;
+  delete PeleC::prob_parm->pmf_Y;
+  delete PeleC::prob_parm->fuel_state;
 
-  ProbParm::pmf_X = nullptr;
-  ProbParm::pmf_Y = nullptr;
-  ProbParm::fuel_state = nullptr;
-  ProbParm::d_pmf_X = nullptr;
-  ProbParm::d_pmf_Y = nullptr;
-  ProbParm::d_fuel_state = nullptr;
+  PeleC::prob_parm->pmf_X = nullptr;
+  PeleC::prob_parm->pmf_Y = nullptr;
+  PeleC::prob_parm->fuel_state = nullptr;
+  PeleC::prob_parm->d_pmf_X = nullptr;
+  PeleC::prob_parm->d_pmf_Y = nullptr;
+  PeleC::prob_parm->d_fuel_state = nullptr;
 }
 
 extern "C" {
@@ -197,24 +175,26 @@ amrex_probinit(
   const amrex_real* problo,
   const amrex_real* probhi)
 {
+  std::string pmf_datafile;
+
   amrex::ParmParse pp("prob");
-  pp.query("pamb", ProbParm::pamb);
-  pp.query("phi_in", ProbParm::phi_in);
-  pp.query("T_in", ProbParm::T_in);
-  pp.query("vn_in", ProbParm::vn_in);
-  pp.query("pertmag", ProbParm::pertmag);
-  pp.query("pmf_datafile", ProbParm::pmf_datafile);
+  pp.query("pamb", PeleC::prob_parm->pamb);
+  pp.query("phi_in", PeleC::prob_parm->phi_in);
+  pp.query("T_in", PeleC::prob_parm->T_in);
+  pp.query("vn_in", PeleC::prob_parm->vn_in);
+  pp.query("pertmag", PeleC::prob_parm->pertmag);
+  pp.query("pmf_datafile", pmf_datafile);
 
-  ProbParm::L[0] = probhi[0] - problo[0];
-  ProbParm::L[1] = probhi[1] - problo[1];
-  ProbParm::L[2] = probhi[2] - problo[2];
+  PeleC::prob_parm->L[0] = probhi[0] - problo[0];
+  PeleC::prob_parm->L[1] = probhi[1] - problo[1];
+  PeleC::prob_parm->L[2] = probhi[2] - problo[2];
 
-  ProbParm::pmf_X = new amrex::Gpu::ManagedVector<amrex::Real>;
-  ProbParm::pmf_Y = new amrex::Gpu::ManagedVector<amrex::Real>;
-  ProbParm::fuel_state = new amrex::Gpu::ManagedVector<amrex::Real>;
-  ProbParm::fuel_state->resize(NVAR);
+  PeleC::prob_parm->pmf_X = new amrex::Gpu::DeviceVector<amrex::Real>;
+  PeleC::prob_parm->pmf_Y = new amrex::Gpu::DeviceVector<amrex::Real>;
+  PeleC::prob_parm->fuel_state = new amrex::Gpu::DeviceVector<amrex::Real>;
+  PeleC::prob_parm->fuel_state->resize(NVAR);
 
-  read_pmf(ProbParm::pmf_datafile);
+  read_pmf(pmf_datafile);
 
   init_bc();
 }

--- a/ExecCpp/RegTests/PMF/prob.cpp
+++ b/ExecCpp/RegTests/PMF/prob.cpp
@@ -74,36 +74,37 @@ read_pmf(const std::string& myfile)
   }
   amrex::Print() << line_count << " data lines found in PMF file" << std::endl;
 
-  PeleC::prob_parm->pmf_N = line_count;
-  PeleC::prob_parm->pmf_M = variable_count - 1;
-  PeleC::prob_parm->h_pmf_X.resize(PeleC::prob_parm->pmf_N);
-  PeleC::prob_parm->pmf_X.resize(PeleC::prob_parm->pmf_N);
-  PeleC::prob_parm->h_pmf_Y.resize(
-    PeleC::prob_parm->pmf_N * PeleC::prob_parm->pmf_M);
-  PeleC::prob_parm->pmf_Y.resize(
-    PeleC::prob_parm->pmf_N * PeleC::prob_parm->pmf_M);
+  PeleC::prob_parm_device->pmf_N = line_count;
+  PeleC::prob_parm_device->pmf_M = variable_count - 1;
+  PeleC::prob_parm_host->h_pmf_X.resize(PeleC::prob_parm_device->pmf_N);
+  PeleC::prob_parm_host->pmf_X.resize(PeleC::prob_parm_device->pmf_N);
+  PeleC::prob_parm_host->h_pmf_Y.resize(
+    PeleC::prob_parm_device->pmf_N * PeleC::prob_parm_device->pmf_M);
+  PeleC::prob_parm_host->pmf_Y.resize(
+    PeleC::prob_parm_device->pmf_N * PeleC::prob_parm_device->pmf_M);
 
   iss.clear();
   iss.seekg(0, std::ios::beg);
   std::getline(iss, firstline);
   std::getline(iss, secondline);
-  for (unsigned int i = 0; i < PeleC::prob_parm->pmf_N; i++) {
+  for (unsigned int i = 0; i < PeleC::prob_parm_device->pmf_N; i++) {
     std::getline(iss, remaininglines);
     std::istringstream sinput(remaininglines);
-    sinput >> PeleC::prob_parm->h_pmf_X[i];
-    for (unsigned int j = 0; j < PeleC::prob_parm->pmf_M; j++) {
-      sinput >> PeleC::prob_parm->h_pmf_Y[j * PeleC::prob_parm->pmf_N + i];
+    sinput >> PeleC::prob_parm_host->h_pmf_X[i];
+    for (unsigned int j = 0; j < PeleC::prob_parm_device->pmf_M; j++) {
+      sinput >>
+        PeleC::prob_parm_host->h_pmf_Y[j * PeleC::prob_parm_device->pmf_N + i];
     }
   }
 
   amrex::Gpu::copy(
-    amrex::Gpu::hostToDevice, PeleC::prob_parm->h_pmf_X.begin(),
-    PeleC::prob_parm->h_pmf_X.end(), PeleC::prob_parm->pmf_X.begin());
+    amrex::Gpu::hostToDevice, PeleC::prob_parm_host->h_pmf_X.begin(),
+    PeleC::prob_parm_host->h_pmf_X.end(), PeleC::prob_parm_host->pmf_X.begin());
   amrex::Gpu::copy(
-    amrex::Gpu::hostToDevice, PeleC::prob_parm->h_pmf_Y.begin(),
-    PeleC::prob_parm->h_pmf_Y.end(), PeleC::prob_parm->pmf_Y.begin());
-  PeleC::prob_parm->d_pmf_X = PeleC::prob_parm->pmf_X.data();
-  PeleC::prob_parm->d_pmf_Y = PeleC::prob_parm->pmf_Y.data();
+    amrex::Gpu::hostToDevice, PeleC::prob_parm_host->h_pmf_Y.begin(),
+    PeleC::prob_parm_host->h_pmf_Y.end(), PeleC::prob_parm_host->pmf_Y.begin());
+  PeleC::prob_parm_device->d_pmf_X = PeleC::prob_parm_host->pmf_X.data();
+  PeleC::prob_parm_device->d_pmf_Y = PeleC::prob_parm_host->pmf_Y.data();
 }
 
 void
@@ -118,10 +119,10 @@ init_bc()
   amrex::Real massfrac[NUM_SPECIES];
   amrex::GpuArray<amrex::Real, NUM_SPECIES + 4> pmf_vals = {{0.0}};
 
-  if (PeleC::prob_parm->phi_in < 0) {
+  if (PeleC::prob_parm_device->phi_in < 0) {
     const amrex::Real yl = 0.0;
     const amrex::Real yr = 0.0;
-    pmf(yl, yr, pmf_vals, *PeleC::prob_parm);
+    pmf(yl, yr, pmf_vals, *PeleC::prob_parm_device);
     amrex::Real mysum = 0.0;
     for (int n = 0; n < NUM_SPECIES; n++) {
       molefrac[n] = amrex::max<amrex::Real>(0.0, pmf_vals[3 + n]);
@@ -129,42 +130,43 @@ init_bc()
     }
     molefrac[N2_ID] = 1.0 - (mysum - molefrac[N2_ID]);
     T = pmf_vals[0];
-    PeleC::prob_parm->vn_in = pmf_vals[1];
+    PeleC::prob_parm_device->vn_in = pmf_vals[1];
   } else {
     const amrex::Real a = 0.5;
     for (amrex::Real& n : molefrac) {
       n = 0.0;
     }
-    molefrac[O2_ID] = 1.0 / (1.0 + PeleC::prob_parm->phi_in / a + 0.79 / 0.21);
-    molefrac[H2_ID] = PeleC::prob_parm->phi_in * molefrac[O2_ID] / a;
+    molefrac[O2_ID] =
+      1.0 / (1.0 + PeleC::prob_parm_device->phi_in / a + 0.79 / 0.21);
+    molefrac[H2_ID] = PeleC::prob_parm_device->phi_in * molefrac[O2_ID] / a;
     molefrac[N2_ID] = 1.0 - molefrac[H2_ID] - molefrac[O2_ID];
-    T = PeleC::prob_parm->T_in;
+    T = PeleC::prob_parm_device->T_in;
   }
-  const amrex::Real p = PeleC::prob_parm->pamb;
+  const amrex::Real p = PeleC::prob_parm_device->pamb;
 
   EOS::X2Y(molefrac, massfrac);
   EOS::PYT2RE(p, massfrac, T, rho, e);
 
-  vt = PeleC::prob_parm->vn_in;
+  vt = PeleC::prob_parm_device->vn_in;
   ek = 0.5 * (vt * vt);
 
-  PeleC::prob_parm->fuel_state[URHO] = rho;
-  PeleC::prob_parm->fuel_state[UMX] = 0.0;
-  PeleC::prob_parm->fuel_state[UMY] = rho * vt;
-  PeleC::prob_parm->fuel_state[UMZ] = 0.0;
-  PeleC::prob_parm->fuel_state[UEINT] = rho * e;
-  PeleC::prob_parm->fuel_state[UEDEN] = rho * (e + ek);
-  PeleC::prob_parm->fuel_state[UTEMP] = T;
+  PeleC::prob_parm_device->fuel_state[URHO] = rho;
+  PeleC::prob_parm_device->fuel_state[UMX] = 0.0;
+  PeleC::prob_parm_device->fuel_state[UMY] = rho * vt;
+  PeleC::prob_parm_device->fuel_state[UMZ] = 0.0;
+  PeleC::prob_parm_device->fuel_state[UEINT] = rho * e;
+  PeleC::prob_parm_device->fuel_state[UEDEN] = rho * (e + ek);
+  PeleC::prob_parm_device->fuel_state[UTEMP] = T;
   for (int n = 0; n < NUM_SPECIES; n++) {
-    PeleC::prob_parm->fuel_state[UFS + n - 1] = rho * massfrac[n];
+    PeleC::prob_parm_device->fuel_state[UFS + n - 1] = rho * massfrac[n];
   }
 }
 
 void
 pc_prob_close()
 {
-  PeleC::prob_parm->d_pmf_X = nullptr;
-  PeleC::prob_parm->d_pmf_Y = nullptr;
+  PeleC::prob_parm_device->d_pmf_X = nullptr;
+  PeleC::prob_parm_device->d_pmf_Y = nullptr;
 }
 
 extern "C" {
@@ -179,16 +181,16 @@ amrex_probinit(
   std::string pmf_datafile;
 
   amrex::ParmParse pp("prob");
-  pp.query("pamb", PeleC::prob_parm->pamb);
-  pp.query("phi_in", PeleC::prob_parm->phi_in);
-  pp.query("T_in", PeleC::prob_parm->T_in);
-  pp.query("vn_in", PeleC::prob_parm->vn_in);
-  pp.query("pertmag", PeleC::prob_parm->pertmag);
+  pp.query("pamb", PeleC::prob_parm_device->pamb);
+  pp.query("phi_in", PeleC::prob_parm_device->phi_in);
+  pp.query("T_in", PeleC::prob_parm_device->T_in);
+  pp.query("vn_in", PeleC::prob_parm_device->vn_in);
+  pp.query("pertmag", PeleC::prob_parm_device->pertmag);
   pp.query("pmf_datafile", pmf_datafile);
 
-  PeleC::prob_parm->L[0] = probhi[0] - problo[0];
-  PeleC::prob_parm->L[1] = probhi[1] - problo[1];
-  PeleC::prob_parm->L[2] = probhi[2] - problo[2];
+  PeleC::prob_parm_device->L[0] = probhi[0] - problo[0];
+  PeleC::prob_parm_device->L[1] = probhi[1] - problo[1];
+  PeleC::prob_parm_device->L[2] = probhi[2] - problo[2];
 
   read_pmf(pmf_datafile);
 

--- a/ExecCpp/RegTests/PMF/prob_parm.H
+++ b/ExecCpp/RegTests/PMF/prob_parm.H
@@ -3,28 +3,26 @@
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>
+#include <AMReX_GpuMemory.H>
 
-namespace ProbParm {
-extern AMREX_GPU_DEVICE_MANAGED amrex::Real pamb;
-extern AMREX_GPU_DEVICE_MANAGED amrex::Real phi_in;
-extern AMREX_GPU_DEVICE_MANAGED amrex::Real T_in;
-extern AMREX_GPU_DEVICE_MANAGED amrex::Real vn_in;
-extern AMREX_GPU_DEVICE_MANAGED amrex::Real pertmag;
-extern AMREX_GPU_DEVICE_MANAGED amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> L;
-extern AMREX_GPU_DEVICE_MANAGED unsigned int pmf_N;
-extern AMREX_GPU_DEVICE_MANAGED unsigned int pmf_M;
-extern AMREX_GPU_DEVICE_MANAGED bool pmf_do_average;
+struct ProbParmDevice : amrex::Gpu::Managed
+{
+  amrex::Real pamb = 1013250.0 * 100.0;
+  amrex::Real phi_in = -0.2;
+  amrex::Real T_in = 298.0;
+  amrex::Real vn_in = 0.2;
+  amrex::Real pertmag = 0.0;
+  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> L = {{1.0}};
+  unsigned int pmf_N = 0;
+  unsigned int pmf_M = 0;
+  int pmf_do_average = 0;
 
-extern amrex::Gpu::ManagedVector<amrex::Real>* pmf_X;
-extern amrex::Gpu::ManagedVector<amrex::Real>* pmf_Y;
-extern amrex::Gpu::ManagedVector<amrex::Real>* fuel_state;
-
-extern AMREX_GPU_DEVICE_MANAGED amrex::Real* d_pmf_X;
-extern AMREX_GPU_DEVICE_MANAGED amrex::Real* d_pmf_Y;
-extern AMREX_GPU_DEVICE_MANAGED amrex::Real* d_fuel_state;
-
-extern std::string pmf_datafile;
-extern amrex::Vector<std::string> pmf_names;
-} // namespace ProbParm
+  amrex::Gpu::DeviceVector<amrex::Real>* pmf_X = nullptr;
+  amrex::Gpu::DeviceVector<amrex::Real>* pmf_Y = nullptr;
+  amrex::Gpu::DeviceVector<amrex::Real>* fuel_state = nullptr;
+  amrex::Real* d_pmf_X = nullptr;
+  amrex::Real* d_pmf_Y = nullptr;
+  amrex::Real* d_fuel_state = nullptr;
+};
 
 #endif

--- a/ExecCpp/RegTests/PMF/prob_parm.H
+++ b/ExecCpp/RegTests/PMF/prob_parm.H
@@ -18,8 +18,10 @@ struct ProbParmDevice : amrex::Gpu::Managed
   int pmf_do_average = 0;
 
   amrex::GpuArray<amrex::Real, NVAR> fuel_state = {{0.0}};
-  amrex::Gpu::DeviceVector<amrex::Real>* pmf_X = nullptr;
-  amrex::Gpu::DeviceVector<amrex::Real>* pmf_Y = nullptr;
+  amrex::Vector<amrex::Real> h_pmf_X;
+  amrex::Vector<amrex::Real> h_pmf_Y;
+  amrex::Gpu::DeviceVector<amrex::Real> pmf_X;
+  amrex::Gpu::DeviceVector<amrex::Real> pmf_Y;
   amrex::Real* d_pmf_X = nullptr;
   amrex::Real* d_pmf_Y = nullptr;
 };

--- a/ExecCpp/RegTests/PMF/prob_parm.H
+++ b/ExecCpp/RegTests/PMF/prob_parm.H
@@ -18,12 +18,16 @@ struct ProbParmDevice : amrex::Gpu::Managed
   int pmf_do_average = 0;
 
   amrex::GpuArray<amrex::Real, NVAR> fuel_state = {{0.0}};
+  amrex::Real* d_pmf_X = nullptr;
+  amrex::Real* d_pmf_Y = nullptr;
+};
+
+struct ProbParmHost : amrex::Gpu::Managed
+{
   amrex::Vector<amrex::Real> h_pmf_X;
   amrex::Vector<amrex::Real> h_pmf_Y;
   amrex::Gpu::DeviceVector<amrex::Real> pmf_X;
   amrex::Gpu::DeviceVector<amrex::Real> pmf_Y;
-  amrex::Real* d_pmf_X = nullptr;
-  amrex::Real* d_pmf_Y = nullptr;
 };
 
 #endif

--- a/ExecCpp/RegTests/PMF/prob_parm.H
+++ b/ExecCpp/RegTests/PMF/prob_parm.H
@@ -17,12 +17,11 @@ struct ProbParmDevice : amrex::Gpu::Managed
   unsigned int pmf_M = 0;
   int pmf_do_average = 0;
 
+  amrex::GpuArray<amrex::Real, NVAR> fuel_state = {{0.0}};
   amrex::Gpu::DeviceVector<amrex::Real>* pmf_X = nullptr;
   amrex::Gpu::DeviceVector<amrex::Real>* pmf_Y = nullptr;
-  amrex::Gpu::DeviceVector<amrex::Real>* fuel_state = nullptr;
   amrex::Real* d_pmf_X = nullptr;
   amrex::Real* d_pmf_Y = nullptr;
-  amrex::Real* d_fuel_state = nullptr;
 };
 
 #endif

--- a/ExecCpp/RegTests/Sedov/prob.H
+++ b/ExecCpp/RegTests/Sedov/prob.H
@@ -25,7 +25,8 @@ pc_initdata(
   int j,
   int k,
   amrex::Array4<amrex::Real> const& state,
-  amrex::GeometryData const& geomdata)
+  amrex::GeometryData const& geomdata,
+  ProbParmDevice const& /*prob_parm*/)
 {
   // Set explosion pressure -- we will convert the point-explosion energy into
   // a corresponding pressure distributed throughout the perturbed volume
@@ -121,7 +122,8 @@ bcnormal(
   const int /*idir*/,
   const int /*sgn*/,
   const amrex::Real /*time*/,
-  amrex::GeometryData const& /*geomdata*/)
+  amrex::GeometryData const& /*geomdata*/,
+  ProbParmDevice const& /*prob_parm*/)
 {
   for (int n = 0; n < NVAR; n++) {
     s_ext[n] = s_int[n];

--- a/ExecCpp/RegTests/Sedov/prob_parm.H
+++ b/ExecCpp/RegTests/Sedov/prob_parm.H
@@ -3,6 +3,15 @@
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>
+#include <AMReX_GpuMemory.H>
+
+struct ProbParmDevice : amrex::Gpu::Managed
+{
+};
+
+struct ProbParmHost : amrex::Gpu::Managed
+{
+};
 
 namespace ProbParm {
 extern AMREX_GPU_DEVICE_MANAGED amrex::Real p_ambient;

--- a/ExecCpp/RegTests/Sod/prob.H
+++ b/ExecCpp/RegTests/Sod/prob.H
@@ -25,9 +25,9 @@ pc_initdata(
   int j,
   int k,
   amrex::Array4<amrex::Real> const& state,
-  amrex::GeometryData const& geomdata)
+  amrex::GeometryData const& geomdata,
+  ProbParmDevice const& /*prob_parm*/)
 {
-
   // Geometry
   const amrex::Real* prob_lo = geomdata.ProbLo();
   // const amrex::Real* prob_hi = geomdata.ProbHi();
@@ -124,7 +124,8 @@ bcnormal(
   const int /*idir*/,
   const int /*sgn*/,
   const amrex::Real /*time*/,
-  amrex::GeometryData const& /*geomdata*/)
+  amrex::GeometryData const& /*geomdata*/,
+  ProbParmDevice const& /*prob_parm*/)
 {
   for (int n = 0; n < NVAR; n++) {
     s_ext[n] = s_int[n];

--- a/ExecCpp/RegTests/Sod/prob_parm.H
+++ b/ExecCpp/RegTests/Sod/prob_parm.H
@@ -3,6 +3,15 @@
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>
+#include <AMReX_GpuMemory.H>
+
+struct ProbParmDevice : amrex::Gpu::Managed
+{
+};
+
+struct ProbParmHost : amrex::Gpu::Managed
+{
+};
 
 namespace ProbParm {
 extern AMREX_GPU_DEVICE_MANAGED amrex::Real p_l;

--- a/ExecCpp/RegTests/TG/prob.H
+++ b/ExecCpp/RegTests/TG/prob.H
@@ -92,7 +92,7 @@ bcnormal(
 
 struct MyProbTagStruct
 {
-  AMREX_GPU_HOST_DEVICE
+  AMREX_GPU_DEVICE
   AMREX_FORCE_INLINE
   static void set_problem_tags(
     const int /*i*/,

--- a/ExecCpp/RegTests/TG/prob.H
+++ b/ExecCpp/RegTests/TG/prob.H
@@ -86,7 +86,7 @@ bcnormal(
   const int /*sgn*/,
   const amrex::Real /*time*/,
   amrex::GeometryData const& /*geomdata*/,
-  ProbParmDevice const& prob_parm)
+  ProbParmDevice const& /*prob_parm*/)
 {
 }
 

--- a/ExecCpp/RegTests/TG/prob.H
+++ b/ExecCpp/RegTests/TG/prob.H
@@ -85,7 +85,8 @@ bcnormal(
   const int /*idir*/,
   const int /*sgn*/,
   const amrex::Real /*time*/,
-  amrex::GeometryData const& /*geomdata*/)
+  amrex::GeometryData const& /*geomdata*/,
+  ProbParmDevice const& prob_parm)
 {
 }
 

--- a/ExecCpp/RegTests/TG/prob.H
+++ b/ExecCpp/RegTests/TG/prob.H
@@ -5,6 +5,8 @@
 #include <AMReX_ParmParse.H>
 #include <AMReX_Geometry.H>
 #include <AMReX_FArrayBox.H>
+#include <AMReX_REAL.H>
+#include <AMReX_GpuMemory.H>
 
 #include "mechanism.h"
 
@@ -25,9 +27,9 @@ pc_initdata(
   int j,
   int k,
   amrex::Array4<amrex::Real> const& state,
-  amrex::GeometryData const& geomdata)
+  amrex::GeometryData const& geomdata,
+  ProbParmDevice const& prob_parm)
 {
-
   // Geometry
   const amrex::Real* prob_lo = geomdata.ProbLo();
   // const amrex::Real* prob_hi = geomdata.ProbHi();
@@ -41,24 +43,24 @@ pc_initdata(
 
   // TG functions
   amrex::Real u[3] = {0.0};
-  u[0] = ProbParm::v0 * sin(ProbParm::omega_x * x / ProbParm::L) *
-         cos(ProbParm::omega_y * y / ProbParm::L) *
-         cos(ProbParm::omega_z * z / ProbParm::L);
-  u[1] = -ProbParm::v0 * cos(ProbParm::omega_x * x / ProbParm::L) *
-         sin(ProbParm::omega_y * y / ProbParm::L) *
-         cos(ProbParm::omega_z * z / ProbParm::L);
-  if (ProbParm::convecting) {
-    u[0] += ProbParm::v0;
-    u[1] += ProbParm::v0;
+  u[0] = prob_parm.v0 * sin(prob_parm.omega_x * x / prob_parm.L) *
+         cos(prob_parm.omega_y * y / prob_parm.L) *
+         cos(prob_parm.omega_z * z / prob_parm.L);
+  u[1] = -prob_parm.v0 * cos(prob_parm.omega_x * x / prob_parm.L) *
+         sin(prob_parm.omega_y * y / prob_parm.L) *
+         cos(prob_parm.omega_z * z / prob_parm.L);
+  if (prob_parm.convecting) {
+    u[0] += prob_parm.v0;
+    u[1] += prob_parm.v0;
   }
   const amrex::Real p =
-    ProbParm::p0 + ProbParm::rho0 * ProbParm::v0 * ProbParm::v0 / 16.0 *
-                     (cos(2.0 * ProbParm::omega_x * x / ProbParm::L) +
-                      cos(2.0 * ProbParm::omega_y * y / ProbParm::L)) *
-                     (cos(2.0 * ProbParm::omega_z * z / ProbParm::L) + 2.0);
+    prob_parm.p0 + prob_parm.rho0 * prob_parm.v0 * prob_parm.v0 / 16.0 *
+                     (cos(2.0 * prob_parm.omega_x * x / prob_parm.L) +
+                      cos(2.0 * prob_parm.omega_y * y / prob_parm.L)) *
+                     (cos(2.0 * prob_parm.omega_z * z / prob_parm.L) + 2.0);
   amrex::Real rho, eint;
   amrex::Real massfrac[NUM_SPECIES] = {1.0};
-  EOS::PYT2RE(p, massfrac, ProbParm::T0, rho, eint);
+  EOS::PYT2RE(p, massfrac, prob_parm.T0, rho, eint);
 
   // Set the state
   state(i, j, k, URHO) = rho;
@@ -68,7 +70,7 @@ pc_initdata(
   state(i, j, k, UEINT) = rho * eint;
   state(i, j, k, UEDEN) =
     rho * (eint + 0.5 * (u[0] * u[0] + u[1] * u[1] + u[2] * u[2]));
-  state(i, j, k, UTEMP) = ProbParm::T0;
+  state(i, j, k, UTEMP) = prob_parm.T0;
   for (int n = 0; n < NUM_SPECIES; n++)
     state(i, j, k, UFS + n) = rho * massfrac[n];
 }

--- a/ExecCpp/RegTests/TG/prob.cpp
+++ b/ExecCpp/RegTests/TG/prob.cpp
@@ -70,9 +70,6 @@ amrex_probinit(
   trans_parm.const_conductivity =
     trans_parm.const_viscosity * cp / PeleC::prob_parm_device->prandtl;
 
-  /* GPU */
-  // trans_parm_g = (TransParm *)
-  // amrex::The_Device_Arena()->alloc(sizeof(trans_parm));
 #ifdef AMREX_USE_GPU
   amrex::Gpu::htod_memcpy(trans_parm_g, &trans_parm, sizeof(trans_parm));
 #else

--- a/ExecCpp/RegTests/TG/prob.cpp
+++ b/ExecCpp/RegTests/TG/prob.cpp
@@ -16,19 +16,19 @@ amrex_probinit(
 {
   // Parse params
   amrex::ParmParse pp("prob");
-  pp.query("reynolds", PeleC::prob_parm->reynolds);
-  pp.query("mach", PeleC::prob_parm->mach);
-  pp.query("prandtl", PeleC::prob_parm->prandtl);
-  pp.query("convecting", PeleC::prob_parm->convecting);
-  pp.query("omega_x", PeleC::prob_parm->omega_x);
-  pp.query("omega_y", PeleC::prob_parm->omega_y);
-  pp.query("omega_z", PeleC::prob_parm->omega_z);
+  pp.query("reynolds", PeleC::prob_parm_device->reynolds);
+  pp.query("mach", PeleC::prob_parm_device->mach);
+  pp.query("prandtl", PeleC::prob_parm_device->prandtl);
+  pp.query("convecting", PeleC::prob_parm_device->convecting);
+  pp.query("omega_x", PeleC::prob_parm_device->omega_x);
+  pp.query("omega_y", PeleC::prob_parm_device->omega_y);
+  pp.query("omega_z", PeleC::prob_parm_device->omega_z);
 
   // Define the length scale
-  PeleC::prob_parm->L = 1.0 / PI;
-  PeleC::prob_parm->L_x = probhi[0] - problo[0];
-  PeleC::prob_parm->L_y = probhi[1] - problo[1];
-  PeleC::prob_parm->L_z = probhi[2] - problo[2];
+  PeleC::prob_parm_device->L = 1.0 / PI;
+  PeleC::prob_parm_device->L_x = probhi[0] - problo[0];
+  PeleC::prob_parm_device->L_y = probhi[1] - problo[1];
+  PeleC::prob_parm_device->L_z = probhi[2] - problo[2];
 
   // Initial density, velocity, and material properties
   amrex::Real eint;
@@ -36,19 +36,20 @@ amrex_probinit(
   amrex::Real cp;
   amrex::Real massfrac[NUM_SPECIES] = {1.0};
   EOS::PYT2RE(
-    PeleC::prob_parm->p0, massfrac, PeleC::prob_parm->T0,
-    PeleC::prob_parm->rho0, eint);
-  EOS::RTY2Cs(PeleC::prob_parm->rho0, PeleC::prob_parm->T0, massfrac, cs);
-  EOS::TY2Cp(PeleC::prob_parm->T0, massfrac, cp);
+    PeleC::prob_parm_device->p0, massfrac, PeleC::prob_parm_device->T0,
+    PeleC::prob_parm_device->rho0, eint);
+  EOS::RTY2Cs(
+    PeleC::prob_parm_device->rho0, PeleC::prob_parm_device->T0, massfrac, cs);
+  EOS::TY2Cp(PeleC::prob_parm_device->T0, massfrac, cp);
 
-  PeleC::prob_parm->v0 = PeleC::prob_parm->mach * cs;
+  PeleC::prob_parm_device->v0 = PeleC::prob_parm_device->mach * cs;
   transport_params::const_bulk_viscosity = 0.0;
   transport_params::const_diffusivity = 0.0;
   transport_params::const_viscosity =
-    PeleC::prob_parm->rho0 * PeleC::prob_parm->v0 * PeleC::prob_parm->L /
-    PeleC::prob_parm->reynolds;
+    PeleC::prob_parm_device->rho0 * PeleC::prob_parm_device->v0 *
+    PeleC::prob_parm_device->L / PeleC::prob_parm_device->reynolds;
   transport_params::const_conductivity =
-    transport_params::const_viscosity * cp / PeleC::prob_parm->prandtl;
+    transport_params::const_viscosity * cp / PeleC::prob_parm_device->prandtl;
 
   // Output IC
   std::ofstream ofs("ic.txt", std::ofstream::out);
@@ -56,15 +57,16 @@ amrex_probinit(
                        "Mach, Prandtl, omega_x, omega_y, omega_z"
                     << std::endl;
   amrex::Print(ofs).SetPrecision(17)
-    << PeleC::prob_parm->L << "," << PeleC::prob_parm->rho0 << ","
-    << PeleC::prob_parm->v0 << "," << PeleC::prob_parm->p0 << ","
-    << PeleC::prob_parm->T0 << "," << EOS::gamma << ","
+    << PeleC::prob_parm_device->L << "," << PeleC::prob_parm_device->rho0 << ","
+    << PeleC::prob_parm_device->v0 << "," << PeleC::prob_parm_device->p0 << ","
+    << PeleC::prob_parm_device->T0 << "," << EOS::gamma << ","
     << transport_params::const_viscosity << ","
     << transport_params::const_conductivity << "," << cs << ","
-    << PeleC::prob_parm->reynolds << "," << PeleC::prob_parm->mach << ","
-    << PeleC::prob_parm->prandtl << "," << PeleC::prob_parm->omega_x << ","
-    << PeleC::prob_parm->omega_y << "," << PeleC::prob_parm->omega_z
-    << std::endl;
+    << PeleC::prob_parm_device->reynolds << "," << PeleC::prob_parm_device->mach
+    << "," << PeleC::prob_parm_device->prandtl << ","
+    << PeleC::prob_parm_device->omega_x << ","
+    << PeleC::prob_parm_device->omega_y << ","
+    << PeleC::prob_parm_device->omega_z << std::endl;
   ofs.close();
 }
 }

--- a/ExecCpp/RegTests/TG/prob_parm.H
+++ b/ExecCpp/RegTests/TG/prob_parm.H
@@ -22,4 +22,9 @@ struct ProbParmDevice : amrex::Gpu::Managed
   amrex::Real rho0 = 0.0;
   amrex::Real v0 = 0.0;
 };
+
+struct ProbParmHost : amrex::Gpu::Managed
+{
+};
+
 #endif

--- a/ExecCpp/RegTests/TG/prob_parm.H
+++ b/ExecCpp/RegTests/TG/prob_parm.H
@@ -2,24 +2,24 @@
 #define _PROB_PARM_H_
 
 #include <AMReX_REAL.H>
-#include <AMReX_GpuQualifiers.H>
+#include <AMReX_GpuMemory.H>
 
-namespace ProbParm {
-extern AMREX_GPU_DEVICE_MANAGED amrex::Real reynolds;
-extern AMREX_GPU_DEVICE_MANAGED amrex::Real mach;
-extern AMREX_GPU_DEVICE_MANAGED amrex::Real prandtl;
-extern AMREX_GPU_DEVICE_MANAGED bool convecting;
-extern AMREX_GPU_DEVICE_MANAGED amrex::Real omega_x;
-extern AMREX_GPU_DEVICE_MANAGED amrex::Real omega_y;
-extern AMREX_GPU_DEVICE_MANAGED amrex::Real omega_z;
-extern AMREX_GPU_DEVICE_MANAGED amrex::Real L_x;
-extern AMREX_GPU_DEVICE_MANAGED amrex::Real L_y;
-extern AMREX_GPU_DEVICE_MANAGED amrex::Real L_z;
-extern AMREX_GPU_DEVICE_MANAGED amrex::Real L;
-extern AMREX_GPU_DEVICE_MANAGED amrex::Real p0;
-extern AMREX_GPU_DEVICE_MANAGED amrex::Real T0;
-extern AMREX_GPU_DEVICE_MANAGED amrex::Real rho0;
-extern AMREX_GPU_DEVICE_MANAGED amrex::Real v0;
-} // namespace ProbParm
-
+struct ProbParmDevice : amrex::Gpu::Managed
+{
+  amrex::Real reynolds = 1600.0;
+  amrex::Real mach = 0.1;
+  amrex::Real prandtl = 0.71;
+  bool convecting = false;
+  amrex::Real omega_x = 1.0;
+  amrex::Real omega_y = 1.0;
+  amrex::Real omega_z = 1.0;
+  amrex::Real L_x = 0.0;
+  amrex::Real L_y = 0.0;
+  amrex::Real L_z = 0.0;
+  amrex::Real L = 0.0;
+  amrex::Real p0 = 1.013e6; // [erg cm^-3]
+  amrex::Real T0 = 300.0;
+  amrex::Real rho0 = 0.0;
+  amrex::Real v0 = 0.0;
+};
 #endif

--- a/ExecCpp/RegTests/zeroD/prob.H
+++ b/ExecCpp/RegTests/zeroD/prob.H
@@ -24,7 +24,8 @@ pc_initdata(
   int j,
   int k,
   amrex::Array4<amrex::Real> const& state,
-  amrex::GeometryData const& /*geomdata*/)
+  amrex::GeometryData const& /*geomdata*/,
+  ProbParmDevice const& /*prob_parm*/)
 {
   // Set the state
   state(i, j, k, URHO) = ProbParm::rho_init;
@@ -48,7 +49,8 @@ bcnormal(
   const int /*idir*/,
   const int /*sgn*/,
   const amrex::Real /*time*/,
-  amrex::GeometryData const& /*geomdata*/)
+  amrex::GeometryData const& /*geomdata*/,
+  ProbParmDevice const& /*prob_parm*/)
 {
 }
 

--- a/ExecCpp/RegTests/zeroD/prob_parm.H
+++ b/ExecCpp/RegTests/zeroD/prob_parm.H
@@ -3,6 +3,15 @@
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>
+#include <AMReX_GpuMemory.H>
+
+struct ProbParmDevice : amrex::Gpu::Managed
+{
+};
+
+struct ProbParmHost : amrex::Gpu::Managed
+{
+};
 
 namespace ProbParm {
 extern AMREX_GPU_DEVICE_MANAGED amrex::Real p_init;

--- a/ExecCpp/UnitTests/prob.H
+++ b/ExecCpp/UnitTests/prob.H
@@ -11,7 +11,8 @@ pc_initdata(
   int /*j*/,
   int /*k*/,
   amrex::Array4<amrex::Real> const& /*state*/,
-  amrex::GeometryData const& /*geomdata*/)
+  amrex::GeometryData const& /*geomdata*/,
+  ProbParmDevice const& /*prob_parm*/)
 {
   // Could init some data here
 }
@@ -26,7 +27,8 @@ bcnormal(
   const int /*idir*/,
   const int /*sgn*/,
   const amrex::Real /*time*/,
-  amrex::GeometryData const& /*geomdata*/)
+  amrex::GeometryData const& /*geomdata*/,
+  ProbParmDevice const& /*prob_parm*/)
 {
 }
 

--- a/ExecCpp/UnitTests/prob_parm.H
+++ b/ExecCpp/UnitTests/prob_parm.H
@@ -3,6 +3,15 @@
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>
+#include <AMReX_GpuMemory.H>
+
+struct ProbParmDevice : amrex::Gpu::Managed
+{
+};
+
+struct ProbParmHost : amrex::Gpu::Managed
+{
+};
 
 namespace ProbParm {
 } // namespace ProbParm

--- a/SourceCpp/BCfill.cpp
+++ b/SourceCpp/BCfill.cpp
@@ -33,6 +33,7 @@ struct PCHypFillExtDir
 
     amrex::Real s_int[NVAR] = {0.0};
     amrex::Real s_ext[NVAR] = {0.0};
+    ProbParmDevice const* lprobparm = PeleC::prob_parm.get();
 
     // xlo and xhi
     int idir = 0;
@@ -41,7 +42,7 @@ struct PCHypFillExtDir
       for (int n = 0; n < NVAR; n++) {
         s_int[n] = dest(loc, n);
       }
-      bcnormal(x, s_int, s_ext, idir, +1, time, geom);
+      bcnormal(x, s_int, s_ext, idir, +1, time, geom, *lprobparm);
       for (int n = 0; n < NVAR; n++) {
         dest(iv, n) = s_ext[n];
       }
@@ -52,7 +53,7 @@ struct PCHypFillExtDir
       for (int n = 0; n < NVAR; n++) {
         s_int[n] = dest(loc, n);
       }
-      bcnormal(x, s_int, s_ext, idir, -1, time, geom);
+      bcnormal(x, s_int, s_ext, idir, -1, time, geom, *lprobparm);
       for (int n = 0; n < NVAR; n++) {
         dest(iv, n) = s_ext[n];
       }
@@ -65,7 +66,7 @@ struct PCHypFillExtDir
       for (int n = 0; n < NVAR; n++) {
         s_int[n] = dest(loc, n);
       }
-      bcnormal(x, s_int, s_ext, idir, +1, time, geom);
+      bcnormal(x, s_int, s_ext, idir, +1, time, geom, *lprobparm);
       for (int n = 0; n < NVAR; n++) {
         dest(iv, n) = s_ext[n];
       }
@@ -76,7 +77,7 @@ struct PCHypFillExtDir
       for (int n = 0; n < NVAR; n++) {
         s_int[n] = dest(loc, n);
       }
-      bcnormal(x, s_int, s_ext, idir, -1, time, geom);
+      bcnormal(x, s_int, s_ext, idir, -1, time, geom, *lprobparm);
       for (int n = 0; n < NVAR; n++) {
         dest(iv, n) = s_ext[n];
       }
@@ -88,7 +89,7 @@ struct PCHypFillExtDir
       for (int n = 0; n < NVAR; n++) {
         s_int[n] = dest(iv[0], iv[1], domlo[idir], n);
       }
-      bcnormal(x, s_int, s_ext, idir, +1, time, geom);
+      bcnormal(x, s_int, s_ext, idir, +1, time, geom, *lprobparm);
       for (int n = 0; n < NVAR; n++) {
         dest(iv, n) = s_ext[n];
       }
@@ -98,7 +99,7 @@ struct PCHypFillExtDir
       for (int n = 0; n < NVAR; n++) {
         s_int[n] = dest(iv[0], iv[1], domhi[idir], n);
       }
-      bcnormal(x, s_int, s_ext, idir, -1, time, geom);
+      bcnormal(x, s_int, s_ext, idir, -1, time, geom, *lprobparm);
       for (int n = 0; n < NVAR; n++) {
         dest(iv, n) = s_ext[n];
       }

--- a/SourceCpp/BCfill.cpp
+++ b/SourceCpp/BCfill.cpp
@@ -145,7 +145,7 @@ pc_bcfill_hyp(
   const int bcomp,
   const int scomp)
 {
-  ProbParmDevice const* lprobparm = PeleC::prob_parm.get();
+  ProbParmDevice const* lprobparm = PeleC::prob_parm_device.get();
   amrex::GpuBndryFuncFab<PCHypFillExtDir> hyp_bndry_func(
     PCHypFillExtDir{lprobparm});
   hyp_bndry_func(bx, data, dcomp, numcomp, geom, time, bcr, bcomp, scomp);

--- a/SourceCpp/BCfill.cpp
+++ b/SourceCpp/BCfill.cpp
@@ -7,6 +7,14 @@
 
 struct PCHypFillExtDir
 {
+  ProbParmDevice const* lprobparm;
+
+  AMREX_GPU_HOST
+  constexpr PCHypFillExtDir(ProbParmDevice const* d_prob_parm)
+    : lprobparm(d_prob_parm)
+  {
+  }
+
   AMREX_GPU_DEVICE
   void operator()(
     const amrex::IntVect& iv,
@@ -33,7 +41,6 @@ struct PCHypFillExtDir
 
     amrex::Real s_int[NVAR] = {0.0};
     amrex::Real s_ext[NVAR] = {0.0};
-    ProbParmDevice const* lprobparm = PeleC::prob_parm.get();
 
     // xlo and xhi
     int idir = 0;
@@ -126,14 +133,6 @@ struct PCReactFillExtDir
   }
 };
 
-namespace {
-PCHypFillExtDir pc_hyp_fill_ext_dir;
-PCReactFillExtDir pc_react_fill_ext_dir;
-amrex::GpuBndryFuncFab<PCHypFillExtDir> hyp_bndry_func(pc_hyp_fill_ext_dir);
-amrex::GpuBndryFuncFab<PCReactFillExtDir>
-  react_bndry_func(pc_react_fill_ext_dir);
-} // namespace
-
 void
 pc_bcfill_hyp(
   amrex::Box const& bx,
@@ -146,6 +145,9 @@ pc_bcfill_hyp(
   const int bcomp,
   const int scomp)
 {
+  ProbParmDevice const* lprobparm = PeleC::prob_parm.get();
+  amrex::GpuBndryFuncFab<PCHypFillExtDir> hyp_bndry_func(
+    PCHypFillExtDir{lprobparm});
   hyp_bndry_func(bx, data, dcomp, numcomp, geom, time, bcr, bcomp, scomp);
 }
 
@@ -162,6 +164,8 @@ pc_reactfill_hyp(
   const int bcomp,
   const int scomp)
 {
+  amrex::GpuBndryFuncFab<PCReactFillExtDir> react_bndry_func(
+    PCReactFillExtDir{});
   react_bndry_func(bx, data, dcomp, numcomp, geom, time, bcr, bcomp, scomp);
 }
 #endif

--- a/SourceCpp/Diffterm.H
+++ b/SourceCpp/Diffterm.H
@@ -155,7 +155,7 @@ pc_diffusion_flux(
 }
 
 // This function computes the flux divergence.
-AMREX_GPU_HOST_DEVICE
+AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
 pc_flux_div(

--- a/SourceCpp/Diffusion.cpp
+++ b/SourceCpp/Diffusion.cpp
@@ -228,10 +228,11 @@ PeleC::getMOLSrcTerm(
         auto const& coe_lambda = coeff_cc.array(dComp_lambda);
         BL_PROFILE("PeleC::get_transport_coeffs()");
         // Get Transport coefs on GPU.
+        TransParm const* ltransparm = trans_parm_g;
         amrex::launch(gbox, [=] AMREX_GPU_DEVICE(amrex::Box const& tbx) {
           get_transport_coeffs(
             tbx, qar_yin, qar_Tin, qar_rhoin, coe_rhoD, coe_mu, coe_xi,
-            coe_lambda);
+            coe_lambda, ltransparm);
         });
       }
 

--- a/SourceCpp/EBStencilTypes.H
+++ b/SourceCpp/EBStencilTypes.H
@@ -43,7 +43,7 @@ struct EBBndryGeom
 // Comparison operator for thrust sort
 struct EBBndryGeomCmp
 {
-  AMREX_GPU_HOST_DEVICE
+  AMREX_GPU_DEVICE
   bool operator()(const EBBndryGeom& a, const EBBndryGeom& b)
   {
     return a.iv < b.iv;

--- a/SourceCpp/IO.cpp
+++ b/SourceCpp/IO.cpp
@@ -43,7 +43,7 @@ amrex::Real vfraceps = 0.000001;
 // I/O routines for PeleC
 
 void
-PeleC::restart(amrex::Amr& papa, istream& is, bool bReadSpecial)
+PeleC::restart(amrex::Amr& papa, std::istream& is, bool bReadSpecial)
 {
   // Let's check PeleC checkpoint version first;
   // trying to read from checkpoint; if nonexisting, set it to 0.
@@ -753,7 +753,8 @@ PeleC::writeBuildInfo(std::ostream& os)
 }
 
 void
-PeleC::writePlotFile(const std::string& dir, ostream& os, amrex::VisMF::How how)
+PeleC::writePlotFile(
+  const std::string& dir, std::ostream& os, amrex::VisMF::How how)
 {
   // The list of indices of State to write to plotfile.
   // first component of pair is state_type,
@@ -986,7 +987,7 @@ PeleC::writePlotFile(const std::string& dir, ostream& os, amrex::VisMF::How how)
 
 void
 PeleC::writeSmallPlotFile(
-  const std::string& dir, ostream& os, amrex::VisMF::How how)
+  const std::string& dir, std::ostream& os, amrex::VisMF::How how)
 {
   // The list of indices of State to write to plotfile.
   // first component of pair is state_type,

--- a/SourceCpp/IndexDefines.H
+++ b/SourceCpp/IndexDefines.H
@@ -83,7 +83,7 @@ extern AMREX_GPU_DEVICE_MANAGED int upassMap[NPASSIVE];
 
 void init();
 
-AMREX_GPU_HOST_DEVICE
+AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 int
 qpass_map(const int i)
@@ -91,7 +91,7 @@ qpass_map(const int i)
   return qpassMap[i];
 }
 
-AMREX_GPU_HOST_DEVICE
+AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 int
 upass_map(const int i)

--- a/SourceCpp/PPM.H
+++ b/SourceCpp/PPM.H
@@ -24,7 +24,7 @@ constexpr int ip2 = 4;
 // @param flatn  The flattening coefficient
 // @param sm     The value of the parabola on the left edge of the zone
 // @param sp     The value of the parabola on the right edge of the zone
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
 ppm_reconstruct(
   const amrex::Real* s,
   const amrex::Real flatn,
@@ -133,7 +133,7 @@ ppm_reconstruct(
 //              the 3 waves from the right zone edge
 // @param Im    amrex::Real[3], the integrals under the parabola over
 //              the 3 waves from the left zone edge
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
 ppm_int_profile(
   const amrex::Real sm,
   const amrex::Real sp,
@@ -204,7 +204,7 @@ ppm_int_profile(
 // @param dtdx  dt/dx (timestep / cell width)
 // @param Ip    integral under the parabola from the right zone edge
 // @param Im    integral under the parabola from the left zone edge
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
 ppm_int_profile_single(
   const amrex::Real sm,
   const amrex::Real sp,

--- a/SourceCpp/PeleC.H
+++ b/SourceCpp/PeleC.H
@@ -29,9 +29,6 @@
 #include "IndexDefines.H"
 #include "prob_parm.H"
 
-using std::istream;
-using std::ostream;
-
 #define UserBC 6
 
 enum StateType {
@@ -94,8 +91,8 @@ public:
   virtual ~PeleC();
 
   // Restart from a checkpoint file.
-  virtual void
-  restart(amrex::Amr& papa, istream& is, bool bReadSpecial = false) override;
+  virtual void restart(
+    amrex::Amr& papa, std::istream& is, bool bReadSpecial = false) override;
 
   // This is called only when we restart from an old checkpoint.
   virtual void
@@ -112,9 +109,9 @@ public:
 
   // Write a plotfile to specified directory.
   virtual void writePlotFile(
-    const std::string& dir, ostream& os, amrex::VisMF::How how) override;
+    const std::string& dir, std::ostream& os, amrex::VisMF::How how) override;
   virtual void writeSmallPlotFile(
-    const std::string& dir, ostream& os, amrex::VisMF::How how) override;
+    const std::string& dir, std::ostream& os, amrex::VisMF::How how) override;
   void writeJobInfo(const std::string& dir);
   static void writeBuildInfo(std::ostream& os);
 

--- a/SourceCpp/PeleC.H
+++ b/SourceCpp/PeleC.H
@@ -533,7 +533,8 @@ public:
   void avgDown();
   void avgDown(int state_indx);
 
-  static std::unique_ptr<ProbParmDevice> prob_parm;
+  static std::unique_ptr<ProbParmDevice> prob_parm_device;
+  static std::unique_ptr<ProbParmHost> prob_parm_host;
 
 protected:
   amrex::iMultiFab level_mask;

--- a/SourceCpp/PeleC.H
+++ b/SourceCpp/PeleC.H
@@ -27,6 +27,7 @@
 
 #include "Filter.H"
 #include "IndexDefines.H"
+#include "prob_parm.H"
 
 using std::istream;
 using std::ostream;
@@ -534,6 +535,8 @@ public:
 #endif
   void avgDown();
   void avgDown(int state_indx);
+
+  static std::unique_ptr<ProbParmDevice> prob_parm;
 
 protected:
   amrex::iMultiFab level_mask;

--- a/SourceCpp/PeleC.cpp
+++ b/SourceCpp/PeleC.cpp
@@ -666,8 +666,10 @@ PeleC::initData()
     auto sfab = S_new.array(mfi);
     const auto geomdata = geom.data();
 
+    ProbParmDevice const* lprobparm = prob_parm.get();
+
     amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-      pc_initdata(i, j, k, sfab, geomdata);
+      pc_initdata(i, j, k, sfab, geomdata, *lprobparm);
       // Verify that the sum of (rho Y)_i = rho at every cell
       pc_check_initial_species(i, j, k, sfab);
     });

--- a/SourceCpp/PeleC.cpp
+++ b/SourceCpp/PeleC.cpp
@@ -847,6 +847,7 @@ amrex::Real PeleC::estTimeStep(amrex::Real /*dt_old*/)
     }
 
     if (diffuse_vel) {
+      TransParm const* ltransparm = trans_parm_g;
       amrex::Real dt = amrex::ReduceMin(
         stateMF,
 #ifdef PELEC_USE_EB
@@ -865,12 +866,13 @@ amrex::Real PeleC::estTimeStep(amrex::Real /*dt_old*/)
 #ifdef PELEC_USE_EB
             flag_arr,
 #endif
-            AMREX_D_DECL(dx1, dx2, dx3));
+            AMREX_D_DECL(dx1, dx2, dx3), ltransparm);
         });
       estdt_vdif = amrex::min<amrex::Real>(estdt_vdif, dt);
     }
 
     if (diffuse_temp) {
+      TransParm const* ltransparm = trans_parm_g;
       amrex::Real dt = amrex::ReduceMin(
         stateMF,
 #ifdef PELEC_USE_EB
@@ -889,12 +891,13 @@ amrex::Real PeleC::estTimeStep(amrex::Real /*dt_old*/)
 #ifdef PELEC_USE_EB
             flag_arr,
 #endif
-            AMREX_D_DECL(dx1, dx2, dx3));
+            AMREX_D_DECL(dx1, dx2, dx3), ltransparm);
         });
       estdt_tdif = amrex::min<amrex::Real>(estdt_tdif, dt);
     }
 
     if (diffuse_enth) {
+      TransParm const* ltransparm = trans_parm_g;
       amrex::Real dt = amrex::ReduceMin(
         stateMF,
 #ifdef PELEC_USE_EB
@@ -913,7 +916,7 @@ amrex::Real PeleC::estTimeStep(amrex::Real /*dt_old*/)
 #ifdef PELEC_USE_EB
             flag_arr,
 #endif
-            AMREX_D_DECL(dx1, dx2, dx3));
+            AMREX_D_DECL(dx1, dx2, dx3), ltransparm);
         });
       estdt_edif = amrex::min<amrex::Real>(estdt_edif, dt);
     }

--- a/SourceCpp/PeleC.cpp
+++ b/SourceCpp/PeleC.cpp
@@ -123,6 +123,10 @@ ebInitialized(bool eb_init_val)
 void
 PeleC::variableCleanUp()
 {
+  prob_parm.reset();
+
+  derive_lst.clear();
+
   desc_lst.clear();
 
   transport_close();

--- a/SourceCpp/PeleC.cpp
+++ b/SourceCpp/PeleC.cpp
@@ -829,7 +829,7 @@ amrex::Real PeleC::estTimeStep(amrex::Real /*dt_old*/)
         flags,
 #endif
         0,
-        [=] AMREX_GPU_HOST_DEVICE(
+        [=] AMREX_GPU_DEVICE(
           amrex::Box const& bx, const amrex::Array4<const amrex::Real>& fab_arr
 #ifdef PELEC_USE_EB
           ,
@@ -853,7 +853,7 @@ amrex::Real PeleC::estTimeStep(amrex::Real /*dt_old*/)
         flags,
 #endif
         0,
-        [=] AMREX_GPU_HOST_DEVICE(
+        [=] AMREX_GPU_DEVICE(
           amrex::Box const& bx, const amrex::Array4<const amrex::Real>& fab_arr
 #ifdef PELEC_USE_EB
           ,
@@ -877,7 +877,7 @@ amrex::Real PeleC::estTimeStep(amrex::Real /*dt_old*/)
         flags,
 #endif
         0,
-        [=] AMREX_GPU_HOST_DEVICE(
+        [=] AMREX_GPU_DEVICE(
           amrex::Box const& bx, const amrex::Array4<const amrex::Real>& fab_arr
 #ifdef PELEC_USE_EB
           ,
@@ -901,7 +901,7 @@ amrex::Real PeleC::estTimeStep(amrex::Real /*dt_old*/)
         flags,
 #endif
         0,
-        [=] AMREX_GPU_HOST_DEVICE(
+        [=] AMREX_GPU_DEVICE(
           amrex::Box const& bx, const amrex::Array4<const amrex::Real>& fab_arr
 #ifdef PELEC_USE_EB
           ,

--- a/SourceCpp/PeleC.cpp
+++ b/SourceCpp/PeleC.cpp
@@ -123,7 +123,8 @@ ebInitialized(bool eb_init_val)
 void
 PeleC::variableCleanUp()
 {
-  prob_parm.reset();
+  prob_parm_device.reset();
+  prob_parm_host.reset();
 
   derive_lst.clear();
 
@@ -670,7 +671,7 @@ PeleC::initData()
     auto sfab = S_new.array(mfi);
     const auto geomdata = geom.data();
 
-    ProbParmDevice const* lprobparm = prob_parm.get();
+    ProbParmDevice const* lprobparm = prob_parm_device.get();
 
     amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
       pc_initdata(i, j, k, sfab, geomdata, *lprobparm);

--- a/SourceCpp/Setup.cpp
+++ b/SourceCpp/Setup.cpp
@@ -13,6 +13,8 @@ using namespace MASA;
 #include "prob.H"
 #include "chemistry_file.H"
 
+std::unique_ptr<ProbParmDevice> PeleC::prob_parm;
+
 // Components are:
 // Interior, Inflow, Outflow,  Symmetry,     SlipWall,     NoSlipWall, UserBC
 static int scalar_bc[] = {INT_DIR,      EXT_DIR,      FOEXTRAP, REFLECT_EVEN,
@@ -134,6 +136,8 @@ PeleC::variableSetUp()
   }
 
   AMREX_ASSERT(desc_lst.size() == 0);
+
+  prob_parm.reset(new ProbParmDevice{});
 
   // Get options, set phys_bc
   read_params();

--- a/SourceCpp/Setup.cpp
+++ b/SourceCpp/Setup.cpp
@@ -325,28 +325,7 @@ PeleC::variableSetUp()
   }
 
   // Get the species names from the network model.
-  {
-    int len = 20;
-    // cppcheck-suppress knownArgument
-    amrex::Vector<int> int_spec_names(len * NUM_SPECIES);
-    CKSYMS(int_spec_names.dataPtr(), &len);
-    for (int i = 0; i < NUM_SPECIES; i++) {
-      int j = 0;
-      for (j = 0; j < len; j++) {
-        if (int_spec_names[i * len + j] == ' ') {
-          break;
-        }
-      }
-      const int strlen = j;
-      char* char_spec_names = new char[strlen + 1];
-      for (j = 0; j < strlen; j++) {
-        char_spec_names[j] = int_spec_names[i * len + j];
-      }
-      char_spec_names[j] = '\0';
-      spec_names.push_back(std::string(char_spec_names));
-      delete[] char_spec_names;
-    }
-  }
+  CKSYMS_STR(spec_names);
 
   if (amrex::ParallelDescriptor::IOProcessor()) {
     amrex::Print() << NUM_SPECIES << " Species: " << std::endl;

--- a/SourceCpp/Setup.cpp
+++ b/SourceCpp/Setup.cpp
@@ -13,7 +13,8 @@ using namespace MASA;
 #include "prob.H"
 #include "chemistry_file.H"
 
-std::unique_ptr<ProbParmDevice> PeleC::prob_parm;
+std::unique_ptr<ProbParmDevice> PeleC::prob_parm_device;
+std::unique_ptr<ProbParmHost> PeleC::prob_parm_host;
 
 // Components are:
 // Interior, Inflow, Outflow,  Symmetry,     SlipWall,     NoSlipWall, UserBC
@@ -137,7 +138,8 @@ PeleC::variableSetUp()
 
   AMREX_ASSERT(desc_lst.size() == 0);
 
-  prob_parm.reset(new ProbParmDevice{});
+  prob_parm_device.reset(new ProbParmDevice{});
+  prob_parm_host.reset(new ProbParmHost{});
 
   // Get options, set phys_bc
   read_params();

--- a/SourceCpp/Setup.cpp
+++ b/SourceCpp/Setup.cpp
@@ -324,7 +324,10 @@ PeleC::variableSetUp()
     name[cnt] = std::string(buf);
   }
 
-  // Get the species names from the network model.
+  // Get the species names from the network model
+  // Set it for Null mechanism let it be overwritten for others
+  spec_names.resize(1);
+  spec_names[0] = "Null";
   CKSYMS_STR(spec_names);
 
   if (amrex::ParallelDescriptor::IOProcessor()) {

--- a/SourceCpp/Setup.cpp
+++ b/SourceCpp/Setup.cpp
@@ -6,6 +6,11 @@
 using namespace MASA;
 #endif
 
+#if defined(PELEC_USE_REACTIONS) && defined(AMREX_USE_GPU) && \
+  defined(USE_SUNDIALS_PP)
+#include <AMReX_SUNMemory.H>
+#endif
+
 #include "mechanism.h"
 #include "PeleC.H"
 #include "Derive.H"
@@ -149,6 +154,9 @@ PeleC::variableSetUp()
   init_transport();
 
 #ifdef PELEC_USE_REACTIONS
+#if defined(AMREX_USE_GPU) && defined(USE_SUNDIALS_PP)
+  amrex::sundials::MemoryHelper::Initialize();
+#endif
   // Initialize the reactor
   if (do_react == 1) {
     init_reactor();

--- a/SourceCpp/Setup.cpp
+++ b/SourceCpp/Setup.cpp
@@ -1,5 +1,6 @@
 #include <AMReX_ParmParse.H>
 #include <AMReX_buildInfo.H>
+#include <memory>
 
 #ifdef PELEC_USE_MASA
 #include <masa.h>
@@ -143,8 +144,8 @@ PeleC::variableSetUp()
 
   AMREX_ASSERT(desc_lst.size() == 0);
 
-  prob_parm_device.reset(new ProbParmDevice{});
-  prob_parm_host.reset(new ProbParmHost{});
+  prob_parm_device = std::make_unique<ProbParmDevice>();
+  prob_parm_host = std::make_unique<ProbParmHost>();
 
   // Get options, set phys_bc
   read_params();

--- a/SourceCpp/SparseData.H
+++ b/SourceCpp/SparseData.H
@@ -3,7 +3,7 @@
 
 #include <AMReX_Vector.H>
 
-AMREX_GPU_HOST_DEVICE
+AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 int
 getIndex(const int i, const int comp, const int size)

--- a/SourceCpp/SparseData.H
+++ b/SourceCpp/SparseData.H
@@ -3,7 +3,7 @@
 
 #include <AMReX_Vector.H>
 
-AMREX_GPU_DEVICE
+AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
 int
 getIndex(const int i, const int comp, const int size)

--- a/SourceCpp/Tagging.H
+++ b/SourceCpp/Tagging.H
@@ -37,7 +37,7 @@ extern AMREX_GPU_DEVICE_MANAGED amrex::Real vfracerr;
 extern AMREX_GPU_DEVICE_MANAGED int max_vfracerr_lev;
 } // namespace TaggingParm
 
-AMREX_GPU_HOST_DEVICE
+AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
 tag_error(
@@ -55,7 +55,7 @@ tag_error(
   }
 }
 
-AMREX_GPU_HOST_DEVICE
+AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
 tag_graderror(
@@ -88,7 +88,7 @@ tag_graderror(
   }
 }
 
-AMREX_GPU_HOST_DEVICE
+AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
 tag_abserror(
@@ -106,7 +106,7 @@ tag_abserror(
   }
 }
 
-AMREX_GPU_HOST_DEVICE
+AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
 tag_error_bounds(
@@ -127,7 +127,7 @@ tag_error_bounds(
 
 struct EmptyProbTagStruct
 {
-  AMREX_GPU_HOST_DEVICE
+  AMREX_GPU_DEVICE
   AMREX_FORCE_INLINE
   static void set_problem_tags(
     const int /*i*/,
@@ -145,7 +145,7 @@ struct EmptyProbTagStruct
 };
 
 template <typename ProbTagStruct, typename... Args>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
 set_problem_tags(Args&&... args)
 {
   ProbTagStruct::set_problem_tags(std::forward<Args>(args)...);

--- a/SourceCpp/Timestep.H
+++ b/SourceCpp/Timestep.H
@@ -18,7 +18,7 @@ namespace TimeStep {
 extern AMREX_GPU_DEVICE_MANAGED amrex::Real max_dt;
 } // namespace TimeStep
 
-AMREX_GPU_HOST_DEVICE
+AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
 pc_trans4dt(
@@ -44,7 +44,7 @@ pc_trans4dt(
   }
 }
 
-AMREX_GPU_HOST_DEVICE
+AMREX_GPU_DEVICE
 amrex::Real pc_estdt_hydro(
   const amrex::Box& bx,
   const amrex::Array4<const amrex::Real>& u,
@@ -57,7 +57,7 @@ amrex::Real pc_estdt_hydro(
     const amrex::Real& dz)) noexcept;
 
 // Diffusion Velocity
-AMREX_GPU_HOST_DEVICE
+AMREX_GPU_DEVICE
 amrex::Real pc_estdt_veldif(
   const amrex::Box& bx,
   const amrex::Array4<const amrex::Real>& u,
@@ -70,7 +70,7 @@ amrex::Real pc_estdt_veldif(
     const amrex::Real& dz)) noexcept;
 
 // Diffusion Temperature
-AMREX_GPU_HOST_DEVICE
+AMREX_GPU_DEVICE
 amrex::Real pc_estdt_tempdif(
   const amrex::Box& bx,
   const amrex::Array4<const amrex::Real>& u,
@@ -83,7 +83,7 @@ amrex::Real pc_estdt_tempdif(
     const amrex::Real& dz)) noexcept;
 
 // Diffusion Enthalpy
-AMREX_GPU_HOST_DEVICE
+AMREX_GPU_DEVICE
 amrex::Real pc_estdt_enthdif(
   const amrex::Box& bx,
   const amrex::Array4<const amrex::Real>& u,

--- a/SourceCpp/Timestep.H
+++ b/SourceCpp/Timestep.H
@@ -26,7 +26,8 @@ pc_trans4dt(
   amrex::Real T,
   amrex::Real rho,
   amrex::Real massfrac[],
-  amrex::Real& D)
+  amrex::Real& D,
+  TransParm const* trans_parm)
 {
   bool get_xi = false, get_mu = false, get_lam = false, get_Ddiag = false;
   amrex::Real dum1 = 0., dum2 = 0.;
@@ -35,12 +36,12 @@ pc_trans4dt(
     get_mu = true;
     transport(
       get_xi, get_mu, get_lam, get_Ddiag, T, rho, massfrac, nullptr, D, dum1,
-      dum2);
+      dum2, trans_parm);
   } else if (which_trans == 1) {
     get_lam = true;
     transport(
       get_xi, get_mu, get_lam, get_Ddiag, T, rho, massfrac, nullptr, dum1, dum2,
-      D);
+      D, trans_parm);
   }
 }
 
@@ -65,9 +66,8 @@ amrex::Real pc_estdt_veldif(
   const amrex::Array4<const amrex::EBCellFlag>& flags,
 #endif
   AMREX_D_DECL(
-    const amrex::Real& dx,
-    const amrex::Real& dy,
-    const amrex::Real& dz)) noexcept;
+    const amrex::Real& dx, const amrex::Real& dy, const amrex::Real& dz),
+  TransParm const* trans_parm) noexcept;
 
 // Diffusion Temperature
 AMREX_GPU_DEVICE
@@ -78,9 +78,8 @@ amrex::Real pc_estdt_tempdif(
   const amrex::Array4<const amrex::EBCellFlag>& flags,
 #endif
   AMREX_D_DECL(
-    const amrex::Real& dx,
-    const amrex::Real& dy,
-    const amrex::Real& dz)) noexcept;
+    const amrex::Real& dx, const amrex::Real& dy, const amrex::Real& dz),
+  TransParm const* trans_parm) noexcept;
 
 // Diffusion Enthalpy
 AMREX_GPU_DEVICE
@@ -91,8 +90,7 @@ amrex::Real pc_estdt_enthdif(
   const amrex::Array4<const amrex::EBCellFlag>& flags,
 #endif
   AMREX_D_DECL(
-    const amrex::Real& dx,
-    const amrex::Real& dy,
-    const amrex::Real& dz)) noexcept;
+    const amrex::Real& dx, const amrex::Real& dy, const amrex::Real& dz),
+  TransParm const* trans_parm) noexcept;
 
 #endif

--- a/SourceCpp/Timestep.cpp
+++ b/SourceCpp/Timestep.cpp
@@ -60,9 +60,8 @@ pc_estdt_veldif(
   const amrex::Array4<const amrex::EBCellFlag>& flags,
 #endif
   AMREX_D_DECL(
-    const amrex::Real& dx,
-    const amrex::Real& dy,
-    const amrex::Real& dz)) noexcept
+    const amrex::Real& dx, const amrex::Real& dy, const amrex::Real& dz),
+  TransParm const* trans_parm) noexcept
 {
   amrex::Real dt = TimeStep::max_dt;
 
@@ -79,7 +78,7 @@ pc_estdt_veldif(
       amrex::Real T = u(i, j, k, UTEMP);
       amrex::Real D = 0.0;
       const int which_trans = 0;
-      pc_trans4dt(which_trans, T, rho, massfrac, D);
+      pc_trans4dt(which_trans, T, rho, massfrac, D, trans_parm);
       D *= rhoInv;
       if (D == 0.0) {
         D = SMALL_NUM;
@@ -108,9 +107,8 @@ pc_estdt_tempdif(
   const amrex::Array4<const amrex::EBCellFlag>& flags,
 #endif
   AMREX_D_DECL(
-    const amrex::Real& dx,
-    const amrex::Real& dy,
-    const amrex::Real& dz)) noexcept
+    const amrex::Real& dx, const amrex::Real& dy, const amrex::Real& dz),
+  TransParm const* trans_parm) noexcept
 {
   amrex::Real dt = TimeStep::max_dt;
 
@@ -127,7 +125,7 @@ pc_estdt_tempdif(
       amrex::Real T = u(i, j, k, UTEMP);
       amrex::Real D = 0.0;
       const int which_trans = 1;
-      pc_trans4dt(which_trans, T, rho, massfrac, D);
+      pc_trans4dt(which_trans, T, rho, massfrac, D, trans_parm);
       amrex::Real cv;
       EOS::TY2Cv(T, massfrac, cv);
       D *= rhoInv / cv;
@@ -158,9 +156,8 @@ pc_estdt_enthdif(
   const amrex::Array4<const amrex::EBCellFlag>& flags,
 #endif
   AMREX_D_DECL(
-    const amrex::Real& dx,
-    const amrex::Real& dy,
-    const amrex::Real& dz)) noexcept
+    const amrex::Real& dx, const amrex::Real& dy, const amrex::Real& dz),
+  TransParm const* trans_parm) noexcept
 {
   amrex::Real dt = TimeStep::max_dt;
 
@@ -179,7 +176,7 @@ pc_estdt_enthdif(
       EOS::TY2Cp(T, massfrac, cp);
       amrex::Real D;
       const int which_trans = 1;
-      pc_trans4dt(which_trans, T, rho, massfrac, D);
+      pc_trans4dt(which_trans, T, rho, massfrac, D, trans_parm);
       D *= rhoInv / cp;
       AMREX_D_TERM(
         const amrex::Real dt1 = 0.5 * dx * dx / (AMREX_SPACEDIM * D);

--- a/SourceCpp/Timestep.cpp
+++ b/SourceCpp/Timestep.cpp
@@ -6,7 +6,7 @@ AMREX_GPU_DEVICE_MANAGED amrex::Real max_dt =
   std::numeric_limits<amrex::Real>::max();
 } // namespace TimeStep
 
-AMREX_GPU_HOST_DEVICE
+AMREX_GPU_DEVICE
 amrex::Real
 pc_estdt_hydro(
   const amrex::Box& bx,
@@ -51,7 +51,7 @@ pc_estdt_hydro(
 }
 
 // Diffusion Velocity
-AMREX_GPU_HOST_DEVICE
+AMREX_GPU_DEVICE
 amrex::Real
 pc_estdt_veldif(
   const amrex::Box& bx,
@@ -99,7 +99,7 @@ pc_estdt_veldif(
 }
 
 // Diffusion Temperature
-AMREX_GPU_HOST_DEVICE
+AMREX_GPU_DEVICE
 amrex::Real
 pc_estdt_tempdif(
   const amrex::Box& bx,
@@ -149,7 +149,7 @@ pc_estdt_tempdif(
 }
 
 // Diffusion Enthalpy
-AMREX_GPU_HOST_DEVICE
+AMREX_GPU_DEVICE
 amrex::Real
 pc_estdt_enthdif(
   const amrex::Box& bx,

--- a/SourceCpp/Utilities.H
+++ b/SourceCpp/Utilities.H
@@ -210,7 +210,7 @@ void read_csv(
   const size_t nz,
   amrex::Vector<amrex::Real>& data);
 
-AMREX_GPU_HOST_DEVICE
+AMREX_GPU_DEVICE
 void locate(
   const amrex::Real* xtable, const int n, const amrex::Real& x, int& idxlo);
 

--- a/SourceCpp/Utilities.H
+++ b/SourceCpp/Utilities.H
@@ -214,14 +214,14 @@ AMREX_GPU_HOST_DEVICE
 void locate(
   const amrex::Real* xtable, const int n, const amrex::Real& x, int& idxlo);
 
-template <typename T>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
+/* This was manually inlined to avoid unique_ptr somehow finding it and
+segfaulting template <typename T> AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
 swap(T* x, T* y)
 {
   T temp = *x;
   *x = *y;
   *y = temp;
-}
+}*/
 
 template <typename T>
 void
@@ -234,7 +234,10 @@ sort(T& vec)
     for (int i = 0; i < vec_size - 1; i++) {
       for (int j = 0; j < vec_size - i - 1; j++) {
         if (d_vec[j + 1] < d_vec[j]) {
-          swap<typename T::value_type>(&d_vec[j], &d_vec[j + 1]);
+          // swap<typename T::value_type>(&d_vec[j], &d_vec[j + 1]);
+          typename T::value_type temp = d_vec[j];
+          d_vec[j] = d_vec[j + 1];
+          d_vec[j + 1] = temp;
         }
       }
     }

--- a/SourceCpp/Utilities.cpp
+++ b/SourceCpp/Utilities.cpp
@@ -267,7 +267,7 @@ read_csv(
 // x             => x location
 // idxlo        <=> output st. xtable(idxlo) <= x < xtable(idxlo+1)
 // -----------------------------------------------------------
-AMREX_GPU_HOST_DEVICE
+AMREX_GPU_DEVICE
 void
 locate(const amrex::Real* xtable, const int n, const amrex::Real& x, int& idxlo)
 {

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -191,7 +191,7 @@ if(PELEC_DIM GREATER 2)
   add_test_re(zerod-1 zeroD)
   if(PELEC_ENABLE_AMREX_EB)
     add_test_re(eb-c3 EB-C3)
-    if(PELEC_ENABLE_FPE_TRAP_FOR_TESTS)
+    if(PELEC_ENABLE_FPE_TRAP_FOR_TESTS AND NOT PELEC_ENABLE_CUDA)
       add_test_rf(eb-c7 EB-C7) # This test exposes an EB issue not yet solved
     else()
       add_test_re(eb-c7 EB-C7)


### PR DESCRIPTION
I focused on TG, PMF, and the transport in these changes. TG and PMF changes need to be applied to the rest of the problems. The changes to transport allow us to use the `development` branch of PelePhysics again.

I'm making this a draft because the latest PelePhysics now segfaults on the GPU when using SUNDIALS. So I need to get that fixed before we merge this because that will break the nightly tests.

There's still a bunch of `AMREX_GPU_DEVICE_MANAGED` in the source code to get rid of.