### PR TITLE
Fix restart issue

### DIFF
--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -1154,6 +1154,17 @@ PeleC::post_restart()
 {
   BL_PROFILE("PeleC::post_restart()");
 
+  // Copy problem parameter structs to device
+#ifdef AMREX_USE_GPU
+  amrex::Gpu::htod_memcpy(
+    PeleC::d_prob_parm_device, PeleC::h_prob_parm_device,
+    sizeof(ProbParmDevice));
+#else
+  std::memcpy(
+    PeleC::d_prob_parm_device, PeleC::h_prob_parm_device,
+    sizeof(ProbParmDevice));
+#endif
+
   // amrex::Real cur_time = state[State_Type].curTime();
 
 #ifdef AMREX_PARTICLES


### PR DESCRIPTION
#257 moved the copy of parameters from host to device outside of the `amrex_probinit`. This copy was moved to the `InitData` call. But this also means the copy did not happen on restart anymore. This PR ensures that, upon restart, host parameters are copied to the device parameters.