### PR TITLE
Fix underoverflow in EB-C8

### DIFF
--- a/SourceCpp/Riemann.H
+++ b/SourceCpp/Riemann.H
@@ -24,7 +24,7 @@ riemann(
   const amrex::Real spr[NUM_SPECIES],
   const amrex::Real gamcr,
   const int bc_test_val,
-  const amrex::Real csmall,
+  const amrex::Real /*csmall*/,
   const amrex::Real cav,
   amrex::Real& ustar,
   amrex::Real& uflx_rho,
@@ -39,7 +39,7 @@ riemann(
   amrex::Real& qint_gdpres,
   amrex::Real& qint_gdgame)
 {
-  const amrex::Real wsmall = std::numeric_limits<amrex::Real>::min() * csmall;
+  const amrex::Real wsmall = std::numeric_limits<amrex::Real>::min();
 
   amrex::Real gdnv_state_rho = rl;
   amrex::Real gdnv_state_p = pl;

--- a/SourceCpp/Utilities.H
+++ b/SourceCpp/Utilities.H
@@ -53,9 +53,13 @@ pc_ctoprim(
   const amrex::Real e = (u(i, j, k, UEDEN) - kineng) * rhoinv;
   amrex::Real T = u(i, j, k, UTEMP);
   amrex::Real massfrac[NUM_SPECIES];
-  //    amrex::Real aux[NUM_AUX];
-  for (int sp = 0; sp < NUM_SPECIES; ++sp)
+  for (int sp = 0; sp < NUM_SPECIES; ++sp){
+    if(( -1e-4*std::numeric_limits<amrex::Real>::epsilon() < q(i,j,k,sp+QFS)) && (q(i,j,k,sp+QFS) < 1e-4*std::numeric_limits<amrex::Real>::epsilon() )){
+      q(i,j,k,sp+QFS) = 0.0;
+    }
     massfrac[sp] = q(i, j, k, sp + QFS);
+  }
+  //    amrex::Real aux[NUM_AUX];
   //    for(int ax = 0; ax < NUM_AUX; ++ax) aux[ax] = q(i,j,k,ax+QFX);
   amrex::Real dpdr_e, dpde, gam1, cs, wbar, p;
 

--- a/SourceCpp/Utilities.H
+++ b/SourceCpp/Utilities.H
@@ -53,9 +53,13 @@ pc_ctoprim(
   const amrex::Real e = (u(i, j, k, UEDEN) - kineng) * rhoinv;
   amrex::Real T = u(i, j, k, UTEMP);
   amrex::Real massfrac[NUM_SPECIES];
-  for (int sp = 0; sp < NUM_SPECIES; ++sp){
-    if(( -1e-4*std::numeric_limits<amrex::Real>::epsilon() < q(i,j,k,sp+QFS)) && (q(i,j,k,sp+QFS) < 1e-4*std::numeric_limits<amrex::Real>::epsilon() )){
-      q(i,j,k,sp+QFS) = 0.0;
+  for (int sp = 0; sp < NUM_SPECIES; ++sp) {
+    if (
+      (-1e-4 * std::numeric_limits<amrex::Real>::epsilon() <
+       q(i, j, k, sp + QFS)) &&
+      (q(i, j, k, sp + QFS) <
+       1e-4 * std::numeric_limits<amrex::Real>::epsilon())) {
+      q(i, j, k, sp + QFS) = 0.0;
     }
     massfrac[sp] = q(i, j, k, sp + QFS);
   }


### PR DESCRIPTION
Apparently EB-C8 was a good one... The fix I thought fixed EB-C8 was definitely a needed fix. But it wasn't the fix needed for the nightly tests. EB-C8 with llvm generates underflow calculations (usually uncaught) and the result of these are written to file. These are then attempted to be read in with `fcompare` and generate a `amrex::Error::0::Read of Vector<Vector<Real>> failed` because it fails to read a number like `-9.5044093114872298e-315`. The way to fix this is to ensure no underflow computations are done in the code. This PR fixes two identified underflow errors in EB-C8:

- an underflow calculation in the riemann solver (fairly straightforward)
- an underflow calculation arising from tiny mass fractions (e.g. around 1e-160). In this case, the fix is to ensure that any mass fraction far below machine precision and close to zero is turned into an actual zero. It is enough to do this in `ctoprim`. 

I should note that I expect this PR to introduce diffs in the nightly tests... But those diffss should all be below machine precision.

