### PR TITLE
Explicit copy of problem parameters to device

### DIFF
--- a/Exec/RegTests/EB-BluffBody/prob.cpp
+++ b/Exec/RegTests/EB-BluffBody/prob.cpp
@@ -17,27 +17,28 @@ amrex_probinit(
   // Parse params
   {
     amrex::ParmParse pp("prob");
-    pp.query("p", PeleC::prob_parm_device->p);
-    pp.query("rho", PeleC::prob_parm_device->rho);
-    pp.query("vx_in", PeleC::prob_parm_device->vx_in);
-    pp.query("vy_in", PeleC::prob_parm_device->vy_in);
-    pp.query("Re_L", PeleC::prob_parm_device->Re_L);
-    pp.query("Pr", PeleC::prob_parm_device->Pr);
+    pp.query("p", PeleC::h_prob_parm_device->p);
+    pp.query("rho", PeleC::h_prob_parm_device->rho);
+    pp.query("vx_in", PeleC::h_prob_parm_device->vx_in);
+    pp.query("vy_in", PeleC::h_prob_parm_device->vy_in);
+    pp.query("Re_L", PeleC::h_prob_parm_device->Re_L);
+    pp.query("Pr", PeleC::h_prob_parm_device->Pr);
   }
 
   amrex::Real L = (probhi[0] - problo[0]) * 0.2;
 
   amrex::Real cp = 0.0;
-  PeleC::prob_parm_device->massfrac[0] = 1.0;
+  PeleC::h_prob_parm_device->massfrac[0] = 1.0;
   auto eos = pele::physics::PhysicsType::eos();
   eos.RYP2E(
-    PeleC::prob_parm_device->rho, PeleC::prob_parm_device->massfrac.begin(),
-    PeleC::prob_parm_device->p, PeleC::prob_parm_device->eint);
+    PeleC::h_prob_parm_device->rho, PeleC::h_prob_parm_device->massfrac.begin(),
+    PeleC::h_prob_parm_device->p, PeleC::h_prob_parm_device->eint);
   eos.EY2T(
-    PeleC::prob_parm_device->eint, PeleC::prob_parm_device->massfrac.begin(),
-    PeleC::prob_parm_device->T);
+    PeleC::h_prob_parm_device->eint,
+    PeleC::h_prob_parm_device->massfrac.begin(), PeleC::h_prob_parm_device->T);
   eos.TY2Cp(
-    PeleC::prob_parm_device->T, PeleC::prob_parm_device->massfrac.begin(), cp);
+    PeleC::h_prob_parm_device->T, PeleC::h_prob_parm_device->massfrac.begin(),
+    cp);
 
   pele::physics::transport::TransParm trans_parm;
 
@@ -58,11 +59,11 @@ amrex_probinit(
 
   trans_parm.const_bulk_viscosity = 0.0;
   trans_parm.const_diffusivity = 0.0;
-  trans_parm.const_viscosity = PeleC::prob_parm_device->rho *
-                               PeleC::prob_parm_device->vx_in * L /
-                               PeleC::prob_parm_device->Re_L;
+  trans_parm.const_viscosity = PeleC::h_prob_parm_device->rho *
+                               PeleC::h_prob_parm_device->vx_in * L /
+                               PeleC::h_prob_parm_device->Re_L;
   trans_parm.const_conductivity =
-    trans_parm.const_viscosity * cp / PeleC::prob_parm_device->Pr;
+    trans_parm.const_viscosity * cp / PeleC::h_prob_parm_device->Pr;
 
 #ifdef AMREX_USE_GPU
   amrex::Gpu::htod_memcpy(

--- a/Exec/RegTests/EB-BluffBody/prob_parm.H
+++ b/Exec/RegTests/EB-BluffBody/prob_parm.H
@@ -5,9 +5,8 @@
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_GpuMemory.H>
 
-struct ProbParmDevice : amrex::Gpu::Managed
+struct ProbParmDevice
 {
-
   amrex::Real p = 1013250.0;
   amrex::Real T = 0.0;
   amrex::Real rho = 0.00116;
@@ -19,7 +18,7 @@ struct ProbParmDevice : amrex::Gpu::Managed
   amrex::GpuArray<amrex::Real, NUM_SPECIES> massfrac = {1.0};
 };
 
-struct ProbParmHost : amrex::Gpu::Managed
+struct ProbParmHost
 {
 };
 

--- a/Exec/RegTests/EB-BluffBody/prob_parm.H
+++ b/Exec/RegTests/EB-BluffBody/prob_parm.H
@@ -20,6 +20,7 @@ struct ProbParmDevice
 
 struct ProbParmHost
 {
+  ProbParmHost() {}
 };
 
 #endif

--- a/Exec/RegTests/EB-C1/prob.cpp
+++ b/Exec/RegTests/EB-C1/prob.cpp
@@ -18,32 +18,32 @@ amrex_probinit(
   // Parse params
   {
     amrex::ParmParse pp("prob");
-    pp.query("reynolds", PeleC::prob_parm_device->reynolds);
-    pp.query("mach", PeleC::prob_parm_device->mach);
-    pp.query("prandtl", PeleC::prob_parm_device->prandtl);
-    pp.query("rho_x_fact", PeleC::prob_parm_device->rho_x_fact);
-    pp.query("rho_y_fact", PeleC::prob_parm_device->rho_y_fact);
-    pp.query("rho_z_fact", PeleC::prob_parm_device->rho_z_fact);
-    pp.query("u_0_fact", PeleC::prob_parm_device->u_0_fact);
-    pp.query("v_0_fact", PeleC::prob_parm_device->v_0_fact);
-    pp.query("w_0_fact", PeleC::prob_parm_device->w_0_fact);
-    pp.query("u_r_fact", PeleC::prob_parm_device->u_r_fact);
-    pp.query("v_r_fact", PeleC::prob_parm_device->v_r_fact);
-    pp.query("w_r_fact", PeleC::prob_parm_device->w_r_fact);
-    pp.query("p_r_fact", PeleC::prob_parm_device->p_r_fact);
-    pp.query("a_rhox", PeleC::prob_parm_device->a_rhox);
-    pp.query("a_rhoy", PeleC::prob_parm_device->a_rhoy);
-    pp.query("a_rhoz", PeleC::prob_parm_device->a_rhoz);
-    pp.query("a_ux", PeleC::prob_parm_device->a_ur);
-    pp.query("a_ux", PeleC::prob_parm_device->a_vr);
-    pp.query("a_ux", PeleC::prob_parm_device->a_wr);
-    pp.query("a_ux", PeleC::prob_parm_device->a_pr);
+    pp.query("reynolds", PeleC::h_prob_parm_device->reynolds);
+    pp.query("mach", PeleC::h_prob_parm_device->mach);
+    pp.query("prandtl", PeleC::h_prob_parm_device->prandtl);
+    pp.query("rho_x_fact", PeleC::h_prob_parm_device->rho_x_fact);
+    pp.query("rho_y_fact", PeleC::h_prob_parm_device->rho_y_fact);
+    pp.query("rho_z_fact", PeleC::h_prob_parm_device->rho_z_fact);
+    pp.query("u_0_fact", PeleC::h_prob_parm_device->u_0_fact);
+    pp.query("v_0_fact", PeleC::h_prob_parm_device->v_0_fact);
+    pp.query("w_0_fact", PeleC::h_prob_parm_device->w_0_fact);
+    pp.query("u_r_fact", PeleC::h_prob_parm_device->u_r_fact);
+    pp.query("v_r_fact", PeleC::h_prob_parm_device->v_r_fact);
+    pp.query("w_r_fact", PeleC::h_prob_parm_device->w_r_fact);
+    pp.query("p_r_fact", PeleC::h_prob_parm_device->p_r_fact);
+    pp.query("a_rhox", PeleC::h_prob_parm_device->a_rhox);
+    pp.query("a_rhoy", PeleC::h_prob_parm_device->a_rhoy);
+    pp.query("a_rhoz", PeleC::h_prob_parm_device->a_rhoz);
+    pp.query("a_ux", PeleC::h_prob_parm_device->a_ur);
+    pp.query("a_ux", PeleC::h_prob_parm_device->a_vr);
+    pp.query("a_ux", PeleC::h_prob_parm_device->a_wr);
+    pp.query("a_ux", PeleC::h_prob_parm_device->a_pr);
   }
 
   // Define the length scale
-  PeleC::prob_parm_device->L_x = probhi[0] - problo[0];
-  PeleC::prob_parm_device->L_y = probhi[1] - problo[1];
-  PeleC::prob_parm_device->L_z = probhi[2] - problo[2];
+  PeleC::h_prob_parm_device->L_x = probhi[0] - problo[0];
+  PeleC::h_prob_parm_device->L_y = probhi[1] - problo[1];
+  PeleC::h_prob_parm_device->L_z = probhi[2] - problo[2];
 
   // Initial density, velocity, and material properties
   amrex::Real eint;
@@ -52,13 +52,14 @@ amrex_probinit(
   amrex::Real massfrac[NUM_SPECIES] = {1.0};
   auto eos = pele::physics::PhysicsType::eos();
   eos.PYT2RE(
-    PeleC::prob_parm_device->p0, massfrac, PeleC::prob_parm_device->T0,
-    PeleC::prob_parm_device->rho0, eint);
+    PeleC::h_prob_parm_device->p0, massfrac, PeleC::h_prob_parm_device->T0,
+    PeleC::h_prob_parm_device->rho0, eint);
   eos.RTY2Cs(
-    PeleC::prob_parm_device->rho0, PeleC::prob_parm_device->T0, massfrac, cs);
-  eos.TY2Cp(PeleC::prob_parm_device->T0, massfrac, cp);
+    PeleC::h_prob_parm_device->rho0, PeleC::h_prob_parm_device->T0, massfrac,
+    cs);
+  eos.TY2Cp(PeleC::h_prob_parm_device->T0, massfrac, cp);
 
-  PeleC::prob_parm_device->u0 = PeleC::prob_parm_device->mach * cs;
+  PeleC::h_prob_parm_device->u0 = PeleC::h_prob_parm_device->mach * cs;
 
   pele::physics::transport::TransParm trans_parm;
 
@@ -78,14 +79,14 @@ amrex_probinit(
   }
 
   trans_parm.const_bulk_viscosity =
-    PeleC::prob_parm_device->rho0 * PeleC::prob_parm_device->u0 *
-    PeleC::prob_parm_device->L_x / PeleC::prob_parm_device->reynolds;
+    PeleC::h_prob_parm_device->rho0 * PeleC::h_prob_parm_device->u0 *
+    PeleC::h_prob_parm_device->L_x / PeleC::h_prob_parm_device->reynolds;
   trans_parm.const_diffusivity = 0.0;
   trans_parm.const_viscosity =
-    PeleC::prob_parm_device->rho0 * PeleC::prob_parm_device->u0 *
-    PeleC::prob_parm_device->L_x / PeleC::prob_parm_device->reynolds;
+    PeleC::h_prob_parm_device->rho0 * PeleC::h_prob_parm_device->u0 *
+    PeleC::h_prob_parm_device->L_x / PeleC::h_prob_parm_device->reynolds;
   trans_parm.const_conductivity =
-    trans_parm.const_viscosity * cp / PeleC::prob_parm_device->prandtl;
+    trans_parm.const_viscosity * cp / PeleC::h_prob_parm_device->prandtl;
 
 #ifdef AMREX_USE_GPU
   amrex::Gpu::htod_memcpy(
@@ -103,41 +104,41 @@ amrex_probinit(
   // w = w_0 + w_r * cos(a_wx * PI * r / L)
   // p = p_0 + p_r * cos(a_px * PI * r / L)
   // clang-format on
-  masa_set_param("L", PeleC::prob_parm_device->L_x);
+  masa_set_param("L", PeleC::h_prob_parm_device->L_x);
   masa_set_param(
     "R", pele::physics::Constants::RU / pele::physics::Constants::AIRMW);
   masa_set_param("k", trans_parm.const_conductivity);
   masa_set_param("Gamma", eos.gamma);
   masa_set_param("mu", trans_parm.const_viscosity);
   masa_set_param("mu_bulk", trans_parm.const_bulk_viscosity);
-  masa_set_param("rho_0", PeleC::prob_parm_device->rho0);
+  masa_set_param("rho_0", PeleC::h_prob_parm_device->rho0);
   masa_set_param(
     "rho_x",
-    PeleC::prob_parm_device->rho_x_fact * PeleC::prob_parm_device->rho0);
-  masa_set_param("rho_y", PeleC::prob_parm_device->rho_y_fact);
-  masa_set_param("rho_z", PeleC::prob_parm_device->rho_z_fact);
+    PeleC::h_prob_parm_device->rho_x_fact * PeleC::h_prob_parm_device->rho0);
+  masa_set_param("rho_y", PeleC::h_prob_parm_device->rho_y_fact);
+  masa_set_param("rho_z", PeleC::h_prob_parm_device->rho_z_fact);
   masa_set_param(
-    "u_0", PeleC::prob_parm_device->u_0_fact * PeleC::prob_parm_device->u0);
+    "u_0", PeleC::h_prob_parm_device->u_0_fact * PeleC::h_prob_parm_device->u0);
   masa_set_param(
-    "v_0", PeleC::prob_parm_device->v_0_fact * PeleC::prob_parm_device->u0);
+    "v_0", PeleC::h_prob_parm_device->v_0_fact * PeleC::h_prob_parm_device->u0);
   masa_set_param(
-    "w_0", PeleC::prob_parm_device->w_0_fact * PeleC::prob_parm_device->u0);
-  masa_set_param("p_0", PeleC::prob_parm_device->p0);
+    "w_0", PeleC::h_prob_parm_device->w_0_fact * PeleC::h_prob_parm_device->u0);
+  masa_set_param("p_0", PeleC::h_prob_parm_device->p0);
   masa_set_param(
-    "u_r", PeleC::prob_parm_device->u_r_fact * PeleC::prob_parm_device->u0);
+    "u_r", PeleC::h_prob_parm_device->u_r_fact * PeleC::h_prob_parm_device->u0);
   masa_set_param(
-    "v_r", PeleC::prob_parm_device->v_r_fact * PeleC::prob_parm_device->u0);
+    "v_r", PeleC::h_prob_parm_device->v_r_fact * PeleC::h_prob_parm_device->u0);
   masa_set_param(
-    "w_r", PeleC::prob_parm_device->w_r_fact * PeleC::prob_parm_device->u0);
+    "w_r", PeleC::h_prob_parm_device->w_r_fact * PeleC::h_prob_parm_device->u0);
   masa_set_param(
-    "p_r", PeleC::prob_parm_device->p_r_fact * PeleC::prob_parm_device->p0);
-  masa_set_param("a_rhox", PeleC::prob_parm_device->a_rhox);
-  masa_set_param("a_rhoy", PeleC::prob_parm_device->a_rhoy);
-  masa_set_param("a_rhoz", PeleC::prob_parm_device->a_rhoz);
-  masa_set_param("a_ur", PeleC::prob_parm_device->a_ur);
-  masa_set_param("a_vr", PeleC::prob_parm_device->a_vr);
-  masa_set_param("a_wr", PeleC::prob_parm_device->a_wr);
-  masa_set_param("a_pr", PeleC::prob_parm_device->a_pr);
+    "p_r", PeleC::h_prob_parm_device->p_r_fact * PeleC::h_prob_parm_device->p0);
+  masa_set_param("a_rhox", PeleC::h_prob_parm_device->a_rhox);
+  masa_set_param("a_rhoy", PeleC::h_prob_parm_device->a_rhoy);
+  masa_set_param("a_rhoz", PeleC::h_prob_parm_device->a_rhoz);
+  masa_set_param("a_ur", PeleC::h_prob_parm_device->a_ur);
+  masa_set_param("a_vr", PeleC::h_prob_parm_device->a_vr);
+  masa_set_param("a_wr", PeleC::h_prob_parm_device->a_wr);
+  masa_set_param("a_pr", PeleC::h_prob_parm_device->a_pr);
 
   // Display and check
   if (amrex::ParallelDescriptor::IOProcessor()) {

--- a/Exec/RegTests/EB-C1/prob_parm.H
+++ b/Exec/RegTests/EB-C1/prob_parm.H
@@ -5,9 +5,8 @@
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_GpuMemory.H>
 
-struct ProbParmDevice : amrex::Gpu::Managed
+struct ProbParmDevice
 {
-
   amrex::Real reynolds = 1.0;
   amrex::Real mach = 1.0;
   amrex::Real prandtl = 1.0;
@@ -37,7 +36,7 @@ struct ProbParmDevice : amrex::Gpu::Managed
   amrex::Real u0 = 0.0;
 };
 
-struct ProbParmHost : amrex::Gpu::Managed
+struct ProbParmHost
 {
 };
 

--- a/Exec/RegTests/EB-C1/prob_parm.H
+++ b/Exec/RegTests/EB-C1/prob_parm.H
@@ -38,6 +38,7 @@ struct ProbParmDevice
 
 struct ProbParmHost
 {
+  ProbParmHost() {}
 };
 
 #endif

--- a/Exec/RegTests/EB-C10/prob_parm.H
+++ b/Exec/RegTests/EB-C10/prob_parm.H
@@ -24,6 +24,7 @@ struct ProbParmDevice
 
 struct ProbParmHost
 {
+  ProbParmHost() {}
 };
 
 #endif

--- a/Exec/RegTests/EB-C10/prob_parm.H
+++ b/Exec/RegTests/EB-C10/prob_parm.H
@@ -5,9 +5,8 @@
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_GpuMemory.H>
 
-struct ProbParmDevice : amrex::Gpu::Managed
+struct ProbParmDevice
 {
-
   amrex::Real p = 1013250.0;
   amrex::Real dpdx = 0.0;
   amrex::Real T = 300.0;
@@ -23,7 +22,7 @@ struct ProbParmDevice : amrex::Gpu::Managed
   amrex::GpuArray<amrex::Real, NUM_SPECIES> massfrac = {1.0};
 };
 
-struct ProbParmHost : amrex::Gpu::Managed
+struct ProbParmHost
 {
 };
 

--- a/Exec/RegTests/EB-C11/prob.cpp
+++ b/Exec/RegTests/EB-C11/prob.cpp
@@ -16,48 +16,48 @@ amrex_probinit(
 {
   // Parse params
   amrex::ParmParse pp("prob");
-  pp.query("p_l", PeleC::prob_parm_device->p_l);
-  pp.query("u_l", PeleC::prob_parm_device->u_l);
-  pp.query("rho_l", PeleC::prob_parm_device->rho_l);
-  pp.query("p_r", PeleC::prob_parm_device->p_r);
-  pp.query("u_r", PeleC::prob_parm_device->u_r);
-  pp.query("rho_r", PeleC::prob_parm_device->rho_r);
-  pp.query("frac", PeleC::prob_parm_device->frac);
-  pp.query("idir", PeleC::prob_parm_device->idir);
+  pp.query("p_l", PeleC::h_prob_parm_device->p_l);
+  pp.query("u_l", PeleC::h_prob_parm_device->u_l);
+  pp.query("rho_l", PeleC::h_prob_parm_device->rho_l);
+  pp.query("p_r", PeleC::h_prob_parm_device->p_r);
+  pp.query("u_r", PeleC::h_prob_parm_device->u_r);
+  pp.query("rho_r", PeleC::h_prob_parm_device->rho_r);
+  pp.query("frac", PeleC::h_prob_parm_device->frac);
+  pp.query("idir", PeleC::h_prob_parm_device->idir);
   pp.get("left_gas", PeleC::prob_parm_host->gasL);
   pp.get("right_gas", PeleC::prob_parm_host->gasR);
 
   for (int idir = 0; idir < AMREX_SPACEDIM; idir++) {
-    PeleC::prob_parm_device->split[idir] = 0.5;
+    PeleC::h_prob_parm_device->split[idir] = 0.5;
   }
 
   if (PeleC::prob_parm_host->gasL == "N2") {
-    PeleC::prob_parm_device->left_gas_id = N2_ID;
-    PeleC::prob_parm_device->right_gas_id = HE_ID;
+    PeleC::h_prob_parm_device->left_gas_id = N2_ID;
+    PeleC::h_prob_parm_device->right_gas_id = HE_ID;
   } else {
-    PeleC::prob_parm_device->left_gas_id = HE_ID;
-    PeleC::prob_parm_device->right_gas_id = N2_ID;
+    PeleC::h_prob_parm_device->left_gas_id = HE_ID;
+    PeleC::h_prob_parm_device->right_gas_id = N2_ID;
   }
 
   amrex::Real e_l;
   amrex::Real e_r /*, cs, cp*/;
   amrex::Real massfrac_l[NUM_SPECIES] = {0.0};
   amrex::Real massfrac_r[NUM_SPECIES] = {0.0};
-  massfrac_l[PeleC::prob_parm_device->left_gas_id] = 1.0;
-  massfrac_r[PeleC::prob_parm_device->right_gas_id] = 1.0;
+  massfrac_l[PeleC::h_prob_parm_device->left_gas_id] = 1.0;
+  massfrac_r[PeleC::h_prob_parm_device->right_gas_id] = 1.0;
 
   auto eos = pele::physics::PhysicsType::eos();
   eos.RYP2E(
-    PeleC::prob_parm_device->rho_l, massfrac_l, PeleC::prob_parm_device->p_l,
-    e_l);
-  eos.EY2T(e_l, massfrac_l, PeleC::prob_parm_device->T_l);
-  PeleC::prob_parm_device->rhoe_l = PeleC::prob_parm_device->rho_l * e_l;
+    PeleC::h_prob_parm_device->rho_l, massfrac_l,
+    PeleC::h_prob_parm_device->p_l, e_l);
+  eos.EY2T(e_l, massfrac_l, PeleC::h_prob_parm_device->T_l);
+  PeleC::h_prob_parm_device->rhoe_l = PeleC::h_prob_parm_device->rho_l * e_l;
 
   eos.RYP2E(
-    PeleC::prob_parm_device->rho_r, massfrac_r, PeleC::prob_parm_device->p_r,
-    e_r);
-  eos.EY2T(e_r, massfrac_r, PeleC::prob_parm_device->T_r);
-  PeleC::prob_parm_device->rhoe_r = PeleC::prob_parm_device->rho_r * e_r;
+    PeleC::h_prob_parm_device->rho_r, massfrac_r,
+    PeleC::h_prob_parm_device->p_r, e_r);
+  eos.EY2T(e_r, massfrac_r, PeleC::h_prob_parm_device->T_r);
+  PeleC::h_prob_parm_device->rhoe_r = PeleC::h_prob_parm_device->rho_r * e_r;
 }
 }
 

--- a/Exec/RegTests/EB-C11/prob_parm.H
+++ b/Exec/RegTests/EB-C11/prob_parm.H
@@ -5,7 +5,7 @@
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_GpuMemory.H>
 
-struct ProbParmDevice : amrex::Gpu::Managed
+struct ProbParmDevice
 {
   amrex::Real p_l = 1.0;   // left pressure (erg/cc)
   amrex::Real u_l = 0.0;   // left velocity (cm/s)
@@ -24,7 +24,7 @@ struct ProbParmDevice : amrex::Gpu::Managed
   int right_gas_id = HE_ID;
 };
 
-struct ProbParmHost : amrex::Gpu::Managed
+struct ProbParmHost
 {
   std::string gasL = "N2";
   std::string gasR = "HE";

--- a/Exec/RegTests/EB-C11/prob_parm.H
+++ b/Exec/RegTests/EB-C11/prob_parm.H
@@ -28,6 +28,7 @@ struct ProbParmHost
 {
   std::string gasL = "N2";
   std::string gasR = "HE";
+  ProbParmHost() {}
 };
 
 #endif

--- a/Exec/RegTests/EB-C12/prob.cpp
+++ b/Exec/RegTests/EB-C12/prob.cpp
@@ -14,7 +14,7 @@ amrex_probinit(
   const amrex_real* /*problo*/,
   const amrex_real* /*probhi*/)
 {
-  PeleC::prob_parm_device->massfrac[0] = 1.0;
+  PeleC::h_prob_parm_device->massfrac[0] = 1.0;
 }
 }
 

--- a/Exec/RegTests/EB-C12/prob_parm.H
+++ b/Exec/RegTests/EB-C12/prob_parm.H
@@ -5,7 +5,7 @@
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_GpuMemory.H>
 
-struct ProbParmDevice : amrex::Gpu::Managed
+struct ProbParmDevice
 {
   amrex::Real p0 = 1.0;
   amrex::Real rho0 = 1.0;
@@ -14,7 +14,7 @@ struct ProbParmDevice : amrex::Gpu::Managed
   amrex::GpuArray<amrex::Real, NUM_SPECIES> massfrac = {0.0};
 };
 
-struct ProbParmHost : amrex::Gpu::Managed
+struct ProbParmHost
 {
 };
 

--- a/Exec/RegTests/EB-C12/prob_parm.H
+++ b/Exec/RegTests/EB-C12/prob_parm.H
@@ -16,6 +16,7 @@ struct ProbParmDevice
 
 struct ProbParmHost
 {
+  ProbParmHost() {}
 };
 
 #endif

--- a/Exec/RegTests/EB-C3/prob.cpp
+++ b/Exec/RegTests/EB-C3/prob.cpp
@@ -16,21 +16,25 @@ amrex_probinit(
 {
   // Parse params
   amrex::ParmParse pp("prob");
-  pp.query("p_init", PeleC::prob_parm_device->p_init);
-  pp.query("Y_init_H2", PeleC::prob_parm_device->Y_init_H2);
-  pp.query("Y_init_O2", PeleC::prob_parm_device->Y_init_O2);
-  pp.query("Y_init_N2", PeleC::prob_parm_device->Y_init_N2);
-  pp.query("T_init", PeleC::prob_parm_device->T_init);
+  pp.query("p_init", PeleC::h_prob_parm_device->p_init);
+  pp.query("Y_init_H2", PeleC::h_prob_parm_device->Y_init_H2);
+  pp.query("Y_init_O2", PeleC::h_prob_parm_device->Y_init_O2);
+  pp.query("Y_init_N2", PeleC::h_prob_parm_device->Y_init_N2);
+  pp.query("T_init", PeleC::h_prob_parm_device->T_init);
 
   // Initial values
-  PeleC::prob_parm_device->massfrac[H2_ID] = PeleC::prob_parm_device->Y_init_H2;
-  PeleC::prob_parm_device->massfrac[O2_ID] = PeleC::prob_parm_device->Y_init_O2;
-  PeleC::prob_parm_device->massfrac[N2_ID] = PeleC::prob_parm_device->Y_init_N2;
+  PeleC::h_prob_parm_device->massfrac[H2_ID] =
+    PeleC::h_prob_parm_device->Y_init_H2;
+  PeleC::h_prob_parm_device->massfrac[O2_ID] =
+    PeleC::h_prob_parm_device->Y_init_O2;
+  PeleC::h_prob_parm_device->massfrac[N2_ID] =
+    PeleC::h_prob_parm_device->Y_init_N2;
   auto eos = pele::physics::PhysicsType::eos();
   eos.PYT2RE(
-    PeleC::prob_parm_device->p_init, PeleC::prob_parm_device->massfrac.begin(),
-    PeleC::prob_parm_device->T_init, PeleC::prob_parm_device->rho_init,
-    PeleC::prob_parm_device->e_init);
+    PeleC::h_prob_parm_device->p_init,
+    PeleC::h_prob_parm_device->massfrac.begin(),
+    PeleC::h_prob_parm_device->T_init, PeleC::h_prob_parm_device->rho_init,
+    PeleC::h_prob_parm_device->e_init);
 }
 }
 

--- a/Exec/RegTests/EB-C3/prob_parm.H
+++ b/Exec/RegTests/EB-C3/prob_parm.H
@@ -20,6 +20,7 @@ struct ProbParmDevice
 
 struct ProbParmHost
 {
+  ProbParmHost() {}
 };
 
 #endif

--- a/Exec/RegTests/EB-C3/prob_parm.H
+++ b/Exec/RegTests/EB-C3/prob_parm.H
@@ -5,7 +5,7 @@
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_GpuMemory.H>
 
-struct ProbParmDevice : amrex::Gpu::Managed
+struct ProbParmDevice
 {
 
   amrex::Real p_init = 1013250.0; // 1 atm
@@ -18,7 +18,7 @@ struct ProbParmDevice : amrex::Gpu::Managed
   amrex::GpuArray<amrex::Real, NUM_SPECIES> massfrac = {0.0};
 };
 
-struct ProbParmHost : amrex::Gpu::Managed
+struct ProbParmHost
 {
 };
 

--- a/Exec/RegTests/EB-C4-5/prob.cpp
+++ b/Exec/RegTests/EB-C4-5/prob.cpp
@@ -16,16 +16,17 @@ amrex_probinit(
 {
   // Parse params
   amrex::ParmParse pp("prob");
-  pp.query("p_init", PeleC::prob_parm_device->p_init);
-  pp.query("T_init", PeleC::prob_parm_device->T_init);
+  pp.query("p_init", PeleC::h_prob_parm_device->p_init);
+  pp.query("T_init", PeleC::h_prob_parm_device->T_init);
 
   // Initial values
-  PeleC::prob_parm_device->massfrac[0] = 1.0;
+  PeleC::h_prob_parm_device->massfrac[0] = 1.0;
   auto eos = pele::physics::PhysicsType::eos();
   eos.PYT2RE(
-    PeleC::prob_parm_device->p_init, PeleC::prob_parm_device->massfrac.begin(),
-    PeleC::prob_parm_device->T_init, PeleC::prob_parm_device->rho_init,
-    PeleC::prob_parm_device->e_init);
+    PeleC::h_prob_parm_device->p_init,
+    PeleC::h_prob_parm_device->massfrac.begin(),
+    PeleC::h_prob_parm_device->T_init, PeleC::h_prob_parm_device->rho_init,
+    PeleC::h_prob_parm_device->e_init);
 }
 }
 

--- a/Exec/RegTests/EB-C4-5/prob_parm.H
+++ b/Exec/RegTests/EB-C4-5/prob_parm.H
@@ -16,6 +16,7 @@ struct ProbParmDevice
 
 struct ProbParmHost
 {
+  ProbParmHost() {}
 };
 
 #endif

--- a/Exec/RegTests/EB-C4-5/prob_parm.H
+++ b/Exec/RegTests/EB-C4-5/prob_parm.H
@@ -5,7 +5,7 @@
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_GpuMemory.H>
 
-struct ProbParmDevice : amrex::Gpu::Managed
+struct ProbParmDevice
 {
   amrex::Real p_init = 1013250.0; // 1 atm
   amrex::Real T_init = 940.0;
@@ -14,7 +14,7 @@ struct ProbParmDevice : amrex::Gpu::Managed
   amrex::GpuArray<amrex::Real, NUM_SPECIES> massfrac = {0.0};
 };
 
-struct ProbParmHost : amrex::Gpu::Managed
+struct ProbParmHost
 {
 };
 

--- a/Exec/RegTests/EB-C7/prob.cpp
+++ b/Exec/RegTests/EB-C7/prob.cpp
@@ -16,41 +16,46 @@ amrex_probinit(
 {
   // Parse params
   amrex::ParmParse pp("prob");
-  pp.query("pl", PeleC::prob_parm_device->pl);
-  pp.query("rhol", PeleC::prob_parm_device->rhol);
-  pp.query("pr", PeleC::prob_parm_device->pr);
-  pp.query("rhor", PeleC::prob_parm_device->rhor);
-  pp.query("angle", PeleC::prob_parm_device->angle);
+  pp.query("pl", PeleC::h_prob_parm_device->pl);
+  pp.query("rhol", PeleC::h_prob_parm_device->rhol);
+  pp.query("pr", PeleC::h_prob_parm_device->pr);
+  pp.query("rhor", PeleC::h_prob_parm_device->rhor);
+  pp.query("angle", PeleC::h_prob_parm_device->angle);
 
-  PeleC::prob_parm_device->L = (probhi[0] - problo[0]);
+  PeleC::h_prob_parm_device->L = (probhi[0] - problo[0]);
 
-  PeleC::prob_parm_device->massfrac[0] = 1.0;
+  PeleC::h_prob_parm_device->massfrac[0] = 1.0;
 
   auto eos = pele::physics::PhysicsType::eos();
   eos.RYP2T(
-    PeleC::prob_parm_device->rhol, PeleC::prob_parm_device->massfrac.begin(),
-    PeleC::prob_parm_device->pl, PeleC::prob_parm_device->Tl);
+    PeleC::h_prob_parm_device->rhol,
+    PeleC::h_prob_parm_device->massfrac.begin(), PeleC::h_prob_parm_device->pl,
+    PeleC::h_prob_parm_device->Tl);
   eos.RYP2E(
-    PeleC::prob_parm_device->rhol, PeleC::prob_parm_device->massfrac.begin(),
-    PeleC::prob_parm_device->pl, PeleC::prob_parm_device->eintl);
+    PeleC::h_prob_parm_device->rhol,
+    PeleC::h_prob_parm_device->massfrac.begin(), PeleC::h_prob_parm_device->pl,
+    PeleC::h_prob_parm_device->eintl);
 
   eos.RYP2T(
-    PeleC::prob_parm_device->rhor, PeleC::prob_parm_device->massfrac.begin(),
-    PeleC::prob_parm_device->pr, PeleC::prob_parm_device->Tr);
+    PeleC::h_prob_parm_device->rhor,
+    PeleC::h_prob_parm_device->massfrac.begin(), PeleC::h_prob_parm_device->pr,
+    PeleC::h_prob_parm_device->Tr);
   eos.RYP2E(
-    PeleC::prob_parm_device->rhor, PeleC::prob_parm_device->massfrac.begin(),
-    PeleC::prob_parm_device->pr, PeleC::prob_parm_device->eintr);
+    PeleC::h_prob_parm_device->rhor,
+    PeleC::h_prob_parm_device->massfrac.begin(), PeleC::h_prob_parm_device->pr,
+    PeleC::h_prob_parm_device->eintr);
 
   // Output IC
   std::ofstream ofs("ic.txt", std::ofstream::out);
   amrex::Print(ofs) << "L, rhol, pl, Tl, rhor, pr, Tr, gamma, angle"
                     << std::endl;
   amrex::Print(ofs).SetPrecision(17)
-    << PeleC::prob_parm_device->L << "," << PeleC::prob_parm_device->rhol << ","
-    << PeleC::prob_parm_device->pl << "," << PeleC::prob_parm_device->Tl << ","
-    << PeleC::prob_parm_device->rhor << "," << PeleC::prob_parm_device->pr
-    << "," << PeleC::prob_parm_device->Tr << "," << eos.gamma << ","
-    << PeleC::prob_parm_device->angle << std::endl;
+    << PeleC::h_prob_parm_device->L << "," << PeleC::h_prob_parm_device->rhol
+    << "," << PeleC::h_prob_parm_device->pl << ","
+    << PeleC::h_prob_parm_device->Tl << "," << PeleC::h_prob_parm_device->rhor
+    << "," << PeleC::h_prob_parm_device->pr << ","
+    << PeleC::h_prob_parm_device->Tr << "," << eos.gamma << ","
+    << PeleC::h_prob_parm_device->angle << std::endl;
   ofs.close();
 }
 }

--- a/Exec/RegTests/EB-C7/prob_parm.H
+++ b/Exec/RegTests/EB-C7/prob_parm.H
@@ -22,6 +22,7 @@ struct ProbParmDevice
 
 struct ProbParmHost
 {
+  ProbParmHost() {}
 };
 
 #endif

--- a/Exec/RegTests/EB-C7/prob_parm.H
+++ b/Exec/RegTests/EB-C7/prob_parm.H
@@ -5,7 +5,7 @@
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_GpuMemory.H>
 
-struct ProbParmDevice : amrex::Gpu::Managed
+struct ProbParmDevice
 {
   amrex::Real pl = 1.0;
   amrex::Real rhol = 1.0;
@@ -20,7 +20,7 @@ struct ProbParmDevice : amrex::Gpu::Managed
   amrex::GpuArray<amrex::Real, NUM_SPECIES> massfrac = {1.0};
 };
 
-struct ProbParmHost : amrex::Gpu::Managed
+struct ProbParmHost
 {
 };
 

--- a/Exec/RegTests/EB-C8/prob.cpp
+++ b/Exec/RegTests/EB-C8/prob.cpp
@@ -16,45 +16,45 @@ amrex_probinit(
 {
   // Parse params
   amrex::ParmParse pp("prob");
-  pp.query("p_l", PeleC::prob_parm_device->p_l);
-  pp.query("rho_l", PeleC::prob_parm_device->rho_l);
-  pp.query("p_r", PeleC::prob_parm_device->p_r);
-  pp.query("rho_r", PeleC::prob_parm_device->rho_r);
-  pp.query("angle", PeleC::prob_parm_device->angle);
+  pp.query("p_l", PeleC::h_prob_parm_device->p_l);
+  pp.query("rho_l", PeleC::h_prob_parm_device->rho_l);
+  pp.query("p_r", PeleC::h_prob_parm_device->p_r);
+  pp.query("rho_r", PeleC::h_prob_parm_device->rho_r);
+  pp.query("angle", PeleC::h_prob_parm_device->angle);
   pp.get("left_gas", PeleC::prob_parm_host->gasL);
   pp.get("right_gas", PeleC::prob_parm_host->gasR);
 
-  PeleC::prob_parm_device->L =
+  PeleC::h_prob_parm_device->L =
     (probhi[0] - problo[0]) /
-    cos(M_PI / 180.0 * PeleC::prob_parm_device->angle);
+    cos(M_PI / 180.0 * PeleC::h_prob_parm_device->angle);
 
   if (PeleC::prob_parm_host->gasL == "N2") {
-    PeleC::prob_parm_device->left_gas_id = N2_ID;
-    PeleC::prob_parm_device->right_gas_id = HE_ID;
+    PeleC::h_prob_parm_device->left_gas_id = N2_ID;
+    PeleC::h_prob_parm_device->right_gas_id = HE_ID;
   } else {
-    PeleC::prob_parm_device->left_gas_id = HE_ID;
-    PeleC::prob_parm_device->right_gas_id = N2_ID;
+    PeleC::h_prob_parm_device->left_gas_id = HE_ID;
+    PeleC::h_prob_parm_device->right_gas_id = N2_ID;
   }
 
   amrex::Real e_l;
   amrex::Real e_r /*, cs, cp */;
   amrex::Real massfrac_l[NUM_SPECIES] = {0.0};
   amrex::Real massfrac_r[NUM_SPECIES] = {0.0};
-  massfrac_l[PeleC::prob_parm_device->left_gas_id] = 1.0;
-  massfrac_r[PeleC::prob_parm_device->right_gas_id] = 1.0;
+  massfrac_l[PeleC::h_prob_parm_device->left_gas_id] = 1.0;
+  massfrac_r[PeleC::h_prob_parm_device->right_gas_id] = 1.0;
 
   auto eos = pele::physics::PhysicsType::eos();
   eos.RYP2E(
-    PeleC::prob_parm_device->rho_l, massfrac_l, PeleC::prob_parm_device->p_l,
-    e_l);
-  eos.EY2T(e_l, massfrac_l, PeleC::prob_parm_device->T_l);
-  PeleC::prob_parm_device->rhoe_l = PeleC::prob_parm_device->rho_l * e_l;
+    PeleC::h_prob_parm_device->rho_l, massfrac_l,
+    PeleC::h_prob_parm_device->p_l, e_l);
+  eos.EY2T(e_l, massfrac_l, PeleC::h_prob_parm_device->T_l);
+  PeleC::h_prob_parm_device->rhoe_l = PeleC::h_prob_parm_device->rho_l * e_l;
 
   eos.RYP2E(
-    PeleC::prob_parm_device->rho_r, massfrac_r, PeleC::prob_parm_device->p_r,
-    e_r);
-  eos.EY2T(e_r, massfrac_r, PeleC::prob_parm_device->T_r);
-  PeleC::prob_parm_device->rhoe_r = PeleC::prob_parm_device->rho_r * e_r;
+    PeleC::h_prob_parm_device->rho_r, massfrac_r,
+    PeleC::h_prob_parm_device->p_r, e_r);
+  eos.EY2T(e_r, massfrac_r, PeleC::h_prob_parm_device->T_r);
+  PeleC::h_prob_parm_device->rhoe_r = PeleC::h_prob_parm_device->rho_r * e_r;
 }
 }
 

--- a/Exec/RegTests/EB-C8/prob_parm.H
+++ b/Exec/RegTests/EB-C8/prob_parm.H
@@ -25,6 +25,7 @@ struct ProbParmHost
 {
   std::string gasL = "N2";
   std::string gasR = "HE";
+  ProbParmHost() {}
 };
 
 #endif

--- a/Exec/RegTests/EB-C8/prob_parm.H
+++ b/Exec/RegTests/EB-C8/prob_parm.H
@@ -5,7 +5,7 @@
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_GpuMemory.H>
 
-struct ProbParmDevice : amrex::Gpu::Managed
+struct ProbParmDevice
 {
   amrex::Real p_l = 1.0;   // left pressure (erg/cc)
   amrex::Real rho_l = 1.0; // left density (g/cc)
@@ -21,7 +21,7 @@ struct ProbParmDevice : amrex::Gpu::Managed
   int right_gas_id = HE_ID;
 };
 
-struct ProbParmHost : amrex::Gpu::Managed
+struct ProbParmHost
 {
   std::string gasL = "N2";
   std::string gasR = "HE";

--- a/Exec/RegTests/EB-C9/prob.H
+++ b/Exec/RegTests/EB-C9/prob.H
@@ -115,7 +115,7 @@ struct MyProbDeriveStruct
     const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx =
       geomdata.CellSizeArray();
 
-    ProbParmDevice const* prob_parm = PeleC::prob_parm_device.get();
+    ProbParmDevice const* prob_parm = PeleC::d_prob_parm_device;
 
     amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
       const amrex::Real x = prob_lo[0] + (i + 0.5) * dx[0];

--- a/Exec/RegTests/EB-C9/prob.cpp
+++ b/Exec/RegTests/EB-C9/prob.cpp
@@ -16,36 +16,37 @@ amrex_probinit(
 {
   // Parse params
   amrex::ParmParse pp("prob");
-  pp.query("rho", PeleC::prob_parm_device->rho);
-  pp.query("p", PeleC::prob_parm_device->p);
-  pp.query("alpha", PeleC::prob_parm_device->alpha);
-  pp.query("sigma", PeleC::prob_parm_device->sigma);
+  pp.query("rho", PeleC::h_prob_parm_device->rho);
+  pp.query("p", PeleC::h_prob_parm_device->p);
+  pp.query("alpha", PeleC::h_prob_parm_device->alpha);
+  pp.query("sigma", PeleC::h_prob_parm_device->sigma);
 
   amrex::ParmParse ppeb("eb2");
-  ppeb.query("cylinder_radius", PeleC::prob_parm_device->radius);
+  ppeb.query("cylinder_radius", PeleC::h_prob_parm_device->radius);
 
-  PeleC::prob_parm_device->L = (probhi[0] - problo[0]);
+  PeleC::h_prob_parm_device->L = (probhi[0] - problo[0]);
 
-  PeleC::prob_parm_device->massfrac[0] = 1.0;
+  PeleC::h_prob_parm_device->massfrac[0] = 1.0;
 
   auto eos = pele::physics::PhysicsType::eos();
   eos.RYP2T(
-    PeleC::prob_parm_device->rho, PeleC::prob_parm_device->massfrac.begin(),
-    PeleC::prob_parm_device->p, PeleC::prob_parm_device->T);
+    PeleC::h_prob_parm_device->rho, PeleC::h_prob_parm_device->massfrac.begin(),
+    PeleC::h_prob_parm_device->p, PeleC::h_prob_parm_device->T);
   eos.RPY2Cs(
-    PeleC::prob_parm_device->rho, PeleC::prob_parm_device->p,
-    PeleC::prob_parm_device->massfrac.begin(), PeleC::prob_parm_device->cs);
+    PeleC::h_prob_parm_device->rho, PeleC::h_prob_parm_device->p,
+    PeleC::h_prob_parm_device->massfrac.begin(), PeleC::h_prob_parm_device->cs);
 
   // Output IC
   std::ofstream ofs("ic.txt", std::ofstream::out);
   amrex::Print(ofs) << "L, rho, p, T, gamma, cs, radius, alpha, sigma"
                     << std::endl;
   amrex::Print(ofs).SetPrecision(17)
-    << PeleC::prob_parm_device->L << "," << PeleC::prob_parm_device->rho << ","
-    << PeleC::prob_parm_device->p << "," << PeleC::prob_parm_device->T << ","
-    << eos.gamma << "," << PeleC::prob_parm_device->cs << ","
-    << PeleC::prob_parm_device->radius << "," << PeleC::prob_parm_device->alpha
-    << "," << PeleC::prob_parm_device->sigma << std::endl;
+    << PeleC::h_prob_parm_device->L << "," << PeleC::h_prob_parm_device->rho
+    << "," << PeleC::h_prob_parm_device->p << ","
+    << PeleC::h_prob_parm_device->T << "," << eos.gamma << ","
+    << PeleC::h_prob_parm_device->cs << "," << PeleC::h_prob_parm_device->radius
+    << "," << PeleC::h_prob_parm_device->alpha << ","
+    << PeleC::h_prob_parm_device->sigma << std::endl;
   ofs.close();
 }
 }

--- a/Exec/RegTests/EB-C9/prob_parm.H
+++ b/Exec/RegTests/EB-C9/prob_parm.H
@@ -5,7 +5,7 @@
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_GpuMemory.H>
 
-struct ProbParmDevice : amrex::Gpu::Managed
+struct ProbParmDevice
 {
   amrex::Real alpha = 1e-6;
   amrex::Real sigma = 10.0;
@@ -18,7 +18,7 @@ struct ProbParmDevice : amrex::Gpu::Managed
   amrex::GpuArray<amrex::Real, NUM_SPECIES> massfrac = {1.0};
 };
 
-struct ProbParmHost : amrex::Gpu::Managed
+struct ProbParmHost
 {
 };
 

--- a/Exec/RegTests/EB-C9/prob_parm.H
+++ b/Exec/RegTests/EB-C9/prob_parm.H
@@ -20,6 +20,7 @@ struct ProbParmDevice
 
 struct ProbParmHost
 {
+  ProbParmHost() {}
 };
 
 #endif

--- a/Exec/RegTests/EB-Plane/prob.cpp
+++ b/Exec/RegTests/EB-Plane/prob.cpp
@@ -17,27 +17,28 @@ amrex_probinit(
   // Parse params
   {
     amrex::ParmParse pp("prob");
-    pp.query("p", PeleC::prob_parm_device->p);
-    pp.query("rho", PeleC::prob_parm_device->rho);
-    pp.query("vx_in", PeleC::prob_parm_device->vx_in);
-    pp.query("vy_in", PeleC::prob_parm_device->vy_in);
-    pp.query("Re_L", PeleC::prob_parm_device->Re_L);
-    pp.query("Pr", PeleC::prob_parm_device->Pr);
+    pp.query("p", PeleC::h_prob_parm_device->p);
+    pp.query("rho", PeleC::h_prob_parm_device->rho);
+    pp.query("vx_in", PeleC::h_prob_parm_device->vx_in);
+    pp.query("vy_in", PeleC::h_prob_parm_device->vy_in);
+    pp.query("Re_L", PeleC::h_prob_parm_device->Re_L);
+    pp.query("Pr", PeleC::h_prob_parm_device->Pr);
   }
 
   amrex::Real L = (probhi[0] - problo[0]) * 0.2;
 
   amrex::Real cp = 0.0;
-  PeleC::prob_parm_device->massfrac[0] = 1.0;
+  PeleC::h_prob_parm_device->massfrac[0] = 1.0;
   auto eos = pele::physics::PhysicsType::eos();
   eos.RYP2E(
-    PeleC::prob_parm_device->rho, PeleC::prob_parm_device->massfrac.begin(),
-    PeleC::prob_parm_device->p, PeleC::prob_parm_device->eint);
+    PeleC::h_prob_parm_device->rho, PeleC::h_prob_parm_device->massfrac.begin(),
+    PeleC::h_prob_parm_device->p, PeleC::h_prob_parm_device->eint);
   eos.EY2T(
-    PeleC::prob_parm_device->eint, PeleC::prob_parm_device->massfrac.begin(),
-    PeleC::prob_parm_device->T);
+    PeleC::h_prob_parm_device->eint,
+    PeleC::h_prob_parm_device->massfrac.begin(), PeleC::h_prob_parm_device->T);
   eos.TY2Cp(
-    PeleC::prob_parm_device->T, PeleC::prob_parm_device->massfrac.begin(), cp);
+    PeleC::h_prob_parm_device->T, PeleC::h_prob_parm_device->massfrac.begin(),
+    cp);
 
   pele::physics::transport::TransParm trans_parm;
 
@@ -58,11 +59,11 @@ amrex_probinit(
 
   trans_parm.const_bulk_viscosity = 0.0;
   trans_parm.const_diffusivity = 0.0;
-  trans_parm.const_viscosity = PeleC::prob_parm_device->rho *
-                               PeleC::prob_parm_device->vx_in * L /
-                               PeleC::prob_parm_device->Re_L;
+  trans_parm.const_viscosity = PeleC::h_prob_parm_device->rho *
+                               PeleC::h_prob_parm_device->vx_in * L /
+                               PeleC::h_prob_parm_device->Re_L;
   trans_parm.const_conductivity =
-    trans_parm.const_viscosity * cp / PeleC::prob_parm_device->Pr;
+    trans_parm.const_viscosity * cp / PeleC::h_prob_parm_device->Pr;
 
 #ifdef AMREX_USE_GPU
   amrex::Gpu::htod_memcpy(

--- a/Exec/RegTests/EB-Plane/prob_parm.H
+++ b/Exec/RegTests/EB-Plane/prob_parm.H
@@ -20,6 +20,7 @@ struct ProbParmDevice
 
 struct ProbParmHost
 {
+  ProbParmHost() {}
 };
 
 #endif

--- a/Exec/RegTests/EB-Plane/prob_parm.H
+++ b/Exec/RegTests/EB-Plane/prob_parm.H
@@ -5,7 +5,7 @@
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_GpuMemory.H>
 
-struct ProbParmDevice : amrex::Gpu::Managed
+struct ProbParmDevice
 {
   amrex::Real p = 1013250.0;
   amrex::Real T = 0.0;
@@ -18,7 +18,7 @@ struct ProbParmDevice : amrex::Gpu::Managed
   amrex::GpuArray<amrex::Real, NUM_SPECIES> massfrac = {1.0};
 };
 
-struct ProbParmHost : amrex::Gpu::Managed
+struct ProbParmHost
 {
 };
 

--- a/Exec/RegTests/HIT/prob.cpp
+++ b/Exec/RegTests/HIT/prob.cpp
@@ -18,31 +18,31 @@ amrex_probinit(
   {
     amrex::ParmParse pp("prob");
     pp.query("iname", PeleC::prob_parm_host->iname);
-    pp.query("binfmt", PeleC::prob_parm_device->binfmt);
-    pp.query("restart", PeleC::prob_parm_device->restart);
-    pp.query("lambda0", PeleC::prob_parm_device->lambda0);
-    pp.query("reynolds_lambda0", PeleC::prob_parm_device->reynolds_lambda0);
-    pp.query("mach_t0", PeleC::prob_parm_device->mach_t0);
-    pp.query("prandtl", PeleC::prob_parm_device->prandtl);
-    pp.query("inres", PeleC::prob_parm_device->inres);
-    pp.query("uin_norm", PeleC::prob_parm_device->uin_norm);
+    pp.query("binfmt", PeleC::h_prob_parm_device->binfmt);
+    pp.query("restart", PeleC::h_prob_parm_device->restart);
+    pp.query("lambda0", PeleC::h_prob_parm_device->lambda0);
+    pp.query("reynolds_lambda0", PeleC::h_prob_parm_device->reynolds_lambda0);
+    pp.query("mach_t0", PeleC::h_prob_parm_device->mach_t0);
+    pp.query("prandtl", PeleC::h_prob_parm_device->prandtl);
+    pp.query("inres", PeleC::h_prob_parm_device->inres);
+    pp.query("uin_norm", PeleC::h_prob_parm_device->uin_norm);
   }
 
   {
     amrex::ParmParse pp("forcing");
-    pp.query("u0", PeleC::prob_parm_device->forcing_u0);
-    pp.query("v0", PeleC::prob_parm_device->forcing_v0);
-    pp.query("w0", PeleC::prob_parm_device->forcing_w0);
-    pp.query("forcing", PeleC::prob_parm_device->forcing_force);
+    pp.query("u0", PeleC::h_prob_parm_device->forcing_u0);
+    pp.query("v0", PeleC::h_prob_parm_device->forcing_v0);
+    pp.query("w0", PeleC::h_prob_parm_device->forcing_w0);
+    pp.query("forcing", PeleC::h_prob_parm_device->forcing_force);
   }
 
   // Define the length scale
-  PeleC::prob_parm_device->L_x = probhi[0] - problo[0];
-  PeleC::prob_parm_device->L_y = probhi[1] - problo[1];
-  PeleC::prob_parm_device->L_z = probhi[2] - problo[2];
+  PeleC::h_prob_parm_device->L_x = probhi[0] - problo[0];
+  PeleC::h_prob_parm_device->L_y = probhi[1] - problo[1];
+  PeleC::h_prob_parm_device->L_z = probhi[2] - problo[2];
 
   // Wavelength associated to Taylor length scale
-  PeleC::prob_parm_device->k0 = 2.0 / PeleC::prob_parm_device->lambda0;
+  PeleC::h_prob_parm_device->k0 = 2.0 / PeleC::h_prob_parm_device->lambda0;
 
   // Initial density, velocity, and material properties
   amrex::Real cs;
@@ -50,16 +50,17 @@ amrex_probinit(
   amrex::Real massfrac[NUM_SPECIES] = {1.0};
   auto eos = pele::physics::PhysicsType::eos();
   eos.PYT2RE(
-    PeleC::prob_parm_device->p0, massfrac, PeleC::prob_parm_device->T0,
-    PeleC::prob_parm_device->rho0, PeleC::prob_parm_device->eint0);
+    PeleC::h_prob_parm_device->p0, massfrac, PeleC::h_prob_parm_device->T0,
+    PeleC::h_prob_parm_device->rho0, PeleC::h_prob_parm_device->eint0);
   eos.RTY2Cs(
-    PeleC::prob_parm_device->rho0, PeleC::prob_parm_device->T0, massfrac, cs);
-  eos.TY2Cp(PeleC::prob_parm_device->T0, massfrac, cp);
+    PeleC::h_prob_parm_device->rho0, PeleC::h_prob_parm_device->T0, massfrac,
+    cs);
+  eos.TY2Cp(PeleC::h_prob_parm_device->T0, massfrac, cp);
 
-  PeleC::prob_parm_device->urms0 =
-    PeleC::prob_parm_device->mach_t0 * cs / sqrt(3.0);
-  PeleC::prob_parm_device->tau =
-    PeleC::prob_parm_device->lambda0 / PeleC::prob_parm_device->urms0;
+  PeleC::h_prob_parm_device->urms0 =
+    PeleC::h_prob_parm_device->mach_t0 * cs / sqrt(3.0);
+  PeleC::h_prob_parm_device->tau =
+    PeleC::h_prob_parm_device->lambda0 / PeleC::h_prob_parm_device->urms0;
 
   pele::physics::transport::TransParm trans_parm;
 
@@ -80,12 +81,12 @@ amrex_probinit(
 
   trans_parm.const_bulk_viscosity = 0.0;
   trans_parm.const_diffusivity = 0.0;
-  trans_parm.const_viscosity = PeleC::prob_parm_device->rho0 *
-                               PeleC::prob_parm_device->urms0 *
-                               PeleC::prob_parm_device->lambda0 /
-                               PeleC::prob_parm_device->reynolds_lambda0;
+  trans_parm.const_viscosity = PeleC::h_prob_parm_device->rho0 *
+                               PeleC::h_prob_parm_device->urms0 *
+                               PeleC::h_prob_parm_device->lambda0 /
+                               PeleC::h_prob_parm_device->reynolds_lambda0;
   trans_parm.const_conductivity =
-    trans_parm.const_viscosity * cp / PeleC::prob_parm_device->prandtl;
+    trans_parm.const_viscosity * cp / PeleC::h_prob_parm_device->prandtl;
 
 #ifdef AMREX_USE_GPU
   amrex::Gpu::htod_memcpy(
@@ -102,19 +103,19 @@ amrex_probinit(
        "Mach, Prandtl, u0, v0, w0, forcing"
     << std::endl;
   amrex::Print(ofs).SetPrecision(17)
-    << PeleC::prob_parm_device->lambda0 << "," << PeleC::prob_parm_device->k0
-    << "," << PeleC::prob_parm_device->rho0 << ","
-    << PeleC::prob_parm_device->urms0 << "," << PeleC::prob_parm_device->tau
-    << "," << PeleC::prob_parm_device->p0 << "," << PeleC::prob_parm_device->T0
-    << "," << eos.gamma << "," << trans_parm.const_viscosity << ","
-    << trans_parm.const_conductivity << "," << cs << ","
-    << PeleC::prob_parm_device->reynolds_lambda0 << ","
-    << PeleC::prob_parm_device->mach_t0 << ","
-    << PeleC::prob_parm_device->prandtl << ","
-    << PeleC::prob_parm_device->forcing_u0 << ","
-    << PeleC::prob_parm_device->forcing_v0 << ","
-    << PeleC::prob_parm_device->forcing_w0 << ","
-    << PeleC::prob_parm_device->forcing_force << std::endl;
+    << PeleC::h_prob_parm_device->lambda0 << ","
+    << PeleC::h_prob_parm_device->k0 << "," << PeleC::h_prob_parm_device->rho0
+    << "," << PeleC::h_prob_parm_device->urms0 << ","
+    << PeleC::h_prob_parm_device->tau << "," << PeleC::h_prob_parm_device->p0
+    << "," << PeleC::h_prob_parm_device->T0 << "," << eos.gamma << ","
+    << trans_parm.const_viscosity << "," << trans_parm.const_conductivity << ","
+    << cs << "," << PeleC::h_prob_parm_device->reynolds_lambda0 << ","
+    << PeleC::h_prob_parm_device->mach_t0 << ","
+    << PeleC::h_prob_parm_device->prandtl << ","
+    << PeleC::h_prob_parm_device->forcing_u0 << ","
+    << PeleC::h_prob_parm_device->forcing_v0 << ","
+    << PeleC::h_prob_parm_device->forcing_w0 << ","
+    << PeleC::h_prob_parm_device->forcing_force << std::endl;
   ofs.close();
 
   // Load velocity fields from file. Assume data set ordered in Fortran
@@ -124,19 +125,19 @@ amrex_probinit(
   // the input data is a periodic cube. If the input cube is smaller
   // than our domain size, the cube will be repeated throughout the
   // domain (hence the mod operations in the interpolation).
-  if (PeleC::prob_parm_device->restart) {
+  if (PeleC::h_prob_parm_device->restart) {
     amrex::Print() << "Skipping input file reading and assuming restart."
                    << std::endl;
   } else {
 #ifdef AMREX_USE_FLOAT
     amrex::Abort("HIT cannot run in single precision at the moment.");
 #else
-    const size_t nx = PeleC::prob_parm_device->inres;
-    const size_t ny = PeleC::prob_parm_device->inres;
-    const size_t nz = PeleC::prob_parm_device->inres;
+    const size_t nx = PeleC::h_prob_parm_device->inres;
+    const size_t ny = PeleC::h_prob_parm_device->inres;
+    const size_t nz = PeleC::h_prob_parm_device->inres;
     amrex::Vector<amrex::Real> data(
       nx * ny * nz * 6); /* this needs to be double */
-    if (PeleC::prob_parm_device->binfmt) {
+    if (PeleC::h_prob_parm_device->binfmt) {
       read_binary(PeleC::prob_parm_host->iname, nx, ny, nz, 6, data);
     } else {
       read_csv(PeleC::prob_parm_host->iname, nx, ny, nz, data);
@@ -150,14 +151,14 @@ amrex_probinit(
     for (long i = 0; i < PeleC::prob_parm_host->h_xinput.size(); i++) {
       PeleC::prob_parm_host->h_xinput[i] = data[0 + i * 6];
       PeleC::prob_parm_host->h_uinput[i] = data[3 + i * 6] *
-                                           PeleC::prob_parm_device->urms0 /
-                                           PeleC::prob_parm_device->uin_norm;
+                                           PeleC::h_prob_parm_device->urms0 /
+                                           PeleC::h_prob_parm_device->uin_norm;
       PeleC::prob_parm_host->h_vinput[i] = data[4 + i * 6] *
-                                           PeleC::prob_parm_device->urms0 /
-                                           PeleC::prob_parm_device->uin_norm;
+                                           PeleC::h_prob_parm_device->urms0 /
+                                           PeleC::h_prob_parm_device->uin_norm;
       PeleC::prob_parm_host->h_winput[i] = data[5 + i * 6] *
-                                           PeleC::prob_parm_device->urms0 /
-                                           PeleC::prob_parm_device->uin_norm;
+                                           PeleC::h_prob_parm_device->urms0 /
+                                           PeleC::h_prob_parm_device->uin_norm;
     }
 
     // Get the xarray table and the differences.
@@ -216,19 +217,28 @@ amrex_probinit(
       PeleC::prob_parm_host->h_xdiff.end(),
       PeleC::prob_parm_host->xdiff.begin());
 
-    PeleC::prob_parm_device->d_xinput = PeleC::prob_parm_host->xinput.data();
-    PeleC::prob_parm_device->d_uinput = PeleC::prob_parm_host->uinput.data();
-    PeleC::prob_parm_device->d_vinput = PeleC::prob_parm_host->vinput.data();
-    PeleC::prob_parm_device->d_winput = PeleC::prob_parm_host->winput.data();
-    PeleC::prob_parm_device->d_xarray = PeleC::prob_parm_host->xarray.data();
-    PeleC::prob_parm_device->d_xdiff = PeleC::prob_parm_host->xdiff.data();
+    PeleC::h_prob_parm_device->d_xinput = PeleC::prob_parm_host->xinput.data();
+    PeleC::h_prob_parm_device->d_uinput = PeleC::prob_parm_host->uinput.data();
+    PeleC::h_prob_parm_device->d_vinput = PeleC::prob_parm_host->vinput.data();
+    PeleC::h_prob_parm_device->d_winput = PeleC::prob_parm_host->winput.data();
+    PeleC::h_prob_parm_device->d_xarray = PeleC::prob_parm_host->xarray.data();
+    PeleC::h_prob_parm_device->d_xdiff = PeleC::prob_parm_host->xdiff.data();
 
     // Dimensions of the input box.
-    PeleC::prob_parm_device->Linput =
+    PeleC::h_prob_parm_device->Linput =
       PeleC::prob_parm_host->h_xarray[nx - 1] +
       0.5 * PeleC::prob_parm_host->h_xdiff[nx - 1];
 #endif
   }
+#ifdef AMREX_USE_GPU
+  amrex::Gpu::htod_memcpy(
+    PeleC::d_prob_parm_device, PeleC::h_prob_parm_device,
+    sizeof(ProbParmDevice));
+#else
+  std::memcpy(
+    PeleC::d_prob_parm_device, PeleC::h_prob_parm_device,
+    sizeof(ProbParmDevice));
+#endif
 }
 }
 

--- a/Exec/RegTests/HIT/prob.cpp
+++ b/Exec/RegTests/HIT/prob.cpp
@@ -230,15 +230,6 @@ amrex_probinit(
       0.5 * PeleC::prob_parm_host->h_xdiff[nx - 1];
 #endif
   }
-#ifdef AMREX_USE_GPU
-  amrex::Gpu::htod_memcpy(
-    PeleC::d_prob_parm_device, PeleC::h_prob_parm_device,
-    sizeof(ProbParmDevice));
-#else
-  std::memcpy(
-    PeleC::d_prob_parm_device, PeleC::h_prob_parm_device,
-    sizeof(ProbParmDevice));
-#endif
 }
 }
 

--- a/Exec/RegTests/HIT/prob_parm.H
+++ b/Exec/RegTests/HIT/prob_parm.H
@@ -5,7 +5,7 @@
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_GpuMemory.H>
 
-struct ProbParmDevice : amrex::Gpu::Managed
+struct ProbParmDevice
 {
   bool binfmt = false;
   bool restart = false;

--- a/Exec/RegTests/HIT/prob_parm.H
+++ b/Exec/RegTests/HIT/prob_parm.H
@@ -38,7 +38,7 @@ struct ProbParmDevice
   amrex::Real forcing_force = 0.0;
 };
 
-struct ProbParmHost : amrex::Gpu::Managed
+struct ProbParmHost
 {
   std::string iname;
   amrex::Vector<amrex::Real> h_xinput;

--- a/Exec/RegTests/HIT/prob_parm.H
+++ b/Exec/RegTests/HIT/prob_parm.H
@@ -53,6 +53,10 @@ struct ProbParmHost
   amrex::Gpu::DeviceVector<amrex::Real> winput;
   amrex::Gpu::DeviceVector<amrex::Real> xarray;
   amrex::Gpu::DeviceVector<amrex::Real> xdiff;
+  ProbParmHost()
+    : xinput(0), uinput(0), vinput(0), winput(0), xarray(0), xdiff()
+  {
+  }
 };
 
 #endif

--- a/Exec/RegTests/MMS/prob.cpp
+++ b/Exec/RegTests/MMS/prob.cpp
@@ -17,48 +17,48 @@ amrex_probinit(
   // Parse params
   {
     amrex::ParmParse pp("prob");
-    pp.query("reynolds", PeleC::prob_parm_device->reynolds);
-    pp.query("mach", PeleC::prob_parm_device->mach);
-    pp.query("prandtl", PeleC::prob_parm_device->prandtl);
-    pp.query("rho_x_fact", PeleC::prob_parm_device->rho_x_fact);
-    pp.query("rho_y_fact", PeleC::prob_parm_device->rho_y_fact);
-    pp.query("rho_z_fact", PeleC::prob_parm_device->rho_z_fact);
-    pp.query("u_0_fact", PeleC::prob_parm_device->u_0_fact);
-    pp.query("u_x_fact", PeleC::prob_parm_device->u_x_fact);
-    pp.query("u_y_fact", PeleC::prob_parm_device->u_y_fact);
-    pp.query("u_z_fact", PeleC::prob_parm_device->u_z_fact);
-    pp.query("v_0_fact", PeleC::prob_parm_device->v_0_fact);
-    pp.query("v_x_fact", PeleC::prob_parm_device->v_x_fact);
-    pp.query("v_y_fact", PeleC::prob_parm_device->v_y_fact);
-    pp.query("v_z_fact", PeleC::prob_parm_device->v_z_fact);
-    pp.query("w_0_fact", PeleC::prob_parm_device->w_0_fact);
-    pp.query("w_x_fact", PeleC::prob_parm_device->w_x_fact);
-    pp.query("w_y_fact", PeleC::prob_parm_device->w_y_fact);
-    pp.query("w_z_fact", PeleC::prob_parm_device->w_z_fact);
-    pp.query("p_x_fact", PeleC::prob_parm_device->p_x_fact);
-    pp.query("p_y_fact", PeleC::prob_parm_device->p_y_fact);
-    pp.query("p_z_fact", PeleC::prob_parm_device->p_z_fact);
-    pp.query("a_rhox", PeleC::prob_parm_device->a_rhox);
-    pp.query("a_rhoy", PeleC::prob_parm_device->a_rhoy);
-    pp.query("a_rhoz", PeleC::prob_parm_device->a_rhoz);
-    pp.query("a_ux", PeleC::prob_parm_device->a_ux);
-    pp.query("a_uy", PeleC::prob_parm_device->a_uy);
-    pp.query("a_uz", PeleC::prob_parm_device->a_uz);
-    pp.query("a_vx", PeleC::prob_parm_device->a_vx);
-    pp.query("a_vy", PeleC::prob_parm_device->a_vy);
-    pp.query("a_vz", PeleC::prob_parm_device->a_vz);
-    pp.query("a_wx", PeleC::prob_parm_device->a_wx);
-    pp.query("a_wy", PeleC::prob_parm_device->a_wy);
-    pp.query("a_wz", PeleC::prob_parm_device->a_wz);
-    pp.query("a_px", PeleC::prob_parm_device->a_px);
-    pp.query("a_py", PeleC::prob_parm_device->a_py);
-    pp.query("a_pz", PeleC::prob_parm_device->a_pz);
+    pp.query("reynolds", PeleC::h_prob_parm_device->reynolds);
+    pp.query("mach", PeleC::h_prob_parm_device->mach);
+    pp.query("prandtl", PeleC::h_prob_parm_device->prandtl);
+    pp.query("rho_x_fact", PeleC::h_prob_parm_device->rho_x_fact);
+    pp.query("rho_y_fact", PeleC::h_prob_parm_device->rho_y_fact);
+    pp.query("rho_z_fact", PeleC::h_prob_parm_device->rho_z_fact);
+    pp.query("u_0_fact", PeleC::h_prob_parm_device->u_0_fact);
+    pp.query("u_x_fact", PeleC::h_prob_parm_device->u_x_fact);
+    pp.query("u_y_fact", PeleC::h_prob_parm_device->u_y_fact);
+    pp.query("u_z_fact", PeleC::h_prob_parm_device->u_z_fact);
+    pp.query("v_0_fact", PeleC::h_prob_parm_device->v_0_fact);
+    pp.query("v_x_fact", PeleC::h_prob_parm_device->v_x_fact);
+    pp.query("v_y_fact", PeleC::h_prob_parm_device->v_y_fact);
+    pp.query("v_z_fact", PeleC::h_prob_parm_device->v_z_fact);
+    pp.query("w_0_fact", PeleC::h_prob_parm_device->w_0_fact);
+    pp.query("w_x_fact", PeleC::h_prob_parm_device->w_x_fact);
+    pp.query("w_y_fact", PeleC::h_prob_parm_device->w_y_fact);
+    pp.query("w_z_fact", PeleC::h_prob_parm_device->w_z_fact);
+    pp.query("p_x_fact", PeleC::h_prob_parm_device->p_x_fact);
+    pp.query("p_y_fact", PeleC::h_prob_parm_device->p_y_fact);
+    pp.query("p_z_fact", PeleC::h_prob_parm_device->p_z_fact);
+    pp.query("a_rhox", PeleC::h_prob_parm_device->a_rhox);
+    pp.query("a_rhoy", PeleC::h_prob_parm_device->a_rhoy);
+    pp.query("a_rhoz", PeleC::h_prob_parm_device->a_rhoz);
+    pp.query("a_ux", PeleC::h_prob_parm_device->a_ux);
+    pp.query("a_uy", PeleC::h_prob_parm_device->a_uy);
+    pp.query("a_uz", PeleC::h_prob_parm_device->a_uz);
+    pp.query("a_vx", PeleC::h_prob_parm_device->a_vx);
+    pp.query("a_vy", PeleC::h_prob_parm_device->a_vy);
+    pp.query("a_vz", PeleC::h_prob_parm_device->a_vz);
+    pp.query("a_wx", PeleC::h_prob_parm_device->a_wx);
+    pp.query("a_wy", PeleC::h_prob_parm_device->a_wy);
+    pp.query("a_wz", PeleC::h_prob_parm_device->a_wz);
+    pp.query("a_px", PeleC::h_prob_parm_device->a_px);
+    pp.query("a_py", PeleC::h_prob_parm_device->a_py);
+    pp.query("a_pz", PeleC::h_prob_parm_device->a_pz);
   }
 
   // Define the length scale
-  AMREX_D_TERM(PeleC::prob_parm_device->L_x = probhi[0] - problo[0];
-               , PeleC::prob_parm_device->L_y = probhi[1] - problo[1];
-               , PeleC::prob_parm_device->L_z = probhi[2] - problo[2];)
+  AMREX_D_TERM(PeleC::h_prob_parm_device->L_x = probhi[0] - problo[0];
+               , PeleC::h_prob_parm_device->L_y = probhi[1] - problo[1];
+               , PeleC::h_prob_parm_device->L_z = probhi[2] - problo[2];)
 
   // Initial density, velocity, and material properties
   amrex::Real eint;
@@ -67,13 +67,14 @@ amrex_probinit(
   amrex::Real massfrac[NUM_SPECIES] = {1.0};
   auto eos = pele::physics::PhysicsType::eos();
   eos.PYT2RE(
-    PeleC::prob_parm_device->p0, massfrac, PeleC::prob_parm_device->T0,
-    PeleC::prob_parm_device->rho0, eint);
+    PeleC::h_prob_parm_device->p0, massfrac, PeleC::h_prob_parm_device->T0,
+    PeleC::h_prob_parm_device->rho0, eint);
   eos.RTY2Cs(
-    PeleC::prob_parm_device->rho0, PeleC::prob_parm_device->T0, massfrac, cs);
-  eos.TY2Cp(PeleC::prob_parm_device->T0, massfrac, cp);
+    PeleC::h_prob_parm_device->rho0, PeleC::h_prob_parm_device->T0, massfrac,
+    cs);
+  eos.TY2Cp(PeleC::h_prob_parm_device->T0, massfrac, cp);
 
-  PeleC::prob_parm_device->u0 = PeleC::prob_parm_device->mach * cs;
+  PeleC::h_prob_parm_device->u0 = PeleC::h_prob_parm_device->mach * cs;
 
   pele::physics::transport::TransParm trans_parm;
 
@@ -93,14 +94,14 @@ amrex_probinit(
   }
 
   trans_parm.const_bulk_viscosity =
-    PeleC::prob_parm_device->rho0 * PeleC::prob_parm_device->u0 *
-    PeleC::prob_parm_device->L_x / PeleC::prob_parm_device->reynolds;
+    PeleC::h_prob_parm_device->rho0 * PeleC::h_prob_parm_device->u0 *
+    PeleC::h_prob_parm_device->L_x / PeleC::h_prob_parm_device->reynolds;
   trans_parm.const_diffusivity = 0.0;
   trans_parm.const_viscosity =
-    PeleC::prob_parm_device->rho0 * PeleC::prob_parm_device->u0 *
-    PeleC::prob_parm_device->L_x / PeleC::prob_parm_device->reynolds;
+    PeleC::h_prob_parm_device->rho0 * PeleC::h_prob_parm_device->u0 *
+    PeleC::h_prob_parm_device->L_x / PeleC::h_prob_parm_device->reynolds;
   trans_parm.const_conductivity =
-    trans_parm.const_viscosity * cp / PeleC::prob_parm_device->prandtl;
+    trans_parm.const_viscosity * cp / PeleC::h_prob_parm_device->prandtl;
 
 #ifdef AMREX_USE_GPU
   amrex::Gpu::htod_memcpy(
@@ -118,57 +119,57 @@ amrex_probinit(
   // w = w_0 + w_x * cos(a_wx * PI * x / L) * w_y * cos(a_wy * PI * y / L) * w_z * cos(a_wz * PI * z / L);
   // p = p_0 + p_x * cos(a_px * PI * x / L) * p_y * cos(a_py * PI * y / L) * p_z * cos(a_pz * PI * z / L);
   // clang-format on
-  masa_set_param("L", PeleC::prob_parm_device->L_x);
+  masa_set_param("L", PeleC::h_prob_parm_device->L_x);
   masa_set_param(
     "R", pele::physics::Constants::RU / pele::physics::Constants::AIRMW);
   masa_set_param("k", trans_parm.const_conductivity);
   masa_set_param("Gamma", eos.gamma);
   masa_set_param("mu", trans_parm.const_viscosity);
   masa_set_param("mu_bulk", trans_parm.const_bulk_viscosity);
-  masa_set_param("rho_0", PeleC::prob_parm_device->rho0);
+  masa_set_param("rho_0", PeleC::h_prob_parm_device->rho0);
   masa_set_param(
     "rho_x",
-    PeleC::prob_parm_device->rho_x_fact * PeleC::prob_parm_device->rho0);
-  masa_set_param("rho_y", PeleC::prob_parm_device->rho_y_fact);
-  masa_set_param("rho_z", PeleC::prob_parm_device->rho_z_fact);
+    PeleC::h_prob_parm_device->rho_x_fact * PeleC::h_prob_parm_device->rho0);
+  masa_set_param("rho_y", PeleC::h_prob_parm_device->rho_y_fact);
+  masa_set_param("rho_z", PeleC::h_prob_parm_device->rho_z_fact);
   masa_set_param(
-    "u_0", PeleC::prob_parm_device->u_0_fact * PeleC::prob_parm_device->u0);
+    "u_0", PeleC::h_prob_parm_device->u_0_fact * PeleC::h_prob_parm_device->u0);
   masa_set_param(
-    "u_x", PeleC::prob_parm_device->u_x_fact * PeleC::prob_parm_device->u0);
-  masa_set_param("u_y", PeleC::prob_parm_device->u_y_fact);
-  masa_set_param("u_z", PeleC::prob_parm_device->u_z_fact);
+    "u_x", PeleC::h_prob_parm_device->u_x_fact * PeleC::h_prob_parm_device->u0);
+  masa_set_param("u_y", PeleC::h_prob_parm_device->u_y_fact);
+  masa_set_param("u_z", PeleC::h_prob_parm_device->u_z_fact);
   masa_set_param(
-    "v_0", PeleC::prob_parm_device->v_0_fact * PeleC::prob_parm_device->u0);
-  masa_set_param("v_x", PeleC::prob_parm_device->v_x_fact);
+    "v_0", PeleC::h_prob_parm_device->v_0_fact * PeleC::h_prob_parm_device->u0);
+  masa_set_param("v_x", PeleC::h_prob_parm_device->v_x_fact);
   masa_set_param(
-    "v_y", PeleC::prob_parm_device->v_y_fact * PeleC::prob_parm_device->u0);
-  masa_set_param("v_z", PeleC::prob_parm_device->v_z_fact);
+    "v_y", PeleC::h_prob_parm_device->v_y_fact * PeleC::h_prob_parm_device->u0);
+  masa_set_param("v_z", PeleC::h_prob_parm_device->v_z_fact);
   masa_set_param(
-    "w_0", PeleC::prob_parm_device->w_0_fact * PeleC::prob_parm_device->u0);
-  masa_set_param("w_x", PeleC::prob_parm_device->w_x_fact);
-  masa_set_param("w_y", PeleC::prob_parm_device->w_y_fact);
+    "w_0", PeleC::h_prob_parm_device->w_0_fact * PeleC::h_prob_parm_device->u0);
+  masa_set_param("w_x", PeleC::h_prob_parm_device->w_x_fact);
+  masa_set_param("w_y", PeleC::h_prob_parm_device->w_y_fact);
   masa_set_param(
-    "w_z", PeleC::prob_parm_device->w_z_fact * PeleC::prob_parm_device->u0);
-  masa_set_param("p_0", PeleC::prob_parm_device->p0);
+    "w_z", PeleC::h_prob_parm_device->w_z_fact * PeleC::h_prob_parm_device->u0);
+  masa_set_param("p_0", PeleC::h_prob_parm_device->p0);
   masa_set_param(
-    "p_x", PeleC::prob_parm_device->p_x_fact * PeleC::prob_parm_device->p0);
-  masa_set_param("p_y", PeleC::prob_parm_device->p_y_fact);
-  masa_set_param("p_z", PeleC::prob_parm_device->p_z_fact);
-  masa_set_param("a_rhox", PeleC::prob_parm_device->a_rhox);
-  masa_set_param("a_rhoy", PeleC::prob_parm_device->a_rhoy);
-  masa_set_param("a_rhoz", PeleC::prob_parm_device->a_rhoz);
-  masa_set_param("a_ux", PeleC::prob_parm_device->a_ux);
-  masa_set_param("a_uy", PeleC::prob_parm_device->a_uy);
-  masa_set_param("a_uz", PeleC::prob_parm_device->a_uz);
-  masa_set_param("a_vx", PeleC::prob_parm_device->a_vx);
-  masa_set_param("a_vy", PeleC::prob_parm_device->a_vy);
-  masa_set_param("a_vz", PeleC::prob_parm_device->a_vz);
-  masa_set_param("a_wx", PeleC::prob_parm_device->a_wx);
-  masa_set_param("a_wy", PeleC::prob_parm_device->a_wy);
-  masa_set_param("a_wz", PeleC::prob_parm_device->a_wz);
-  masa_set_param("a_px", PeleC::prob_parm_device->a_px);
-  masa_set_param("a_py", PeleC::prob_parm_device->a_py);
-  masa_set_param("a_pz", PeleC::prob_parm_device->a_pz);
+    "p_x", PeleC::h_prob_parm_device->p_x_fact * PeleC::h_prob_parm_device->p0);
+  masa_set_param("p_y", PeleC::h_prob_parm_device->p_y_fact);
+  masa_set_param("p_z", PeleC::h_prob_parm_device->p_z_fact);
+  masa_set_param("a_rhox", PeleC::h_prob_parm_device->a_rhox);
+  masa_set_param("a_rhoy", PeleC::h_prob_parm_device->a_rhoy);
+  masa_set_param("a_rhoz", PeleC::h_prob_parm_device->a_rhoz);
+  masa_set_param("a_ux", PeleC::h_prob_parm_device->a_ux);
+  masa_set_param("a_uy", PeleC::h_prob_parm_device->a_uy);
+  masa_set_param("a_uz", PeleC::h_prob_parm_device->a_uz);
+  masa_set_param("a_vx", PeleC::h_prob_parm_device->a_vx);
+  masa_set_param("a_vy", PeleC::h_prob_parm_device->a_vy);
+  masa_set_param("a_vz", PeleC::h_prob_parm_device->a_vz);
+  masa_set_param("a_wx", PeleC::h_prob_parm_device->a_wx);
+  masa_set_param("a_wy", PeleC::h_prob_parm_device->a_wy);
+  masa_set_param("a_wz", PeleC::h_prob_parm_device->a_wz);
+  masa_set_param("a_px", PeleC::h_prob_parm_device->a_px);
+  masa_set_param("a_py", PeleC::h_prob_parm_device->a_py);
+  masa_set_param("a_pz", PeleC::h_prob_parm_device->a_pz);
 
   // Display and check
   if (amrex::ParallelDescriptor::IOProcessor()) {

--- a/Exec/RegTests/MMS/prob_parm.H
+++ b/Exec/RegTests/MMS/prob_parm.H
@@ -54,6 +54,7 @@ struct ProbParmDevice
 
 struct ProbParmHost
 {
+  ProbParmHost() {}
 };
 
 #endif

--- a/Exec/RegTests/MMS/prob_parm.H
+++ b/Exec/RegTests/MMS/prob_parm.H
@@ -5,7 +5,7 @@
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_GpuMemory.H>
 
-struct ProbParmDevice : amrex::Gpu::Managed
+struct ProbParmDevice
 {
   amrex::Real reynolds = 1.0;
   amrex::Real mach = 1.0;
@@ -52,7 +52,7 @@ struct ProbParmDevice : amrex::Gpu::Managed
   amrex::Real u0 = 0.0;
 };
 
-struct ProbParmHost : amrex::Gpu::Managed
+struct ProbParmHost
 {
 };
 

--- a/Exec/RegTests/MultiSpecSod/prob.cpp
+++ b/Exec/RegTests/MultiSpecSod/prob.cpp
@@ -16,49 +16,49 @@ amrex_probinit(
 {
   // Parse params
   amrex::ParmParse pp("prob");
-  pp.query("p_l", PeleC::prob_parm_device->p_l);
-  pp.query("u_l", PeleC::prob_parm_device->u_l);
-  pp.query("rho_l", PeleC::prob_parm_device->rho_l);
-  pp.query("p_r", PeleC::prob_parm_device->p_r);
-  pp.query("u_r", PeleC::prob_parm_device->u_r);
-  pp.query("rho_r", PeleC::prob_parm_device->rho_r);
-  pp.query("frac", PeleC::prob_parm_device->frac);
-  pp.query("idir", PeleC::prob_parm_device->idir);
+  pp.query("p_l", PeleC::h_prob_parm_device->p_l);
+  pp.query("u_l", PeleC::h_prob_parm_device->u_l);
+  pp.query("rho_l", PeleC::h_prob_parm_device->rho_l);
+  pp.query("p_r", PeleC::h_prob_parm_device->p_r);
+  pp.query("u_r", PeleC::h_prob_parm_device->u_r);
+  pp.query("rho_r", PeleC::h_prob_parm_device->rho_r);
+  pp.query("frac", PeleC::h_prob_parm_device->frac);
+  pp.query("idir", PeleC::h_prob_parm_device->idir);
   pp.get("left_gas", PeleC::prob_parm_host->gasL);
   pp.get("right_gas", PeleC::prob_parm_host->gasR);
 
   for (int idir = 0; idir < AMREX_SPACEDIM; idir++) {
-    PeleC::prob_parm_device->split[idir] =
-      PeleC::prob_parm_device->frac * (problo[idir] + probhi[idir]);
+    PeleC::h_prob_parm_device->split[idir] =
+      PeleC::h_prob_parm_device->frac * (problo[idir] + probhi[idir]);
   }
 
   if (PeleC::prob_parm_host->gasL == "N2") {
-    PeleC::prob_parm_device->left_gas_id = N2_ID;
-    PeleC::prob_parm_device->right_gas_id = HE_ID;
+    PeleC::h_prob_parm_device->left_gas_id = N2_ID;
+    PeleC::h_prob_parm_device->right_gas_id = HE_ID;
   } else {
-    PeleC::prob_parm_device->left_gas_id = HE_ID;
-    PeleC::prob_parm_device->right_gas_id = N2_ID;
+    PeleC::h_prob_parm_device->left_gas_id = HE_ID;
+    PeleC::h_prob_parm_device->right_gas_id = N2_ID;
   }
 
   amrex::Real e_l;
   amrex::Real e_r /*, cs, cp */;
   amrex::Real massfrac_l[NUM_SPECIES] = {0.0};
   amrex::Real massfrac_r[NUM_SPECIES] = {0.0};
-  massfrac_l[PeleC::prob_parm_device->left_gas_id] = 1.0;
-  massfrac_r[PeleC::prob_parm_device->right_gas_id] = 1.0;
+  massfrac_l[PeleC::h_prob_parm_device->left_gas_id] = 1.0;
+  massfrac_r[PeleC::h_prob_parm_device->right_gas_id] = 1.0;
 
   auto eos = pele::physics::PhysicsType::eos();
   eos.RYP2E(
-    PeleC::prob_parm_device->rho_l, massfrac_l, PeleC::prob_parm_device->p_l,
-    e_l);
-  eos.EY2T(e_l, massfrac_l, PeleC::prob_parm_device->T_l);
-  PeleC::prob_parm_device->rhoe_l = PeleC::prob_parm_device->rho_l * e_l;
+    PeleC::h_prob_parm_device->rho_l, massfrac_l,
+    PeleC::h_prob_parm_device->p_l, e_l);
+  eos.EY2T(e_l, massfrac_l, PeleC::h_prob_parm_device->T_l);
+  PeleC::h_prob_parm_device->rhoe_l = PeleC::h_prob_parm_device->rho_l * e_l;
 
   eos.RYP2E(
-    PeleC::prob_parm_device->rho_r, massfrac_r, PeleC::prob_parm_device->p_r,
-    e_r);
-  eos.EY2T(e_r, massfrac_r, PeleC::prob_parm_device->T_r);
-  PeleC::prob_parm_device->rhoe_r = PeleC::prob_parm_device->rho_r * e_r;
+    PeleC::h_prob_parm_device->rho_r, massfrac_r,
+    PeleC::h_prob_parm_device->p_r, e_r);
+  eos.EY2T(e_r, massfrac_r, PeleC::h_prob_parm_device->T_r);
+  PeleC::h_prob_parm_device->rhoe_r = PeleC::h_prob_parm_device->rho_r * e_r;
 }
 }
 

--- a/Exec/RegTests/MultiSpecSod/prob_parm.H
+++ b/Exec/RegTests/MultiSpecSod/prob_parm.H
@@ -28,5 +28,6 @@ struct ProbParmHost
 {
   std::string gasL = "N2";
   std::string gasR = "HE";
+  ProbParmHost() {}
 };
 #endif

--- a/Exec/RegTests/MultiSpecSod/prob_parm.H
+++ b/Exec/RegTests/MultiSpecSod/prob_parm.H
@@ -5,7 +5,7 @@
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_GpuMemory.H>
 
-struct ProbParmDevice : amrex::Gpu::Managed
+struct ProbParmDevice
 {
   amrex::Real p_l = 1.0;   // left pressure (erg/cc)
   amrex::Real u_l = 0.0;   // left velocity (cm/s)
@@ -24,7 +24,7 @@ struct ProbParmDevice : amrex::Gpu::Managed
   int right_gas_id = HE_ID;
 };
 
-struct ProbParmHost : amrex::Gpu::Managed
+struct ProbParmHost
 {
   std::string gasL = "N2";
   std::string gasR = "HE";

--- a/Exec/RegTests/PMF-SRK/prob.cpp
+++ b/Exec/RegTests/PMF-SRK/prob.cpp
@@ -74,26 +74,26 @@ read_pmf(const std::string& myfile)
   }
   amrex::Print() << line_count << " data lines found in PMF file" << std::endl;
 
-  PeleC::prob_parm_device->pmf_N = line_count;
-  PeleC::prob_parm_device->pmf_M = variable_count - 1;
-  PeleC::prob_parm_host->h_pmf_X.resize(PeleC::prob_parm_device->pmf_N);
-  PeleC::prob_parm_host->pmf_X.resize(PeleC::prob_parm_device->pmf_N);
+  PeleC::h_prob_parm_device->pmf_N = line_count;
+  PeleC::h_prob_parm_device->pmf_M = variable_count - 1;
+  PeleC::prob_parm_host->h_pmf_X.resize(PeleC::h_prob_parm_device->pmf_N);
+  PeleC::prob_parm_host->pmf_X.resize(PeleC::h_prob_parm_device->pmf_N);
   PeleC::prob_parm_host->h_pmf_Y.resize(
-    PeleC::prob_parm_device->pmf_N * PeleC::prob_parm_device->pmf_M);
+    PeleC::h_prob_parm_device->pmf_N * PeleC::h_prob_parm_device->pmf_M);
   PeleC::prob_parm_host->pmf_Y.resize(
-    PeleC::prob_parm_device->pmf_N * PeleC::prob_parm_device->pmf_M);
+    PeleC::h_prob_parm_device->pmf_N * PeleC::h_prob_parm_device->pmf_M);
 
   iss.clear();
   iss.seekg(0, std::ios::beg);
   std::getline(iss, firstline);
   std::getline(iss, secondline);
-  for (unsigned int i = 0; i < PeleC::prob_parm_device->pmf_N; i++) {
+  for (unsigned int i = 0; i < PeleC::h_prob_parm_device->pmf_N; i++) {
     std::getline(iss, remaininglines);
     std::istringstream sinput(remaininglines);
     sinput >> PeleC::prob_parm_host->h_pmf_X[i];
-    for (unsigned int j = 0; j < PeleC::prob_parm_device->pmf_M; j++) {
-      sinput >>
-        PeleC::prob_parm_host->h_pmf_Y[j * PeleC::prob_parm_device->pmf_N + i];
+    for (unsigned int j = 0; j < PeleC::h_prob_parm_device->pmf_M; j++) {
+      sinput >> PeleC::prob_parm_host
+                  ->h_pmf_Y[j * PeleC::h_prob_parm_device->pmf_N + i];
     }
   }
 
@@ -103,8 +103,10 @@ read_pmf(const std::string& myfile)
   amrex::Gpu::copy(
     amrex::Gpu::hostToDevice, PeleC::prob_parm_host->h_pmf_Y.begin(),
     PeleC::prob_parm_host->h_pmf_Y.end(), PeleC::prob_parm_host->pmf_Y.begin());
-  PeleC::prob_parm_device->d_pmf_X = PeleC::prob_parm_host->pmf_X.data();
-  PeleC::prob_parm_device->d_pmf_Y = PeleC::prob_parm_host->pmf_Y.data();
+  PeleC::h_prob_parm_device->d_pmf_X = PeleC::prob_parm_host->pmf_X.data();
+  PeleC::h_prob_parm_device->d_pmf_Y = PeleC::prob_parm_host->pmf_Y.data();
+  PeleC::d_prob_parm_device->d_pmf_X = PeleC::prob_parm_host->pmf_X.data();
+  PeleC::d_prob_parm_device->d_pmf_Y = PeleC::prob_parm_host->pmf_Y.data();
 }
 
 void
@@ -119,10 +121,10 @@ init_bc()
   amrex::Real massfrac[NUM_SPECIES];
   amrex::GpuArray<amrex::Real, NUM_SPECIES + 4> pmf_vals = {{0.0}};
 
-  if (PeleC::prob_parm_device->phi_in < 0) {
+  if (PeleC::h_prob_parm_device->phi_in < 0) {
     const amrex::Real yl = 0.0;
     const amrex::Real yr = 0.0;
-    pmf(yl, yr, pmf_vals, *PeleC::prob_parm_device);
+    pmf(yl, yr, pmf_vals, *PeleC::h_prob_parm_device);
     amrex::Real mysum = 0.0;
     for (int n = 0; n < NUM_SPECIES; n++) {
       molefrac[n] = amrex::max<amrex::Real>(0.0, pmf_vals[3 + n]);
@@ -130,36 +132,36 @@ init_bc()
     }
     molefrac[N2_ID] = 1.0 - (mysum - molefrac[N2_ID]);
     T = pmf_vals[0];
-    PeleC::prob_parm_device->vn_in = pmf_vals[1];
+    PeleC::h_prob_parm_device->vn_in = pmf_vals[1];
   } else {
     const amrex::Real a = 0.5;
     for (amrex::Real& n : molefrac) {
       n = 0.0;
     }
     molefrac[O2_ID] =
-      1.0 / (1.0 + PeleC::prob_parm_device->phi_in / a + 0.79 / 0.21);
-    molefrac[H2_ID] = PeleC::prob_parm_device->phi_in * molefrac[O2_ID] / a;
+      1.0 / (1.0 + PeleC::h_prob_parm_device->phi_in / a + 0.79 / 0.21);
+    molefrac[H2_ID] = PeleC::h_prob_parm_device->phi_in * molefrac[O2_ID] / a;
     molefrac[N2_ID] = 1.0 - molefrac[H2_ID] - molefrac[O2_ID];
-    T = PeleC::prob_parm_device->T_in;
+    T = PeleC::h_prob_parm_device->T_in;
   }
-  const amrex::Real p = PeleC::prob_parm_device->pamb;
+  const amrex::Real p = PeleC::h_prob_parm_device->pamb;
 
   auto eos = pele::physics::PhysicsType::eos();
   eos.X2Y(molefrac, massfrac);
   eos.PYT2RE(p, massfrac, T, rho, e);
 
-  vt = PeleC::prob_parm_device->vn_in;
+  vt = PeleC::h_prob_parm_device->vn_in;
   ek = 0.5 * (vt * vt);
 
-  PeleC::prob_parm_device->fuel_state[URHO] = rho;
-  PeleC::prob_parm_device->fuel_state[UMX] = 0.0;
-  PeleC::prob_parm_device->fuel_state[UMY] = rho * vt;
-  PeleC::prob_parm_device->fuel_state[UMZ] = 0.0;
-  PeleC::prob_parm_device->fuel_state[UEINT] = rho * e;
-  PeleC::prob_parm_device->fuel_state[UEDEN] = rho * (e + ek);
-  PeleC::prob_parm_device->fuel_state[UTEMP] = T;
+  PeleC::h_prob_parm_device->fuel_state[URHO] = rho;
+  PeleC::h_prob_parm_device->fuel_state[UMX] = 0.0;
+  PeleC::h_prob_parm_device->fuel_state[UMY] = rho * vt;
+  PeleC::h_prob_parm_device->fuel_state[UMZ] = 0.0;
+  PeleC::h_prob_parm_device->fuel_state[UEINT] = rho * e;
+  PeleC::h_prob_parm_device->fuel_state[UEDEN] = rho * (e + ek);
+  PeleC::h_prob_parm_device->fuel_state[UTEMP] = T;
   for (int n = 0; n < NUM_SPECIES; n++) {
-    PeleC::prob_parm_device->fuel_state[UFS + n - 1] = rho * massfrac[n];
+    PeleC::h_prob_parm_device->fuel_state[UFS + n - 1] = rho * massfrac[n];
   }
 }
 
@@ -180,16 +182,16 @@ amrex_probinit(
   std::string pmf_datafile;
 
   amrex::ParmParse pp("prob");
-  pp.query("pamb", PeleC::prob_parm_device->pamb);
-  pp.query("phi_in", PeleC::prob_parm_device->phi_in);
-  pp.query("T_in", PeleC::prob_parm_device->T_in);
-  pp.query("vn_in", PeleC::prob_parm_device->vn_in);
-  pp.query("pertmag", PeleC::prob_parm_device->pertmag);
+  pp.query("pamb", PeleC::h_prob_parm_device->pamb);
+  pp.query("phi_in", PeleC::h_prob_parm_device->phi_in);
+  pp.query("T_in", PeleC::h_prob_parm_device->T_in);
+  pp.query("vn_in", PeleC::h_prob_parm_device->vn_in);
+  pp.query("pertmag", PeleC::h_prob_parm_device->pertmag);
   pp.query("pmf_datafile", pmf_datafile);
 
-  PeleC::prob_parm_device->L[0] = probhi[0] - problo[0];
-  PeleC::prob_parm_device->L[1] = probhi[1] - problo[1];
-  PeleC::prob_parm_device->L[2] = probhi[2] - problo[2];
+  PeleC::h_prob_parm_device->L[0] = probhi[0] - problo[0];
+  PeleC::h_prob_parm_device->L[1] = probhi[1] - problo[1];
+  PeleC::h_prob_parm_device->L[2] = probhi[2] - problo[2];
 
   read_pmf(pmf_datafile);
 

--- a/Exec/RegTests/PMF-SRK/prob_parm.H
+++ b/Exec/RegTests/PMF-SRK/prob_parm.H
@@ -28,6 +28,7 @@ struct ProbParmHost
   amrex::Vector<amrex::Real> h_pmf_Y;
   amrex::Gpu::DeviceVector<amrex::Real> pmf_X;
   amrex::Gpu::DeviceVector<amrex::Real> pmf_Y;
+  ProbParmHost() : pmf_X(0), pmf_Y(0) {}
 };
 
 #endif

--- a/Exec/RegTests/PMF-SRK/prob_parm.H
+++ b/Exec/RegTests/PMF-SRK/prob_parm.H
@@ -5,7 +5,7 @@
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_GpuMemory.H>
 
-struct ProbParmDevice : amrex::Gpu::Managed
+struct ProbParmDevice
 {
   amrex::Real pamb = 1013250.0 * 100.0;
   amrex::Real phi_in = -0.2;
@@ -22,7 +22,7 @@ struct ProbParmDevice : amrex::Gpu::Managed
   amrex::Real* d_pmf_Y = nullptr;
 };
 
-struct ProbParmHost : amrex::Gpu::Managed
+struct ProbParmHost
 {
   amrex::Vector<amrex::Real> h_pmf_X;
   amrex::Vector<amrex::Real> h_pmf_Y;

--- a/Exec/RegTests/PMF/prob.H
+++ b/Exec/RegTests/PMF/prob.H
@@ -22,8 +22,9 @@ pmf(
   amrex::Real xlo,
   amrex::Real xhi,
   amrex::GpuArray<amrex::Real, NUM_SPECIES + 4>& y_vector,
-  ProbParmDevice const& prob_parm)
+  const ProbParmDevice& prob_parm)
 {
+  std::cout << "pmf\n";
   if (prob_parm.pmf_do_average) {
     int lo_loside = 0;
     int lo_hiside = 0;
@@ -144,6 +145,7 @@ pc_initdata(
   amrex::GeometryData const& geomdata,
   ProbParmDevice const& prob_parm)
 {
+  std::cout << "pc_initdata\n";
   if (prob_parm.phi_in < 0.0) {
     const amrex::Real* prob_lo = geomdata.ProbLo();
     // const amrex::Real* prob_hi = geomdata.ProbHi();
@@ -213,6 +215,7 @@ bcnormal(
   amrex::GeometryData const& geomdata,
   ProbParmDevice const& prob_parm)
 {
+  std::cout << "bcnormal\n";
   const amrex::Real* prob_lo = geomdata.ProbLo();
   const amrex::Real* prob_hi = geomdata.ProbHi();
   amrex::GpuArray<amrex::Real, NUM_SPECIES + 4> pmf_vals = {{0.0}};

--- a/Exec/RegTests/PMF/prob.H
+++ b/Exec/RegTests/PMF/prob.H
@@ -24,7 +24,6 @@ pmf(
   amrex::GpuArray<amrex::Real, NUM_SPECIES + 4>& y_vector,
   const ProbParmDevice& prob_parm)
 {
-  std::cout << "pmf\n";
   if (prob_parm.pmf_do_average) {
     int lo_loside = 0;
     int lo_hiside = 0;
@@ -145,7 +144,6 @@ pc_initdata(
   amrex::GeometryData const& geomdata,
   ProbParmDevice const& prob_parm)
 {
-  std::cout << "pc_initdata\n";
   if (prob_parm.phi_in < 0.0) {
     const amrex::Real* prob_lo = geomdata.ProbLo();
     // const amrex::Real* prob_hi = geomdata.ProbHi();
@@ -215,7 +213,6 @@ bcnormal(
   amrex::GeometryData const& geomdata,
   ProbParmDevice const& prob_parm)
 {
-  std::cout << "bcnormal\n";
   const amrex::Real* prob_lo = geomdata.ProbLo();
   const amrex::Real* prob_hi = geomdata.ProbHi();
   amrex::GpuArray<amrex::Real, NUM_SPECIES + 4> pmf_vals = {{0.0}};

--- a/Exec/RegTests/PMF/prob.cpp
+++ b/Exec/RegTests/PMF/prob.cpp
@@ -23,7 +23,6 @@ checkQuotes(const std::string& str)
 void
 read_pmf(const std::string& myfile)
 {
-  std::cout << "read_pmf\n";
   std::string firstline;
   std::string secondline;
   std::string remaininglines;
@@ -113,7 +112,6 @@ read_pmf(const std::string& myfile)
 void
 init_bc()
 {
-  std::cout << "init_bc\n";
   amrex::Real vt;
   amrex::Real ek;
   amrex::Real T;
@@ -181,7 +179,6 @@ amrex_probinit(
   const amrex_real* problo,
   const amrex_real* probhi)
 {
-  std::cout << "amrex_probinit\n";
   std::string pmf_datafile;
 
   amrex::ParmParse pp("prob");
@@ -205,7 +202,9 @@ amrex_probinit(
     PeleC::d_prob_parm_device, PeleC::h_prob_parm_device,
     sizeof(ProbParmDevice));
 #else
-  PeleC::d_prob_parm_device = PeleC::h_prob_parm_device;
+  std::memcpy(
+    PeleC::d_prob_parm_device, PeleC::h_prob_parm_device,
+    sizeof(ProbParmDevice));
 #endif
 }
 }

--- a/Exec/RegTests/PMF/prob.cpp
+++ b/Exec/RegTests/PMF/prob.cpp
@@ -196,16 +196,6 @@ amrex_probinit(
   read_pmf(pmf_datafile);
 
   init_bc();
-
-#ifdef AMREX_USE_GPU
-  amrex::Gpu::htod_memcpy(
-    PeleC::d_prob_parm_device, PeleC::h_prob_parm_device,
-    sizeof(ProbParmDevice));
-#else
-  std::memcpy(
-    PeleC::d_prob_parm_device, PeleC::h_prob_parm_device,
-    sizeof(ProbParmDevice));
-#endif
 }
 }
 

--- a/Exec/RegTests/PMF/prob.cpp
+++ b/Exec/RegTests/PMF/prob.cpp
@@ -23,6 +23,7 @@ checkQuotes(const std::string& str)
 void
 read_pmf(const std::string& myfile)
 {
+  std::cout << "read_pmf\n";
   std::string firstline;
   std::string secondline;
   std::string remaininglines;
@@ -74,26 +75,26 @@ read_pmf(const std::string& myfile)
   }
   amrex::Print() << line_count << " data lines found in PMF file" << std::endl;
 
-  PeleC::prob_parm_device->pmf_N = line_count;
-  PeleC::prob_parm_device->pmf_M = variable_count - 1;
-  PeleC::prob_parm_host->h_pmf_X.resize(PeleC::prob_parm_device->pmf_N);
-  PeleC::prob_parm_host->pmf_X.resize(PeleC::prob_parm_device->pmf_N);
+  PeleC::h_prob_parm_device->pmf_N = line_count;
+  PeleC::h_prob_parm_device->pmf_M = variable_count - 1;
+  PeleC::prob_parm_host->h_pmf_X.resize(PeleC::h_prob_parm_device->pmf_N);
+  PeleC::prob_parm_host->pmf_X.resize(PeleC::h_prob_parm_device->pmf_N);
   PeleC::prob_parm_host->h_pmf_Y.resize(
-    PeleC::prob_parm_device->pmf_N * PeleC::prob_parm_device->pmf_M);
+    PeleC::h_prob_parm_device->pmf_N * PeleC::h_prob_parm_device->pmf_M);
   PeleC::prob_parm_host->pmf_Y.resize(
-    PeleC::prob_parm_device->pmf_N * PeleC::prob_parm_device->pmf_M);
+    PeleC::h_prob_parm_device->pmf_N * PeleC::h_prob_parm_device->pmf_M);
 
   iss.clear();
   iss.seekg(0, std::ios::beg);
   std::getline(iss, firstline);
   std::getline(iss, secondline);
-  for (unsigned int i = 0; i < PeleC::prob_parm_device->pmf_N; i++) {
+  for (unsigned int i = 0; i < PeleC::h_prob_parm_device->pmf_N; i++) {
     std::getline(iss, remaininglines);
     std::istringstream sinput(remaininglines);
     sinput >> PeleC::prob_parm_host->h_pmf_X[i];
-    for (unsigned int j = 0; j < PeleC::prob_parm_device->pmf_M; j++) {
-      sinput >>
-        PeleC::prob_parm_host->h_pmf_Y[j * PeleC::prob_parm_device->pmf_N + i];
+    for (unsigned int j = 0; j < PeleC::h_prob_parm_device->pmf_M; j++) {
+      sinput >> PeleC::prob_parm_host
+                  ->h_pmf_Y[j * PeleC::h_prob_parm_device->pmf_N + i];
     }
   }
 
@@ -103,13 +104,16 @@ read_pmf(const std::string& myfile)
   amrex::Gpu::copy(
     amrex::Gpu::hostToDevice, PeleC::prob_parm_host->h_pmf_Y.begin(),
     PeleC::prob_parm_host->h_pmf_Y.end(), PeleC::prob_parm_host->pmf_Y.begin());
-  PeleC::prob_parm_device->d_pmf_X = PeleC::prob_parm_host->pmf_X.data();
-  PeleC::prob_parm_device->d_pmf_Y = PeleC::prob_parm_host->pmf_Y.data();
+  PeleC::h_prob_parm_device->d_pmf_X = PeleC::prob_parm_host->pmf_X.data();
+  PeleC::h_prob_parm_device->d_pmf_Y = PeleC::prob_parm_host->pmf_Y.data();
+  PeleC::d_prob_parm_device->d_pmf_X = PeleC::prob_parm_host->pmf_X.data();
+  PeleC::d_prob_parm_device->d_pmf_Y = PeleC::prob_parm_host->pmf_Y.data();
 }
 
 void
 init_bc()
 {
+  std::cout << "init_bc\n";
   amrex::Real vt;
   amrex::Real ek;
   amrex::Real T;
@@ -119,10 +123,10 @@ init_bc()
   amrex::Real massfrac[NUM_SPECIES];
   amrex::GpuArray<amrex::Real, NUM_SPECIES + 4> pmf_vals = {{0.0}};
 
-  if (PeleC::prob_parm_device->phi_in < 0) {
+  if (PeleC::h_prob_parm_device->phi_in < 0) {
     const amrex::Real yl = 0.0;
     const amrex::Real yr = 0.0;
-    pmf(yl, yr, pmf_vals, *PeleC::prob_parm_device);
+    pmf(yl, yr, pmf_vals, *PeleC::h_prob_parm_device);
     amrex::Real mysum = 0.0;
     for (int n = 0; n < NUM_SPECIES; n++) {
       molefrac[n] = amrex::max<amrex::Real>(0.0, pmf_vals[3 + n]);
@@ -130,36 +134,36 @@ init_bc()
     }
     molefrac[N2_ID] = 1.0 - (mysum - molefrac[N2_ID]);
     T = pmf_vals[0];
-    PeleC::prob_parm_device->vn_in = pmf_vals[1];
+    PeleC::h_prob_parm_device->vn_in = pmf_vals[1];
   } else {
     const amrex::Real a = 0.5;
     for (amrex::Real& n : molefrac) {
       n = 0.0;
     }
     molefrac[O2_ID] =
-      1.0 / (1.0 + PeleC::prob_parm_device->phi_in / a + 0.79 / 0.21);
-    molefrac[H2_ID] = PeleC::prob_parm_device->phi_in * molefrac[O2_ID] / a;
+      1.0 / (1.0 + PeleC::h_prob_parm_device->phi_in / a + 0.79 / 0.21);
+    molefrac[H2_ID] = PeleC::h_prob_parm_device->phi_in * molefrac[O2_ID] / a;
     molefrac[N2_ID] = 1.0 - molefrac[H2_ID] - molefrac[O2_ID];
-    T = PeleC::prob_parm_device->T_in;
+    T = PeleC::h_prob_parm_device->T_in;
   }
-  const amrex::Real p = PeleC::prob_parm_device->pamb;
+  const amrex::Real p = PeleC::h_prob_parm_device->pamb;
 
   auto eos = pele::physics::PhysicsType::eos();
   eos.X2Y(molefrac, massfrac);
   eos.PYT2RE(p, massfrac, T, rho, e);
 
-  vt = PeleC::prob_parm_device->vn_in;
+  vt = PeleC::h_prob_parm_device->vn_in;
   ek = 0.5 * (vt * vt);
 
-  PeleC::prob_parm_device->fuel_state[URHO] = rho;
-  PeleC::prob_parm_device->fuel_state[UMX] = 0.0;
-  PeleC::prob_parm_device->fuel_state[UMY] = rho * vt;
-  PeleC::prob_parm_device->fuel_state[UMZ] = 0.0;
-  PeleC::prob_parm_device->fuel_state[UEINT] = rho * e;
-  PeleC::prob_parm_device->fuel_state[UEDEN] = rho * (e + ek);
-  PeleC::prob_parm_device->fuel_state[UTEMP] = T;
+  PeleC::h_prob_parm_device->fuel_state[URHO] = rho;
+  PeleC::h_prob_parm_device->fuel_state[UMX] = 0.0;
+  PeleC::h_prob_parm_device->fuel_state[UMY] = rho * vt;
+  PeleC::h_prob_parm_device->fuel_state[UMZ] = 0.0;
+  PeleC::h_prob_parm_device->fuel_state[UEINT] = rho * e;
+  PeleC::h_prob_parm_device->fuel_state[UEDEN] = rho * (e + ek);
+  PeleC::h_prob_parm_device->fuel_state[UTEMP] = T;
   for (int n = 0; n < NUM_SPECIES; n++) {
-    PeleC::prob_parm_device->fuel_state[UFS + n - 1] = rho * massfrac[n];
+    PeleC::h_prob_parm_device->fuel_state[UFS + n - 1] = rho * massfrac[n];
   }
 }
 
@@ -177,23 +181,32 @@ amrex_probinit(
   const amrex_real* problo,
   const amrex_real* probhi)
 {
+  std::cout << "amrex_probinit\n";
   std::string pmf_datafile;
 
   amrex::ParmParse pp("prob");
-  pp.query("pamb", PeleC::prob_parm_device->pamb);
-  pp.query("phi_in", PeleC::prob_parm_device->phi_in);
-  pp.query("T_in", PeleC::prob_parm_device->T_in);
-  pp.query("vn_in", PeleC::prob_parm_device->vn_in);
-  pp.query("pertmag", PeleC::prob_parm_device->pertmag);
+  pp.query("pamb", PeleC::h_prob_parm_device->pamb);
+  pp.query("phi_in", PeleC::h_prob_parm_device->phi_in);
+  pp.query("T_in", PeleC::h_prob_parm_device->T_in);
+  pp.query("vn_in", PeleC::h_prob_parm_device->vn_in);
+  pp.query("pertmag", PeleC::h_prob_parm_device->pertmag);
   pp.query("pmf_datafile", pmf_datafile);
 
-  PeleC::prob_parm_device->L[0] = probhi[0] - problo[0];
-  PeleC::prob_parm_device->L[1] = probhi[1] - problo[1];
-  PeleC::prob_parm_device->L[2] = probhi[2] - problo[2];
+  PeleC::h_prob_parm_device->L[0] = probhi[0] - problo[0];
+  PeleC::h_prob_parm_device->L[1] = probhi[1] - problo[1];
+  PeleC::h_prob_parm_device->L[2] = probhi[2] - problo[2];
 
   read_pmf(pmf_datafile);
 
   init_bc();
+
+#ifdef AMREX_USE_GPU
+  amrex::Gpu::htod_memcpy(
+    PeleC::d_prob_parm_device, PeleC::h_prob_parm_device,
+    sizeof(ProbParmDevice));
+#else
+  PeleC::d_prob_parm_device = PeleC::h_prob_parm_device;
+#endif
 }
 }
 

--- a/Exec/RegTests/PMF/prob_parm.H
+++ b/Exec/RegTests/PMF/prob_parm.H
@@ -5,7 +5,7 @@
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_GpuMemory.H>
 
-struct ProbParmDevice : amrex::Gpu::Managed
+struct ProbParmDevice
 {
   amrex::Real pamb = 1013250.0 * 100.0;
   amrex::Real phi_in = -0.2;
@@ -22,12 +22,13 @@ struct ProbParmDevice : amrex::Gpu::Managed
   amrex::Real* d_pmf_Y = nullptr;
 };
 
-struct ProbParmHost : amrex::Gpu::Managed
+struct ProbParmHost
 {
   amrex::Vector<amrex::Real> h_pmf_X;
   amrex::Vector<amrex::Real> h_pmf_Y;
   amrex::Gpu::DeviceVector<amrex::Real> pmf_X;
   amrex::Gpu::DeviceVector<amrex::Real> pmf_Y;
+  ProbParmHost() : pmf_X(0), pmf_Y(0) {}
 };
 
 #endif

--- a/Exec/RegTests/Sedov/prob.cpp
+++ b/Exec/RegTests/Sedov/prob.cpp
@@ -16,11 +16,11 @@ amrex_probinit(
 {
   // Parse params
   amrex::ParmParse pp("prob");
-  pp.query("p_ambient", PeleC::prob_parm_device->p_ambient);
-  pp.query("dens_ambient", PeleC::prob_parm_device->dens_ambient);
-  pp.query("exp_energy", PeleC::prob_parm_device->exp_energy);
-  pp.query("r_init", PeleC::prob_parm_device->r_init);
-  pp.query("nsub", PeleC::prob_parm_device->nsub);
+  pp.query("p_ambient", PeleC::h_prob_parm_device->p_ambient);
+  pp.query("dens_ambient", PeleC::h_prob_parm_device->dens_ambient);
+  pp.query("exp_energy", PeleC::h_prob_parm_device->exp_energy);
+  pp.query("r_init", PeleC::h_prob_parm_device->r_init);
+  pp.query("nsub", PeleC::h_prob_parm_device->nsub);
 }
 }
 

--- a/Exec/RegTests/Sedov/prob_parm.H
+++ b/Exec/RegTests/Sedov/prob_parm.H
@@ -17,5 +17,6 @@ struct ProbParmDevice
 
 struct ProbParmHost
 {
+  ProbParmHost() {}
 };
 #endif

--- a/Exec/RegTests/Sedov/prob_parm.H
+++ b/Exec/RegTests/Sedov/prob_parm.H
@@ -5,7 +5,7 @@
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_GpuMemory.H>
 
-struct ProbParmDevice : amrex::Gpu::Managed
+struct ProbParmDevice
 {
   amrex::Real p_ambient;
   amrex::Real dens_ambient;
@@ -15,7 +15,7 @@ struct ProbParmDevice : amrex::Gpu::Managed
   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> split;
 };
 
-struct ProbParmHost : amrex::Gpu::Managed
+struct ProbParmHost
 {
 };
 #endif

--- a/Exec/RegTests/Shu-Osher/prob.cpp
+++ b/Exec/RegTests/Shu-Osher/prob.cpp
@@ -16,22 +16,22 @@ amrex_probinit(
 {
   // Parse params
   amrex::ParmParse pp("prob");
-  pp.query("p_l", PeleC::prob_parm_device->p_l);
-  pp.query("u_l", PeleC::prob_parm_device->u_l);
-  pp.query("rho_l", PeleC::prob_parm_device->rho_l);
-  pp.query("T_l", PeleC::prob_parm_device->T_l);
-  pp.query("p_r", PeleC::prob_parm_device->p_r);
-  pp.query("u_r", PeleC::prob_parm_device->u_r);
-  pp.query("rho_r_base", PeleC::prob_parm_device->rho_r_base);
-  pp.query("rho_r_amp", PeleC::prob_parm_device->rho_r_amp);
-  pp.query("rho_r_osc", PeleC::prob_parm_device->rho_r_osc);
-  pp.query("T_r", PeleC::prob_parm_device->T_r);
-  pp.query("frac", PeleC::prob_parm_device->frac);
-  pp.query("idir", PeleC::prob_parm_device->idir);
+  pp.query("p_l", PeleC::h_prob_parm_device->p_l);
+  pp.query("u_l", PeleC::h_prob_parm_device->u_l);
+  pp.query("rho_l", PeleC::h_prob_parm_device->rho_l);
+  pp.query("T_l", PeleC::h_prob_parm_device->T_l);
+  pp.query("p_r", PeleC::h_prob_parm_device->p_r);
+  pp.query("u_r", PeleC::h_prob_parm_device->u_r);
+  pp.query("rho_r_base", PeleC::h_prob_parm_device->rho_r_base);
+  pp.query("rho_r_amp", PeleC::h_prob_parm_device->rho_r_amp);
+  pp.query("rho_r_osc", PeleC::h_prob_parm_device->rho_r_osc);
+  pp.query("T_r", PeleC::h_prob_parm_device->T_r);
+  pp.query("frac", PeleC::h_prob_parm_device->frac);
+  pp.query("idir", PeleC::h_prob_parm_device->idir);
 
   for (int idir = 0; idir < AMREX_SPACEDIM; idir++) {
-    PeleC::prob_parm_device->split[idir] =
-      PeleC::prob_parm_device->frac * (problo[idir] + probhi[idir]);
+    PeleC::h_prob_parm_device->split[idir] =
+      PeleC::h_prob_parm_device->frac * (problo[idir] + probhi[idir]);
   }
 
   amrex::Real e_l;
@@ -41,15 +41,16 @@ amrex_probinit(
 
   auto eos = pele::physics::PhysicsType::eos();
   eos.RYP2E(
-    PeleC::prob_parm_device->rho_l, massfrac, PeleC::prob_parm_device->p_l,
+    PeleC::h_prob_parm_device->rho_l, massfrac, PeleC::h_prob_parm_device->p_l,
     e_l);
-  eos.EY2T(e_l, massfrac, PeleC::prob_parm_device->T_l);
-  PeleC::prob_parm_device->rhoe_l = PeleC::prob_parm_device->rho_l * e_l;
+  eos.EY2T(e_l, massfrac, PeleC::h_prob_parm_device->T_l);
+  PeleC::h_prob_parm_device->rhoe_l = PeleC::h_prob_parm_device->rho_l * e_l;
   eos.RYP2E(
-    PeleC::prob_parm_device->rho_r_base, massfrac, PeleC::prob_parm_device->p_r,
-    e_r);
-  eos.EY2T(e_r, massfrac, PeleC::prob_parm_device->T_r);
-  PeleC::prob_parm_device->rhoe_r = PeleC::prob_parm_device->rho_r_base * e_r;
+    PeleC::h_prob_parm_device->rho_r_base, massfrac,
+    PeleC::h_prob_parm_device->p_r, e_r);
+  eos.EY2T(e_r, massfrac, PeleC::h_prob_parm_device->T_r);
+  PeleC::h_prob_parm_device->rhoe_r =
+    PeleC::h_prob_parm_device->rho_r_base * e_r;
 }
 }
 

--- a/Exec/RegTests/Shu-Osher/prob_parm.H
+++ b/Exec/RegTests/Shu-Osher/prob_parm.H
@@ -26,5 +26,6 @@ struct ProbParmDevice
 
 struct ProbParmHost
 {
+  ProbParmHost() {}
 };
 #endif

--- a/Exec/RegTests/Shu-Osher/prob_parm.H
+++ b/Exec/RegTests/Shu-Osher/prob_parm.H
@@ -5,7 +5,7 @@
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_GpuMemory.H>
 
-struct ProbParmDevice : amrex::Gpu::Managed
+struct ProbParmDevice
 {
   amrex::Real p_l = 10.33333;   // left pressure (erg/cc)
   amrex::Real u_l = 2.629369;   // left velocity (cm/s)
@@ -24,7 +24,7 @@ struct ProbParmDevice : amrex::Gpu::Managed
   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> split;
 };
 
-struct ProbParmHost : amrex::Gpu::Managed
+struct ProbParmHost
 {
 };
 #endif

--- a/Exec/RegTests/Sod/prob.cpp
+++ b/Exec/RegTests/Sod/prob.cpp
@@ -17,21 +17,21 @@ amrex_probinit(
   // Parse params
   {
     amrex::ParmParse pp("prob");
-    pp.query("p_l", PeleC::prob_parm_device->p_l);
-    pp.query("u_l", PeleC::prob_parm_device->u_l);
-    pp.query("rho_l", PeleC::prob_parm_device->rho_l);
-    pp.query("T_l", PeleC::prob_parm_device->T_l);
-    pp.query("p_r", PeleC::prob_parm_device->p_r);
-    pp.query("u_r", PeleC::prob_parm_device->u_r);
-    pp.query("rho_r", PeleC::prob_parm_device->rho_r);
-    pp.query("T_r", PeleC::prob_parm_device->T_r);
-    pp.query("frac", PeleC::prob_parm_device->frac);
-    pp.query("idir", PeleC::prob_parm_device->idir);
-    pp.query("use_Tinit", PeleC::prob_parm_device->use_Tinit);
+    pp.query("p_l", PeleC::h_prob_parm_device->p_l);
+    pp.query("u_l", PeleC::h_prob_parm_device->u_l);
+    pp.query("rho_l", PeleC::h_prob_parm_device->rho_l);
+    pp.query("T_l", PeleC::h_prob_parm_device->T_l);
+    pp.query("p_r", PeleC::h_prob_parm_device->p_r);
+    pp.query("u_r", PeleC::h_prob_parm_device->u_r);
+    pp.query("rho_r", PeleC::h_prob_parm_device->rho_r);
+    pp.query("T_r", PeleC::h_prob_parm_device->T_r);
+    pp.query("frac", PeleC::h_prob_parm_device->frac);
+    pp.query("idir", PeleC::h_prob_parm_device->idir);
+    pp.query("use_Tinit", PeleC::h_prob_parm_device->use_Tinit);
   }
   for (int idir = 0; idir < AMREX_SPACEDIM; idir++) {
-    PeleC::prob_parm_device->split[idir] =
-      PeleC::prob_parm_device->frac * (problo[idir] + probhi[idir]);
+    PeleC::h_prob_parm_device->split[idir] =
+      PeleC::h_prob_parm_device->frac * (problo[idir] + probhi[idir]);
   }
 
   amrex::Real e_l;
@@ -40,32 +40,32 @@ amrex_probinit(
   massfrac[0] = 1.0;
 
   auto eos = pele::physics::PhysicsType::eos();
-  if (PeleC::prob_parm_device->use_Tinit) {
+  if (PeleC::h_prob_parm_device->use_Tinit) {
     eos.RTY2P(
-      PeleC::prob_parm_device->rho_l, PeleC::prob_parm_device->T_l, massfrac,
-      PeleC::prob_parm_device->p_l);
+      PeleC::h_prob_parm_device->rho_l, PeleC::h_prob_parm_device->T_l,
+      massfrac, PeleC::h_prob_parm_device->p_l);
     eos.RYP2E(
-      PeleC::prob_parm_device->rho_l, massfrac, PeleC::prob_parm_device->p_l,
-      e_l);
-    PeleC::prob_parm_device->rhoe_l = PeleC::prob_parm_device->rho_l * e_l;
+      PeleC::h_prob_parm_device->rho_l, massfrac,
+      PeleC::h_prob_parm_device->p_l, e_l);
+    PeleC::h_prob_parm_device->rhoe_l = PeleC::h_prob_parm_device->rho_l * e_l;
     eos.RTY2P(
-      PeleC::prob_parm_device->rho_r, PeleC::prob_parm_device->T_r, massfrac,
-      PeleC::prob_parm_device->p_r);
+      PeleC::h_prob_parm_device->rho_r, PeleC::h_prob_parm_device->T_r,
+      massfrac, PeleC::h_prob_parm_device->p_r);
     eos.RYP2E(
-      PeleC::prob_parm_device->rho_r, massfrac, PeleC::prob_parm_device->p_r,
-      e_r);
-    PeleC::prob_parm_device->rhoe_r = PeleC::prob_parm_device->rho_r * e_r;
+      PeleC::h_prob_parm_device->rho_r, massfrac,
+      PeleC::h_prob_parm_device->p_r, e_r);
+    PeleC::h_prob_parm_device->rhoe_r = PeleC::h_prob_parm_device->rho_r * e_r;
   } else {
     eos.RYP2E(
-      PeleC::prob_parm_device->rho_l, massfrac, PeleC::prob_parm_device->p_l,
-      e_l);
-    eos.EY2T(e_l, massfrac, PeleC::prob_parm_device->T_l);
-    PeleC::prob_parm_device->rhoe_l = PeleC::prob_parm_device->rho_l * e_l;
+      PeleC::h_prob_parm_device->rho_l, massfrac,
+      PeleC::h_prob_parm_device->p_l, e_l);
+    eos.EY2T(e_l, massfrac, PeleC::h_prob_parm_device->T_l);
+    PeleC::h_prob_parm_device->rhoe_l = PeleC::h_prob_parm_device->rho_l * e_l;
     eos.RYP2E(
-      PeleC::prob_parm_device->rho_r, massfrac, PeleC::prob_parm_device->p_r,
-      e_r);
-    eos.EY2T(e_r, massfrac, PeleC::prob_parm_device->T_r);
-    PeleC::prob_parm_device->rhoe_r = PeleC::prob_parm_device->rho_r * e_r;
+      PeleC::h_prob_parm_device->rho_r, massfrac,
+      PeleC::h_prob_parm_device->p_r, e_r);
+    eos.EY2T(e_r, massfrac, PeleC::h_prob_parm_device->T_r);
+    PeleC::h_prob_parm_device->rhoe_r = PeleC::h_prob_parm_device->rho_r * e_r;
   }
 }
 }

--- a/Exec/RegTests/Sod/prob_parm.H
+++ b/Exec/RegTests/Sod/prob_parm.H
@@ -26,5 +26,6 @@ struct ProbParmDevice
 
 struct ProbParmHost
 {
+  ProbParmHost() {}
 };
 #endif

--- a/Exec/RegTests/Sod/prob_parm.H
+++ b/Exec/RegTests/Sod/prob_parm.H
@@ -5,7 +5,7 @@
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_GpuMemory.H>
 
-struct ProbParmDevice : amrex::Gpu::Managed
+struct ProbParmDevice
 {
   amrex::Real p_l = 1.0;   // left pressure (erg/cc)
   amrex::Real u_l = 0.0;   // left velocity (cm/s)
@@ -24,7 +24,7 @@ struct ProbParmDevice : amrex::Gpu::Managed
   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> split;
 };
 
-struct ProbParmHost : amrex::Gpu::Managed
+struct ProbParmHost
 {
 };
 #endif

--- a/Exec/RegTests/TG/prob_parm.H
+++ b/Exec/RegTests/TG/prob_parm.H
@@ -25,6 +25,7 @@ struct ProbParmDevice
 
 struct ProbParmHost
 {
+  ProbParmHost() {}
 };
 
 #endif

--- a/Exec/RegTests/TG/prob_parm.H
+++ b/Exec/RegTests/TG/prob_parm.H
@@ -4,7 +4,7 @@
 #include <AMReX_REAL.H>
 #include <AMReX_GpuMemory.H>
 
-struct ProbParmDevice : amrex::Gpu::Managed
+struct ProbParmDevice
 {
   amrex::Real reynolds = 1600.0;
   amrex::Real mach = 0.1;
@@ -23,7 +23,7 @@ struct ProbParmDevice : amrex::Gpu::Managed
   amrex::Real v0 = 0.0;
 };
 
-struct ProbParmHost : amrex::Gpu::Managed
+struct ProbParmHost
 {
 };
 

--- a/Exec/RegTests/zeroD/prob.cpp
+++ b/Exec/RegTests/zeroD/prob.cpp
@@ -17,22 +17,26 @@ amrex_probinit(
   // Parse params
   {
     amrex::ParmParse pp("prob");
-    pp.query("p_init", PeleC::prob_parm_device->p_init);
-    pp.query("Y_init_H2", PeleC::prob_parm_device->Y_init_H2);
-    pp.query("Y_init_O2", PeleC::prob_parm_device->Y_init_O2);
-    pp.query("Y_init_N2", PeleC::prob_parm_device->Y_init_N2);
-    pp.query("T_init", PeleC::prob_parm_device->T_init);
+    pp.query("p_init", PeleC::h_prob_parm_device->p_init);
+    pp.query("Y_init_H2", PeleC::h_prob_parm_device->Y_init_H2);
+    pp.query("Y_init_O2", PeleC::h_prob_parm_device->Y_init_O2);
+    pp.query("Y_init_N2", PeleC::h_prob_parm_device->Y_init_N2);
+    pp.query("T_init", PeleC::h_prob_parm_device->T_init);
   }
 
   // Initial values
-  PeleC::prob_parm_device->massfrac[H2_ID] = PeleC::prob_parm_device->Y_init_H2;
-  PeleC::prob_parm_device->massfrac[O2_ID] = PeleC::prob_parm_device->Y_init_O2;
-  PeleC::prob_parm_device->massfrac[N2_ID] = PeleC::prob_parm_device->Y_init_N2;
+  PeleC::h_prob_parm_device->massfrac[H2_ID] =
+    PeleC::h_prob_parm_device->Y_init_H2;
+  PeleC::h_prob_parm_device->massfrac[O2_ID] =
+    PeleC::h_prob_parm_device->Y_init_O2;
+  PeleC::h_prob_parm_device->massfrac[N2_ID] =
+    PeleC::h_prob_parm_device->Y_init_N2;
   auto eos = pele::physics::PhysicsType::eos();
   eos.PYT2RE(
-    PeleC::prob_parm_device->p_init, PeleC::prob_parm_device->massfrac.begin(),
-    PeleC::prob_parm_device->T_init, PeleC::prob_parm_device->rho_init,
-    PeleC::prob_parm_device->e_init);
+    PeleC::h_prob_parm_device->p_init,
+    PeleC::h_prob_parm_device->massfrac.begin(),
+    PeleC::h_prob_parm_device->T_init, PeleC::h_prob_parm_device->rho_init,
+    PeleC::h_prob_parm_device->e_init);
 }
 }
 

--- a/Exec/RegTests/zeroD/prob_parm.H
+++ b/Exec/RegTests/zeroD/prob_parm.H
@@ -18,5 +18,6 @@ struct ProbParmDevice
 
 struct ProbParmHost
 {
+  ProbParmHost() {}
 };
 #endif

--- a/Exec/RegTests/zeroD/prob_parm.H
+++ b/Exec/RegTests/zeroD/prob_parm.H
@@ -4,7 +4,7 @@
 #include <AMReX_REAL.H>
 #include <AMReX_GpuMemory.H>
 
-struct ProbParmDevice : amrex::Gpu::Managed
+struct ProbParmDevice
 {
   amrex::Real p_init = 1013250.0; // 1 atm
   amrex::Real Y_init_H2 = 0.06;
@@ -16,7 +16,7 @@ struct ProbParmDevice : amrex::Gpu::Managed
   amrex::GpuArray<amrex::Real, NUM_SPECIES> massfrac = {0.0};
 };
 
-struct ProbParmHost : amrex::Gpu::Managed
+struct ProbParmHost
 {
 };
 #endif

--- a/Exec/UnitTests/prob.cpp
+++ b/Exec/UnitTests/prob.cpp
@@ -1,8 +1,5 @@
 #include "prob.H"
 
-namespace ProbParm {
-} // namespace ProbParm
-
 void
 pc_prob_close()
 {

--- a/Exec/UnitTests/prob_parm.H
+++ b/Exec/UnitTests/prob_parm.H
@@ -5,15 +5,13 @@
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_GpuMemory.H>
 
-struct ProbParmDevice : amrex::Gpu::Managed
+struct ProbParmDevice
 {
 };
 
-struct ProbParmHost : amrex::Gpu::Managed
+struct ProbParmHost
 {
+  ProbParmHost() {}
 };
-
-namespace ProbParm {
-} // namespace ProbParm
 
 #endif

--- a/Source/BCfill.cpp
+++ b/Source/BCfill.cpp
@@ -10,7 +10,7 @@ struct PCHypFillExtDir
   ProbParmDevice const* lprobparm;
 
   AMREX_GPU_HOST
-  constexpr explicit PCHypFillExtDir(ProbParmDevice const* d_prob_parm)
+  constexpr explicit PCHypFillExtDir(const ProbParmDevice* d_prob_parm)
     : lprobparm(d_prob_parm)
   {
   }
@@ -145,7 +145,7 @@ pc_bcfill_hyp(
   const int bcomp,
   const int scomp)
 {
-  ProbParmDevice const* lprobparm = PeleC::prob_parm_device.get();
+  const ProbParmDevice* lprobparm = PeleC::d_prob_parm_device;
   amrex::GpuBndryFuncFab<PCHypFillExtDir> hyp_bndry_func(
     PCHypFillExtDir{lprobparm});
   hyp_bndry_func(bx, data, dcomp, numcomp, geom, time, bcr, bcomp, scomp);

--- a/Source/Diffusion.cpp
+++ b/Source/Diffusion.cpp
@@ -178,7 +178,7 @@ PeleC::getMOLSrcTerm(
       // required for D term
       {
         BL_PROFILE("PeleC::ctoprim()");
-        PassMap const* lpmap = pass_map.get();
+        PassMap const* lpmap = d_pass_map;
         amrex::ParallelFor(
           gbox, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
             pc_ctoprim(i, j, k, s, qar, qauxar, *lpmap);

--- a/Source/Forcing.cpp
+++ b/Source/Forcing.cpp
@@ -76,10 +76,10 @@ PeleC::fill_forcing_source(
     amrex::Real w0 = 0.0;
     amrex::Real force = 0.0;
 #ifdef PELEC_USE_FORCING
-    u0 = PeleC::h_prob_parm_device.forcing_u0;
-    v0 = PeleC::h_prob_parm_device.forcing_v0;
-    w0 = PeleC::h_prob_parm_device.forcing_w0;
-    force = PeleC::h_prob_parm_device.forcing_force;
+    u0 = PeleC::h_prob_parm_device->forcing_u0;
+    v0 = PeleC::h_prob_parm_device->forcing_v0;
+    w0 = PeleC::h_prob_parm_device->forcing_w0;
+    force = PeleC::h_prob_parm_device->forcing_force;
 #endif
 
     // Evaluate the linear forcing term

--- a/Source/Forcing.cpp
+++ b/Source/Forcing.cpp
@@ -76,11 +76,10 @@ PeleC::fill_forcing_source(
     amrex::Real w0 = 0.0;
     amrex::Real force = 0.0;
 #ifdef PELEC_USE_FORCING
-    ProbParmDevice const* lpp = PeleC::prob_parm_device.get();
-    u0 = lpp->forcing_u0;
-    v0 = lpp->forcing_v0;
-    w0 = lpp->forcing_w0;
-    force = lpp->forcing_force;
+    u0 = PeleC::h_prob_parm_device.forcing_u0;
+    v0 = PeleC::h_prob_parm_device.forcing_v0;
+    w0 = PeleC::h_prob_parm_device.forcing_w0;
+    force = PeleC::h_prob_parm_device.forcing_force;
 #endif
 
     // Evaluate the linear forcing term

--- a/Source/Godunov.cpp
+++ b/Source/Godunov.cpp
@@ -93,7 +93,7 @@ pc_umeth_3D(
   auto const& qzmarr = qzm.array();
   auto const& qzparr = qzp.array();
 
-  PassMap const* lpmap = PeleC::pass_map.get();
+  const PassMap* lpmap = PeleC::d_pass_map;
 
   // Put the PLM and slopes in the same kernel launch to avoid unnecessary
   // launch overhead Pelec_Slope_* are SIMD as well as PeleC_plm_* which loop
@@ -533,7 +533,7 @@ pc_umeth_2D(
   auto const& qymarr = qym.array();
   auto const& qyparr = qyp.array();
 
-  PassMap const* lpmap = PeleC::pass_map.get();
+  const PassMap* lpmap = PeleC::d_pass_map;
   amrex::ParallelFor(
     xslpbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
       amrex::Real slope[QVAR];

--- a/Source/Hydro.cpp
+++ b/Source/Hydro.cpp
@@ -138,7 +138,7 @@ PeleC::construct_hydro_source(
         auto const& srcqarr = src_q.array();
 
         BL_PROFILE_VAR("PeleC::ctoprim()", ctop);
-        PassMap const* lpmap = pass_map.get();
+        const PassMap* lpmap = d_pass_map;
         amrex::ParallelFor(
           qbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
             pc_ctoprim(i, j, k, s, qarr, qauxar, *lpmap);

--- a/Source/IndexDefines.H
+++ b/Source/IndexDefines.H
@@ -77,12 +77,12 @@
 // This value was hardcoded to 4 in get_method_params in the old Fortran code
 #define NUM_GROW 4
 
-struct PassMap : amrex::Gpu::Managed
+struct PassMap
 {
   amrex::GpuArray<int, NPASSIVE> upassMap = {{0}};
   amrex::GpuArray<int, NPASSIVE> qpassMap = {{0}};
 };
 
-void init_pass_map(std::unique_ptr<PassMap>& pmap);
+void init_pass_map(PassMap* pmap);
 
 #endif

--- a/Source/IndexDefines.cpp
+++ b/Source/IndexDefines.cpp
@@ -1,7 +1,7 @@
 #include "IndexDefines.H"
 
 void
-init_pass_map(std::unique_ptr<PassMap>& pmap)
+init_pass_map(PassMap* pmap)
 {
   AMREX_D_PICK(
     pmap->upassMap[0] = UMY; pmap->qpassMap[0] = QV; pmap->upassMap[1] = UMZ;

--- a/Source/LES.cpp
+++ b/Source/LES.cpp
@@ -238,7 +238,7 @@ PeleC::getSmagorinskyLESTerm(
       // required for L term
       {
         BL_PROFILE("PeleC::ctoprim()");
-        PassMap const* lpmap = pass_map.get();
+        const PassMap* lpmap = d_pass_map;
         amrex::ParallelFor(
           gbox, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
             pc_ctoprim(i, j, k, s, q_ar, qauxar, *lpmap);
@@ -461,7 +461,7 @@ PeleC::getDynamicSmagorinskyLESTerm(
       // required for L term
       {
         BL_PROFILE("PeleC::ctoprim()");
-        PassMap const* lpmap = pass_map.get();
+        const PassMap* lpmap = d_pass_map;
         amrex::ParallelFor(
           g0box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
             pc_ctoprim(i, j, k, s, q_ar, qauxar, *lpmap);
@@ -540,7 +540,7 @@ PeleC::getDynamicSmagorinskyLESTerm(
       test_filter.apply_filter(g2box, Sfab, filtered_S);
       {
         BL_PROFILE("PeleC::ctoprim()");
-        PassMap const* lpmap = pass_map.get();
+        const PassMap* lpmap = d_pass_map;
         amrex::ParallelFor(
           g2box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
             pc_ctoprim(

--- a/Source/PeleC.H
+++ b/Source/PeleC.H
@@ -536,10 +536,12 @@ public:
   static int use_hybrid_weno;
   static int weno_scheme;
 
-  static std::unique_ptr<ProbParmDevice> prob_parm_device;
-  static std::unique_ptr<ProbParmHost> prob_parm_host;
-  static std::unique_ptr<TaggingParm> tagging_parm;
-  static std::unique_ptr<PassMap> pass_map;
+  static ProbParmDevice* h_prob_parm_device;
+  static ProbParmDevice* d_prob_parm_device;
+  static ProbParmHost* prob_parm_host;
+  static TaggingParm* tagging_parm;
+  static PassMap* h_pass_map;
+  static PassMap* d_pass_map;
 
 protected:
   amrex::iMultiFab level_mask;

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -123,34 +123,6 @@ ebInitialized(bool eb_init_val)
 #endif
 
 void
-PeleC::variableCleanUp()
-{
-  prob_parm_device.reset();
-  prob_parm_host.reset();
-  tagging_parm.reset();
-  pass_map.reset();
-
-  derive_lst.clear();
-
-  desc_lst.clear();
-
-  pele::physics::transport::CloseTransport<
-    pele::physics::PhysicsType::eos_type>()();
-
-#ifdef PELEC_USE_REACTIONS
-  if (do_react == 1) {
-    close_reactor();
-  }
-#endif
-
-  clear_prob();
-
-#ifdef PELEC_USE_EB
-  eb_initialized = false;
-#endif
-}
-
-void
 PeleC::read_params()
 {
   static bool read_params_done = false;
@@ -680,7 +652,7 @@ PeleC::initData()
     auto sfab = S_new.array(mfi);
     const auto geomdata = geom.data();
 
-    ProbParmDevice const* lprobparm = prob_parm_device.get();
+    const ProbParmDevice* lprobparm = h_prob_parm_device;
 
     amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
       pc_initdata(i, j, k, sfab, geomdata, *lprobparm);

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -652,7 +652,7 @@ PeleC::initData()
     auto sfab = S_new.array(mfi);
     const auto geomdata = geom.data();
 
-    const ProbParmDevice* lprobparm = h_prob_parm_device;
+    const ProbParmDevice* lprobparm = d_prob_parm_device;
 
     amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
       pc_initdata(i, j, k, sfab, geomdata, *lprobparm);

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -611,6 +611,17 @@ PeleC::initData()
 {
   BL_PROFILE("PeleC::initData()");
 
+  // Copy problem parameter structs to device
+#ifdef AMREX_USE_GPU
+  amrex::Gpu::htod_memcpy(
+    PeleC::d_prob_parm_device, PeleC::h_prob_parm_device,
+    sizeof(ProbParmDevice));
+#else
+  std::memcpy(
+    PeleC::d_prob_parm_device, PeleC::h_prob_parm_device,
+    sizeof(ProbParmDevice));
+#endif
+
   // int ns = NVAR;
   const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = geom.CellSizeArray();
   amrex::MultiFab& S_new = get_new_data(State_Type);

--- a/Source/Setup.cpp
+++ b/Source/Setup.cpp
@@ -647,9 +647,8 @@ PeleC::variableCleanUp()
 
   desc_lst.clear();
 
-  transport_close();
-
-  EOS::close();
+  pele::physics::transport::CloseTransport<
+    pele::physics::PhysicsType::eos_type>()();
 
 #ifdef PELEC_USE_REACTIONS
   if (do_react == 1) {

--- a/Source/Setup.cpp
+++ b/Source/Setup.cpp
@@ -12,6 +12,7 @@ using namespace MASA;
 #include <AMReX_SUNMemory.H>
 #endif
 
+#include "Transport.H"
 #include "mechanism.h"
 #include "PeleC.H"
 #include "Derive.H"
@@ -19,10 +20,12 @@ using namespace MASA;
 #include "prob.H"
 #include "chemistry_file.H"
 
-std::unique_ptr<ProbParmDevice> PeleC::prob_parm_device;
-std::unique_ptr<ProbParmHost> PeleC::prob_parm_host;
-std::unique_ptr<TaggingParm> PeleC::tagging_parm;
-std::unique_ptr<PassMap> PeleC::pass_map;
+ProbParmDevice* PeleC::d_prob_parm_device = nullptr;
+ProbParmDevice* PeleC::h_prob_parm_device = nullptr;
+ProbParmHost* PeleC::prob_parm_host = nullptr;
+TaggingParm* PeleC::tagging_parm = nullptr;
+PassMap* PeleC::d_pass_map = nullptr;
+PassMap* PeleC::h_pass_map = nullptr;
 
 // Components are:
 // Interior, Inflow, Outflow,  Symmetry,     SlipWall,     NoSlipWall, UserBC
@@ -146,10 +149,13 @@ PeleC::variableSetUp()
 
   AMREX_ASSERT(desc_lst.size() == 0);
 
-  prob_parm_device = std::make_unique<ProbParmDevice>();
-  prob_parm_host = std::make_unique<ProbParmHost>();
-  tagging_parm = std::make_unique<TaggingParm>();
-  pass_map = std::make_unique<PassMap>();
+  prob_parm_host = new ProbParmHost{};
+  h_prob_parm_device = new ProbParmDevice{};
+  tagging_parm = new TaggingParm{};
+  h_pass_map = new PassMap{};
+  d_prob_parm_device =
+    (ProbParmDevice*)amrex::The_Arena()->alloc(sizeof(ProbParmDevice));
+  d_pass_map = (PassMap*)amrex::The_Arena()->alloc(sizeof(PassMap));
 
   // Get options, set phys_bc
   read_params();
@@ -177,7 +183,13 @@ PeleC::variableSetUp()
   }
 #endif
 
-  init_pass_map(pass_map);
+  init_pass_map(h_pass_map);
+
+#ifdef AMREX_USE_GPU
+  amrex::Gpu::htod_memcpy(d_pass_map, h_pass_map, sizeof(PassMap));
+#else
+  d_pass_map = h_pass_map;
+#endif
 
 #ifdef PELEC_USE_MASA
   if (do_mms) {
@@ -238,19 +250,21 @@ PeleC::variableSetUp()
   // if (ParallelDescriptor::IOProcessor())
   //    std::cout << "\nTime in set_method_params: " << run_stop << '\n' ;
 
-  if (nscbc_adv == 1 && amrex::ParallelDescriptor::IOProcessor()) {
-    amrex::Print() << "Using Ghost-Cells Navier-Stokes Characteristic BCs for "
-                      "advection: nscbc_adv = "
-                   << nscbc_adv << '\n'
-                   << '\n';
-  }
+  // if (nscbc_adv == 1 && amrex::ParallelDescriptor::IOProcessor()) {
+  //  amrex::Print() << "Using Ghost-Cells Navier-Stokes Characteristic BCs for
+  //  "
+  //                    "advection: nscbc_adv = "
+  //                 << nscbc_adv << '\n'
+  //                 << '\n';
+  //}
 
-  if (nscbc_diff == 1 && amrex::ParallelDescriptor::IOProcessor()) {
-    amrex::Print() << "Using Ghost-Cells Navier-Stokes Characteristic BCs for "
-                      "diffusion: nscbc_diff = "
-                   << nscbc_diff << '\n'
-                   << '\n';
-  }
+  // if (nscbc_diff == 1 && amrex::ParallelDescriptor::IOProcessor()) {
+  //  amrex::Print() << "Using Ghost-Cells Navier-Stokes Characteristic BCs for
+  //  "
+  //                    "diffusion: nscbc_diff = "
+  //                 << nscbc_diff << '\n'
+  //                 << '\n';
+  //}
 
   // int coord_type = amrex::DefaultGeometry().Coord();
 
@@ -622,6 +636,37 @@ PeleC::variableSetUp()
   set_active_sources();
 #ifdef AMREX_PARTICLES
   defineParticles();
+#endif
+}
+
+void
+PeleC::variableCleanUp()
+{
+  delete prob_parm_host;
+  delete tagging_parm;
+  delete h_prob_parm_device;
+  delete h_pass_map;
+  amrex::The_Arena()->free(d_prob_parm_device);
+  amrex::The_Arena()->free(d_pass_map);
+
+  derive_lst.clear();
+
+  desc_lst.clear();
+
+  transport_close();
+
+  EOS::close();
+
+#ifdef PELEC_USE_REACTIONS
+  if (do_react == 1) {
+    close_reactor();
+  }
+#endif
+
+  clear_prob();
+
+#ifdef PELEC_USE_EB
+  eb_initialized = false;
 #endif
 }
 

--- a/Source/Setup.cpp
+++ b/Source/Setup.cpp
@@ -153,6 +153,7 @@ PeleC::variableSetUp()
   h_prob_parm_device = new ProbParmDevice{};
   tagging_parm = new TaggingParm{};
   h_pass_map = new PassMap{};
+  std::cout << "alloc\n";
   d_prob_parm_device =
     (ProbParmDevice*)amrex::The_Arena()->alloc(sizeof(ProbParmDevice));
   d_pass_map = (PassMap*)amrex::The_Arena()->alloc(sizeof(PassMap));
@@ -188,7 +189,7 @@ PeleC::variableSetUp()
 #ifdef AMREX_USE_GPU
   amrex::Gpu::htod_memcpy(d_pass_map, h_pass_map, sizeof(PassMap));
 #else
-  d_pass_map = h_pass_map;
+  std::memcpy(d_pass_map, h_pass_map, sizeof(PassMap));
 #endif
 
 #ifdef PELEC_USE_MASA
@@ -642,13 +643,6 @@ PeleC::variableSetUp()
 void
 PeleC::variableCleanUp()
 {
-  delete prob_parm_host;
-  delete tagging_parm;
-  delete h_prob_parm_device;
-  delete h_pass_map;
-  amrex::The_Arena()->free(d_prob_parm_device);
-  amrex::The_Arena()->free(d_pass_map);
-
   derive_lst.clear();
 
   desc_lst.clear();
@@ -668,6 +662,14 @@ PeleC::variableCleanUp()
 #ifdef PELEC_USE_EB
   eb_initialized = false;
 #endif
+
+  delete prob_parm_host;
+  delete tagging_parm;
+  delete h_prob_parm_device;
+  delete h_pass_map;
+  std::cout << "dealloc\n";
+  amrex::The_Arena()->free(d_prob_parm_device);
+  amrex::The_Arena()->free(d_pass_map);
 }
 
 void

--- a/Source/Setup.cpp
+++ b/Source/Setup.cpp
@@ -153,7 +153,6 @@ PeleC::variableSetUp()
   h_prob_parm_device = new ProbParmDevice{};
   tagging_parm = new TaggingParm{};
   h_pass_map = new PassMap{};
-  std::cout << "alloc\n";
   d_prob_parm_device =
     (ProbParmDevice*)amrex::The_Arena()->alloc(sizeof(ProbParmDevice));
   d_pass_map = (PassMap*)amrex::The_Arena()->alloc(sizeof(PassMap));
@@ -249,7 +248,7 @@ PeleC::variableSetUp()
   // ParallelDescriptor::ReduceRealMax(run_stop,ParallelDescriptor::IOProcessorNumber());
 
   // if (ParallelDescriptor::IOProcessor())
-  //    std::cout << "\nTime in set_method_params: " << run_stop << '\n' ;
+  //    amrex::Print() << "\nTime in set_method_params: " << run_stop << '\n' ;
 
   // if (nscbc_adv == 1 && amrex::ParallelDescriptor::IOProcessor()) {
   //  amrex::Print() << "Using Ghost-Cells Navier-Stokes Characteristic BCs for
@@ -666,7 +665,6 @@ PeleC::variableCleanUp()
   delete tagging_parm;
   delete h_prob_parm_device;
   delete h_pass_map;
-  std::cout << "dealloc\n";
   amrex::The_Arena()->free(d_prob_parm_device);
   amrex::The_Arena()->free(d_pass_map);
 }


### PR DESCRIPTION
Here we removed the reliance on managed memory for the problem parameter structs and do the copies to device explicitly.

I'm a little concerned about diffs, but the templating for the EOS hasn't run overnight yet, so I need to compare against that first.