### PR TITLE
Remove std::memcpy ifdefs

### DIFF
--- a/Exec/RegTests/EB-BluffBody/prob.cpp
+++ b/Exec/RegTests/EB-BluffBody/prob.cpp
@@ -65,13 +65,9 @@ amrex_probinit(
   trans_parm.const_conductivity =
     trans_parm.const_viscosity * cp / PeleC::h_prob_parm_device->Pr;
 
-#ifdef AMREX_USE_GPU
-  amrex::Gpu::htod_memcpy(
-    pele::physics::transport::trans_parm_g, &trans_parm, sizeof(trans_parm));
-#else
-  std::memcpy(
-    pele::physics::transport::trans_parm_g, &trans_parm, sizeof(trans_parm));
-#endif
+  amrex::Gpu::copy(
+    amrex::Gpu::hostToDevice, &trans_parm, &trans_parm + 1,
+    pele::physics::transport::trans_parm_g);
 }
 }
 

--- a/Exec/RegTests/EB-C1/prob.cpp
+++ b/Exec/RegTests/EB-C1/prob.cpp
@@ -88,13 +88,9 @@ amrex_probinit(
   trans_parm.const_conductivity =
     trans_parm.const_viscosity * cp / PeleC::h_prob_parm_device->prandtl;
 
-#ifdef AMREX_USE_GPU
-  amrex::Gpu::htod_memcpy(
-    pele::physics::transport::trans_parm_g, &trans_parm, sizeof(trans_parm));
-#else
-  std::memcpy(
-    pele::physics::transport::trans_parm_g, &trans_parm, sizeof(trans_parm));
-#endif
+  amrex::Gpu::copy(
+    amrex::Gpu::hostToDevice, &trans_parm, &trans_parm + 1,
+    pele::physics::transport::trans_parm_g);
 
   // clang-format off
   // MASA parameters for the following functions

--- a/Exec/RegTests/EB-C10/prob.cpp
+++ b/Exec/RegTests/EB-C10/prob.cpp
@@ -75,13 +75,9 @@ amrex_probinit(
   trans_parm.const_conductivity =
     trans_parm.const_viscosity * cp / PeleC::h_prob_parm_device->Pr;
 
-#ifdef AMREX_USE_GPU
-  amrex::Gpu::htod_memcpy(
-    pele::physics::transport::trans_parm_g, &trans_parm, sizeof(trans_parm));
-#else
-  std::memcpy(
-    pele::physics::transport::trans_parm_g, &trans_parm, sizeof(trans_parm));
-#endif
+  amrex::Gpu::copy(
+    amrex::Gpu::hostToDevice, &trans_parm, &trans_parm + 1,
+    pele::physics::transport::trans_parm_g);
 
   PeleC::h_prob_parm_device->G =
     PeleC::h_prob_parm_device->umax * 4 * trans_parm.const_viscosity /

--- a/Exec/RegTests/EB-Plane/prob.cpp
+++ b/Exec/RegTests/EB-Plane/prob.cpp
@@ -65,13 +65,9 @@ amrex_probinit(
   trans_parm.const_conductivity =
     trans_parm.const_viscosity * cp / PeleC::h_prob_parm_device->Pr;
 
-#ifdef AMREX_USE_GPU
-  amrex::Gpu::htod_memcpy(
-    pele::physics::transport::trans_parm_g, &trans_parm, sizeof(trans_parm));
-#else
-  std::memcpy(
-    pele::physics::transport::trans_parm_g, &trans_parm, sizeof(trans_parm));
-#endif
+  amrex::Gpu::copy(
+    amrex::Gpu::hostToDevice, &trans_parm, &trans_parm + 1,
+    pele::physics::transport::trans_parm_g);
 }
 }
 

--- a/Exec/RegTests/HIT/prob.cpp
+++ b/Exec/RegTests/HIT/prob.cpp
@@ -88,13 +88,9 @@ amrex_probinit(
   trans_parm.const_conductivity =
     trans_parm.const_viscosity * cp / PeleC::h_prob_parm_device->prandtl;
 
-#ifdef AMREX_USE_GPU
-  amrex::Gpu::htod_memcpy(
-    pele::physics::transport::trans_parm_g, &trans_parm, sizeof(trans_parm));
-#else
-  std::memcpy(
-    pele::physics::transport::trans_parm_g, &trans_parm, sizeof(trans_parm));
-#endif
+  amrex::Gpu::copy(
+    amrex::Gpu::hostToDevice, &trans_parm, &trans_parm + 1,
+    pele::physics::transport::trans_parm_g);
 
   // Output IC
   std::ofstream ofs("ic.txt", std::ofstream::out);

--- a/Exec/RegTests/MMS/prob.cpp
+++ b/Exec/RegTests/MMS/prob.cpp
@@ -103,13 +103,9 @@ amrex_probinit(
   trans_parm.const_conductivity =
     trans_parm.const_viscosity * cp / PeleC::h_prob_parm_device->prandtl;
 
-#ifdef AMREX_USE_GPU
-  amrex::Gpu::htod_memcpy(
-    pele::physics::transport::trans_parm_g, &trans_parm, sizeof(trans_parm));
-#else
-  std::memcpy(
-    pele::physics::transport::trans_parm_g, &trans_parm, sizeof(trans_parm));
-#endif
+  amrex::Gpu::copy(
+    amrex::Gpu::hostToDevice, &trans_parm, &trans_parm + 1,
+    pele::physics::transport::trans_parm_g);
 
   // clang-format off
   // MASA parameters for the following functions

--- a/Exec/RegTests/PMF/GNUmakefile
+++ b/Exec/RegTests/PMF/GNUmakefile
@@ -1,6 +1,6 @@
 # AMReX
 DIM = 3
-COMP = llvm
+COMP = gnu
 PRECISION = DOUBLE
 
 # Profiling
@@ -31,9 +31,6 @@ USE_MASA = FALSE
 Eos_dir := Fuego
 Chemistry_Model := LiDryer
 Transport_dir := Simple
-
-#USE_HDF5  = FALSE
-#HDF5_HOME = /Users/jrood/spack/opt/spack/darwin-catalina-x86_64/apple-clang-11.0.3/hdf5-1.10.4-nb5dk5var5kf7kbeekh6rt3dfytbdf2f
 
 # GNU Make
 Bpack := ./Make.package

--- a/Exec/RegTests/PMF/GNUmakefile
+++ b/Exec/RegTests/PMF/GNUmakefile
@@ -1,6 +1,6 @@
 # AMReX
 DIM = 3
-COMP = gnu
+COMP = llvm
 PRECISION = DOUBLE
 
 # Profiling
@@ -31,6 +31,9 @@ USE_MASA = FALSE
 Eos_dir := Fuego
 Chemistry_Model := LiDryer
 Transport_dir := Simple
+
+#USE_HDF5  = FALSE
+#HDF5_HOME = /Users/jrood/spack/opt/spack/darwin-catalina-x86_64/apple-clang-11.0.3/hdf5-1.10.4-nb5dk5var5kf7kbeekh6rt3dfytbdf2f
 
 # GNU Make
 Bpack := ./Make.package

--- a/Exec/RegTests/TG/prob.cpp
+++ b/Exec/RegTests/TG/prob.cpp
@@ -72,13 +72,9 @@ amrex_probinit(
   trans_parm.const_conductivity =
     trans_parm.const_viscosity * cp / PeleC::h_prob_parm_device->prandtl;
 
-#ifdef AMREX_USE_GPU
-  amrex::Gpu::htod_memcpy(
-    pele::physics::transport::trans_parm_g, &trans_parm, sizeof(trans_parm));
-#else
-  std::memcpy(
-    pele::physics::transport::trans_parm_g, &trans_parm, sizeof(trans_parm));
-#endif
+  amrex::Gpu::copy(
+    amrex::Gpu::hostToDevice, &trans_parm, &trans_parm + 1,
+    pele::physics::transport::trans_parm_g);
 
   // Output IC
   std::ofstream ofs("ic.txt", std::ofstream::out);

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -612,15 +612,9 @@ PeleC::initData()
   BL_PROFILE("PeleC::initData()");
 
   // Copy problem parameter structs to device
-#ifdef AMREX_USE_GPU
-  amrex::Gpu::htod_memcpy(
-    PeleC::d_prob_parm_device, PeleC::h_prob_parm_device,
-    sizeof(ProbParmDevice));
-#else
-  std::memcpy(
-    PeleC::d_prob_parm_device, PeleC::h_prob_parm_device,
-    sizeof(ProbParmDevice));
-#endif
+  amrex::Gpu::copy(
+    amrex::Gpu::hostToDevice, PeleC::h_prob_parm_device,
+    PeleC::h_prob_parm_device + 1, PeleC::d_prob_parm_device);
 
   // int ns = NVAR;
   const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = geom.CellSizeArray();
@@ -1155,15 +1149,9 @@ PeleC::post_restart()
   BL_PROFILE("PeleC::post_restart()");
 
   // Copy problem parameter structs to device
-#ifdef AMREX_USE_GPU
-  amrex::Gpu::htod_memcpy(
-    PeleC::d_prob_parm_device, PeleC::h_prob_parm_device,
-    sizeof(ProbParmDevice));
-#else
-  std::memcpy(
-    PeleC::d_prob_parm_device, PeleC::h_prob_parm_device,
-    sizeof(ProbParmDevice));
-#endif
+  amrex::Gpu::copy(
+    amrex::Gpu::hostToDevice, PeleC::h_prob_parm_device,
+    PeleC::h_prob_parm_device + 1, PeleC::d_prob_parm_device);
 
   // amrex::Real cur_time = state[State_Type].curTime();
 

--- a/Source/Setup.cpp
+++ b/Source/Setup.cpp
@@ -192,11 +192,8 @@ PeleC::variableSetUp()
 
   init_pass_map(h_pass_map);
 
-#ifdef AMREX_USE_GPU
-  amrex::Gpu::htod_memcpy(d_pass_map, h_pass_map, sizeof(PassMap));
-#else
-  std::memcpy(d_pass_map, h_pass_map, sizeof(PassMap));
-#endif
+  amrex::Gpu::copy(
+    amrex::Gpu::hostToDevice, h_pass_map, h_pass_map + 1, d_pass_map);
 
 #ifdef PELEC_USE_MASA
   if (do_mms) {


### PR DESCRIPTION
I figured this functionality existed in an AMReX copy function when we created these ifdefs, but didn't actually realize it until this https://github.com/AMReX-Codes/amrex/pull/1930 . So this copies to device for GPUs and `std::memcpy` on CPUs without the ifdefs. This happens in PelePhysics as well which I will need to clean up too.

Oops I committed a makefile change. I will remove that in the next commit.