### PR TITLE
Hari/addheatrelease

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: PeleC-CI
 
 on:
   push:
-    branches: [development]
+    branches: [hari/addheatrelease]
   pull_request:
-    branches: [development]
+    branches: [hari/addheatrelease]
 
 jobs:
   Formatting:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: PeleC-CI
 
 on:
   push:
-    branches: [hari/addheatrelease]
+    branches: [development]
   pull_request:
-    branches: [hari/addheatrelease]
+    branches: [development]
 
 jobs:
   Formatting:

--- a/Source/React.cpp
+++ b/Source/React.cpp
@@ -431,8 +431,20 @@ PeleC::react_state(
           bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
             I_R(i, j, k, NUM_SPECIES + 1) = 0.0;
             auto eos = pele::physics::PhysicsType::eos();
+
             amrex::Real hi[NUM_SPECIES] = {0.0};
+
+#ifndef PELEC_USE_SRK
             eos.T2Hi(snew_arr(i, j, k, UTEMP), hi);
+#else
+            amrex::Real Yspec[NUM_SPECIES] = {0.0};
+            for(int nsp=0;nsp<NUM_SPECIES;nsp++)
+            {
+                Yspec[nsp]=snew_arr(i, j, k, UFS+nsp)/snew_arr(i, j, k, URHO);
+            }
+            eos.RTY2Hi(snew_arr(i,j,k,URHO), snew_arr(i,j,k,UTEMP), Yspec, hi);
+#endif
+
             for (int nsp = 0; nsp < NUM_SPECIES; nsp++) {
               I_R(i, j, k, NUM_SPECIES + 1) -= hi[nsp] * I_R(i, j, k, nsp);
             }

--- a/Source/React.cpp
+++ b/Source/React.cpp
@@ -425,21 +425,18 @@ PeleC::react_state(
         } else {
           amrex::Abort("chem_integrator must be equal to 1, 2, or 3");
         }
-        
-        //update heat release
-        amrex::ParallelFor(
-            bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept 
-        {
 
-              I_R(i,j,k,NUM_SPECIES+1)=0.0;
-              auto eos = pele::physics::PhysicsType::eos();
-              amrex::Real ei[NUM_SPECIES] = {0.0};
-              eos.T2Ei(snew_arr(i,j,k,UTEMP), ei);
-              for(int nsp=0;nsp<NUM_SPECIES;nsp++)
-              {
-                I_R(i,j,k,NUM_SPECIES+1) -= ei[nsp]*I_R(i, j, k, nsp);
-              } 
-        });
+        // update heat release
+        amrex::ParallelFor(
+          bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+            I_R(i, j, k, NUM_SPECIES + 1) = 0.0;
+            auto eos = pele::physics::PhysicsType::eos();
+            amrex::Real ei[NUM_SPECIES] = {0.0};
+            eos.T2Ei(snew_arr(i, j, k, UTEMP), ei);
+            for (int nsp = 0; nsp < NUM_SPECIES; nsp++) {
+              I_R(i, j, k, NUM_SPECIES + 1) -= ei[nsp] * I_R(i, j, k, nsp);
+            }
+          });
       }
     }
   }

--- a/Source/React.cpp
+++ b/Source/React.cpp
@@ -425,6 +425,21 @@ PeleC::react_state(
         } else {
           amrex::Abort("chem_integrator must be equal to 1, 2, or 3");
         }
+        
+        //update heat release
+        amrex::ParallelFor(
+            bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept 
+        {
+
+              I_R(i,j,k,NUM_SPECIES+1)=0.0;
+              auto eos = pele::physics::PhysicsType::eos();
+              amrex::Real ei[NUM_SPECIES] = {0.0};
+              eos.T2Ei(snew_arr(i,j,k,UTEMP), ei);
+              for(int nsp=0;nsp<NUM_SPECIES;nsp++)
+              {
+                I_R(i,j,k,NUM_SPECIES+1) -= ei[nsp]*I_R(i, j, k, nsp);
+              } 
+        });
       }
     }
   }

--- a/Source/React.cpp
+++ b/Source/React.cpp
@@ -431,10 +431,10 @@ PeleC::react_state(
           bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
             I_R(i, j, k, NUM_SPECIES + 1) = 0.0;
             auto eos = pele::physics::PhysicsType::eos();
-            amrex::Real ei[NUM_SPECIES] = {0.0};
-            eos.T2Ei(snew_arr(i, j, k, UTEMP), ei);
+            amrex::Real hi[NUM_SPECIES] = {0.0};
+            eos.T2Hi(snew_arr(i, j, k, UTEMP), hi);
             for (int nsp = 0; nsp < NUM_SPECIES; nsp++) {
-              I_R(i, j, k, NUM_SPECIES + 1) -= ei[nsp] * I_R(i, j, k, nsp);
+              I_R(i, j, k, NUM_SPECIES + 1) -= hi[nsp] * I_R(i, j, k, nsp);
             }
           });
       }

--- a/Source/Setup.cpp
+++ b/Source/Setup.cpp
@@ -316,14 +316,14 @@ PeleC::variableSetUp()
   store_in_checkpoint = true;
   desc_lst.addDescriptor(
     Reactions_Type, amrex::IndexType::TheCellType(),
-    amrex::StateDescriptor::Point, 0, NUM_SPECIES + 1, interp,
+    amrex::StateDescriptor::Point, 0, NUM_SPECIES + 2, interp,
     state_data_extrap, store_in_checkpoint);
 #endif
 
   amrex::Vector<amrex::BCRec> bcs(NVAR);
   amrex::Vector<std::string> name(NVAR);
-  amrex::Vector<amrex::BCRec> react_bcs(NUM_SPECIES + 1);
-  amrex::Vector<std::string> react_name(NUM_SPECIES + 1);
+  amrex::Vector<amrex::BCRec> react_bcs(NUM_SPECIES + 2);
+  amrex::Vector<std::string> react_name(NUM_SPECIES + 2);
 
   amrex::BCRec bc;
   cnt = 0;
@@ -430,8 +430,10 @@ PeleC::variableSetUp()
     react_name[i] = "rho_omega_" + spec_names[i];
   }
   set_react_src_bc(bc, phys_bc);
-  react_bcs[NUM_SPECIES] = bc;
-  react_name[NUM_SPECIES] = "rhoe_dot";
+  react_bcs[NUM_SPECIES]    = bc;
+  react_name[NUM_SPECIES]   = "rhoe_dot";
+  react_bcs[NUM_SPECIES+1]  = bc;
+  react_name[NUM_SPECIES+1] = "heatRelease";
 
   amrex::StateDescriptor::BndryFunc bndryfunc2(pc_reactfill_hyp);
   bndryfunc2.setRunOnGPU(true);
@@ -512,6 +514,7 @@ PeleC::variableSetUp()
   derive_lst.add(
     "logden", amrex::IndexType::TheCellType(), 1, pc_derlogden, the_same_box);
   derive_lst.addComponent("logden", desc_lst, State_Type, Density, NVAR);
+  
 
   // Y from rhoY
   amrex::Vector<std::string> var_names_massfrac(NUM_SPECIES);
@@ -560,7 +563,7 @@ PeleC::variableSetUp()
   derive_lst.add(
     "magmom", amrex::IndexType::TheCellType(), 1, pc_dermagmom, the_same_box);
   derive_lst.addComponent("magmom", desc_lst, State_Type, Density, NVAR);
-
+  
 #ifdef PELEC_USE_EB
   // A dummy
   derive_lst.add(

--- a/Source/Setup.cpp
+++ b/Source/Setup.cpp
@@ -430,10 +430,10 @@ PeleC::variableSetUp()
     react_name[i] = "rho_omega_" + spec_names[i];
   }
   set_react_src_bc(bc, phys_bc);
-  react_bcs[NUM_SPECIES]    = bc;
-  react_name[NUM_SPECIES]   = "rhoe_dot";
-  react_bcs[NUM_SPECIES+1]  = bc;
-  react_name[NUM_SPECIES+1] = "heatRelease";
+  react_bcs[NUM_SPECIES] = bc;
+  react_name[NUM_SPECIES] = "rhoe_dot";
+  react_bcs[NUM_SPECIES + 1] = bc;
+  react_name[NUM_SPECIES + 1] = "heatRelease";
 
   amrex::StateDescriptor::BndryFunc bndryfunc2(pc_reactfill_hyp);
   bndryfunc2.setRunOnGPU(true);
@@ -514,7 +514,6 @@ PeleC::variableSetUp()
   derive_lst.add(
     "logden", amrex::IndexType::TheCellType(), 1, pc_derlogden, the_same_box);
   derive_lst.addComponent("logden", desc_lst, State_Type, Density, NVAR);
-  
 
   // Y from rhoY
   amrex::Vector<std::string> var_names_massfrac(NUM_SPECIES);
@@ -563,7 +562,7 @@ PeleC::variableSetUp()
   derive_lst.add(
     "magmom", amrex::IndexType::TheCellType(), 1, pc_dermagmom, the_same_box);
   derive_lst.addComponent("magmom", desc_lst, State_Type, Density, NVAR);
-  
+
 #ifdef PELEC_USE_EB
   // A dummy
   derive_lst.add(


### PR DESCRIPTION
This PR adds heat-release as an extra variable to plot. Most often it gets cumbersome to calculate offline using other methods. see below heat-release from the PMF case active at the flame interface.
![Screen Shot 2021-04-29 at 1 50 41 PM](https://user-images.githubusercontent.com/7399475/116621143-f8d88b80-a8ff-11eb-8850-0e66bb033578.png)
