### PR TITLE
Fix AMREX_D_TERM comma for graderror tagging.

### DIFF
--- a/SourceCpp/Tagging.H
+++ b/SourceCpp/Tagging.H
@@ -71,14 +71,11 @@ tag_graderror(
   // Tag on regions of high field gradient
   AMREX_D_TERM(
     amrex::Real ax = amrex::Math::abs(field(i + 1, j, k) - field(i, j, k));
-    ax = amrex::max<amrex::Real>(
-      ax, amrex::Math::abs(field(i, j, k) - field(i - 1, j, k)));
-    , amrex::Real ay = amrex::Math::abs(field(i, j + 1, k) - field(i, j, k));
-    ay = amrex::max<amrex::Real>(
-      ay, amrex::Math::abs(field(i, j, k) - field(i, j - 1, k)));
-    amrex::Real az = amrex::Math::abs(field(i, j, k + 1) - field(i, j, k));
-    , az = amrex::max<amrex::Real>(
-        az, amrex::Math::abs(field(i, j, k) - field(i, j, k - 1)));)
+    ax = amrex::max<amrex::Real>(ax, amrex::Math::abs(field(i, j, k) - field(i - 1, j, k)));
+  , amrex::Real ay = amrex::Math::abs(field(i, j + 1, k) - field(i, j, k));
+    ay = amrex::max<amrex::Real>(ay, amrex::Math::abs(field(i, j, k) - field(i, j - 1, k)));
+  , amrex::Real az = amrex::Math::abs(field(i, j, k + 1) - field(i, j, k));
+    az = amrex::max<amrex::Real>(az, amrex::Math::abs(field(i, j, k) - field(i, j, k - 1)));)
 #if AMREX_SPACEDIM > 1
   if (amrex::max<amrex::Real>(AMREX_D_DECL(ax, ay, az)) >= fieldgrad)
 #elif AMREX_SPACEDIM == 1

--- a/SourceCpp/Tagging.H
+++ b/SourceCpp/Tagging.H
@@ -71,11 +71,14 @@ tag_graderror(
   // Tag on regions of high field gradient
   AMREX_D_TERM(
     amrex::Real ax = amrex::Math::abs(field(i + 1, j, k) - field(i, j, k));
-    ax = amrex::max<amrex::Real>(ax, amrex::Math::abs(field(i, j, k) - field(i - 1, j, k)));
+    ax = amrex::max<amrex::Real>(
+      ax, amrex::Math::abs(field(i, j, k) - field(i - 1, j, k)));
   , amrex::Real ay = amrex::Math::abs(field(i, j + 1, k) - field(i, j, k));
-    ay = amrex::max<amrex::Real>(ay, amrex::Math::abs(field(i, j, k) - field(i, j - 1, k)));
+    ay = amrex::max<amrex::Real>(
+      ay, amrex::Math::abs(field(i, j, k) - field(i, j - 1, k)));
   , amrex::Real az = amrex::Math::abs(field(i, j, k + 1) - field(i, j, k));
-    az = amrex::max<amrex::Real>(az, amrex::Math::abs(field(i, j, k) - field(i, j, k - 1)));)
+    az = amrex::max<amrex::Real>(
+      az, amrex::Math::abs(field(i, j, k) - field(i, j, k - 1)));)
 #if AMREX_SPACEDIM > 1
   if (amrex::max<amrex::Real>(AMREX_D_DECL(ax, ay, az)) >= fieldgrad)
 #elif AMREX_SPACEDIM == 1

--- a/SourceCpp/Tagging.H
+++ b/SourceCpp/Tagging.H
@@ -73,10 +73,10 @@ tag_graderror(
     amrex::Real ax = amrex::Math::abs(field(i + 1, j, k) - field(i, j, k));
     ax = amrex::max<amrex::Real>(
       ax, amrex::Math::abs(field(i, j, k) - field(i - 1, j, k)));
-  , amrex::Real ay = amrex::Math::abs(field(i, j + 1, k) - field(i, j, k));
+    , amrex::Real ay = amrex::Math::abs(field(i, j + 1, k) - field(i, j, k));
     ay = amrex::max<amrex::Real>(
       ay, amrex::Math::abs(field(i, j, k) - field(i, j - 1, k)));
-  , amrex::Real az = amrex::Math::abs(field(i, j, k + 1) - field(i, j, k));
+    , amrex::Real az = amrex::Math::abs(field(i, j, k + 1) - field(i, j, k));
     az = amrex::max<amrex::Real>(
       az, amrex::Math::abs(field(i, j, k) - field(i, j, k - 1)));)
 #if AMREX_SPACEDIM > 1


### PR DESCRIPTION
The AMREX_D_TERM comma separating the Y and Z was misplaced and the code tried to access z > 0 when tagging based on gradient error in 2D.