### PR TITLE
Fix EB C8 plt file with llvm

### DIFF
--- a/SourceCpp/Advance.cpp
+++ b/SourceCpp/Advance.cpp
@@ -80,6 +80,7 @@ PeleC::do_mol_advance(
   }
 
 #ifdef PELEC_USE_REACTIONS
+  get_new_data(Reactions_Type).setVal(0);
   const amrex::MultiFab& I_R = get_new_data(Reactions_Type);
 #endif
 

--- a/SourceCpp/Advance.cpp
+++ b/SourceCpp/Advance.cpp
@@ -81,7 +81,7 @@ PeleC::do_mol_advance(
 
 #ifdef PELEC_USE_REACTIONS
   if (do_react == 0) {
-    get_new_data(Reactions_Type).setVal(0);
+    get_new_data(Reactions_Type).setVal(0.0);
   }
   const amrex::MultiFab& I_R = get_new_data(Reactions_Type);
 #endif

--- a/SourceCpp/Advance.cpp
+++ b/SourceCpp/Advance.cpp
@@ -80,7 +80,9 @@ PeleC::do_mol_advance(
   }
 
 #ifdef PELEC_USE_REACTIONS
-  get_new_data(Reactions_Type).setVal(0);
+  if (do_react == 0) {
+    get_new_data(Reactions_Type).setVal(0);
+  }
   const amrex::MultiFab& I_R = get_new_data(Reactions_Type);
 #endif
 


### PR DESCRIPTION
I think reactions source needs to be reset to zero at the beginning of the step such that, when in debug mode with llvm, NaN's don't get written to the plt file for the `rho_omega_*` components.  