### PR TITLE
Clean Riemann solver

### DIFF
--- a/Source/Godunov.H
+++ b/Source/Godunov.H
@@ -123,7 +123,7 @@ pc_cmpflx(
   amrex::Real cav, ustar;
   amrex::Real spl[NUM_SPECIES];
   amrex::Real spr[NUM_SPECIES];
-  amrex::Real ul, ur, vl, vr, v2l, v2r, rel, rer, gamcl, gamcr;
+  amrex::Real ul, ur, vl, vr, v2l, v2r;
   int idx;
   int IU, IV, IV2;
   int GU, GV, GV2;
@@ -135,8 +135,6 @@ pc_cmpflx(
     GU = GDU;
     GV = GDV;
     GV2 = GDW;
-    gamcl = qa(i - 1, j, k, QGAMC);
-    gamcr = qa(i, j, k, QGAMC);
     cav = 0.5 * (qa(i, j, k, QC) + qa(i - 1, j, k, QC));
     f_idx[0] = UMX;
     f_idx[1] = UMY;
@@ -148,8 +146,6 @@ pc_cmpflx(
     GU = GDV;
     GV = GDU;
     GV2 = GDW;
-    gamcl = qa(i, j - 1, k, QGAMC);
-    gamcr = qa(i, j, k, QGAMC);
     cav = 0.5 * (qa(i, j, k, QC) + qa(i, j - 1, k, QC));
     f_idx[0] = UMY;
     f_idx[1] = UMX;
@@ -161,8 +157,6 @@ pc_cmpflx(
     GU = GDW;
     GV = GDU;
     GV2 = GDV;
-    gamcl = qa(i, j, k - 1, QGAMC);
-    gamcr = qa(i, j, k, QGAMC);
     cav = 0.5 * (qa(i, j, k, QC) + qa(i, j, k - 1, QC));
     f_idx[0] = UMZ;
     f_idx[1] = UMX;
@@ -176,12 +170,10 @@ pc_cmpflx(
   ul = ql(i, j, k, IU);
   vl = ql(i, j, k, IV);
   v2l = ql(i, j, k, IV2);
-  rel = ql(i, j, k, QREINT);
 
   ur = qr(i, j, k, IU);
   vr = qr(i, j, k, IV);
   v2r = qr(i, j, k, IV2);
-  rer = qr(i, j, k, QREINT);
 
   // Outflow Hack
   if (dir == 2)
@@ -192,23 +184,21 @@ pc_cmpflx(
     ul = ur;
     vl = vr;
     v2l = v2r;
-    rel = rer;
   }
   if (bchi == Outflow && idx == domhi + 1) {
     ur = ul;
     vr = vl;
     v2r = v2l;
-    rer = rel;
   }
 
   const int bc_test_val = 1;
   riemann(
-    ql(i, j, k, QRHO), ul, vl, v2l, ql(i, j, k, QPRES), rel, spl, gamcl,
-    qr(i, j, k, QRHO), ur, vr, v2r, qr(i, j, k, QPRES), rer, spr, gamcr,
-    bc_test_val, qa(i, j, k, QCSML), cav, ustar, flx(i, j, k, URHO),
-    flx(i, j, k, f_idx[0]), flx(i, j, k, f_idx[1]), flx(i, j, k, f_idx[2]),
-    flx(i, j, k, UEDEN), flx(i, j, k, UEINT), q(i, j, k, GU), q(i, j, k, GV),
-    q(i, j, k, GV2), q(i, j, k, GDPRES), q(i, j, k, GDGAME));
+    ql(i, j, k, QRHO), ul, vl, v2l, ql(i, j, k, QPRES), spl, qr(i, j, k, QRHO),
+    ur, vr, v2r, qr(i, j, k, QPRES), spr, bc_test_val, cav, ustar,
+    flx(i, j, k, URHO), flx(i, j, k, f_idx[0]), flx(i, j, k, f_idx[1]),
+    flx(i, j, k, f_idx[2]), flx(i, j, k, UEDEN), flx(i, j, k, UEINT),
+    q(i, j, k, GU), q(i, j, k, GV), q(i, j, k, GV2), q(i, j, k, GDPRES),
+    q(i, j, k, GDGAME));
 
   amrex::Real flxrho = flx(i, j, k, URHO);
   for (int ipass = 0; ipass < NPASSIVE; ++ipass) {

--- a/Source/Riemann.H
+++ b/Source/Riemann.H
@@ -12,19 +12,14 @@ riemann(
   const amrex::Real vl,
   const amrex::Real v2l,
   const amrex::Real pl,
-  const amrex::Real /*rel*/,
   const amrex::Real spl[NUM_SPECIES],
-  const amrex::Real gamcl,
   const amrex::Real rr,
   const amrex::Real ur,
   const amrex::Real vr,
   const amrex::Real v2r,
   const amrex::Real pr,
-  const amrex::Real /*rer*/,
   const amrex::Real spr[NUM_SPECIES],
-  const amrex::Real gamcr,
   const int bc_test_val,
-  const amrex::Real /*csmall*/,
   const amrex::Real cav,
   amrex::Real& ustar,
   amrex::Real& uflx_rho,
@@ -43,24 +38,21 @@ riemann(
 
   auto eos = pele::physics::PhysicsType::eos();
 
-  amrex::Real gdnv_state_rho = rl;
-  amrex::Real gdnv_state_p = pl;
   amrex::Real gdnv_state_massfrac[NUM_SPECIES];
   for (int n = 0; n < NUM_SPECIES; n++) {
     gdnv_state_massfrac[n] = spl[n];
   }
-  amrex::Real gdnv_state_cs;
+  amrex::Real cl = 0.0;
+  eos.RPY2Cs(rl, pl, gdnv_state_massfrac, cl);
 
-  gdnv_state_rho = rr;
-  gdnv_state_p = pr;
   for (int n = 0; n < NUM_SPECIES; n++) {
     gdnv_state_massfrac[n] = spr[n];
   }
+  amrex::Real cr = 0.0;
+  eos.RPY2Cs(rr, pr, gdnv_state_massfrac, cr);
 
-  const amrex::Real wl = amrex::max<amrex::Real>(
-    wsmall, std::sqrt(amrex::Math::abs(gamcl * pl * rl)));
-  const amrex::Real wr = amrex::max<amrex::Real>(
-    wsmall, std::sqrt(amrex::Math::abs(gamcr * pr * rr)));
+  const amrex::Real wl = amrex::max<amrex::Real>(wsmall, cl * rl);
+  const amrex::Real wr = amrex::max<amrex::Real>(wsmall, cr * rr);
   const amrex::Real pstar = amrex::max<amrex::Real>(
     std::numeric_limits<amrex::Real>::min(),
     ((wr * pl + wl * pr) + wl * wr * (ul - ur)) / (wl + wr));
@@ -87,16 +79,16 @@ riemann(
     sp[n] = mask ? 0.5 * (spl[n] + spr[n]) : sp[n];
   }
 
-  gdnv_state_rho = ro;
-  gdnv_state_p = po;
+  amrex::Real gdnv_state_rho = ro;
+  amrex::Real gdnv_state_p = po;
   for (int n = 0; n < NUM_SPECIES; n++) {
     gdnv_state_massfrac[n] = sp[n];
   }
   amrex::Real gdnv_state_e;
   eos.RYP2E(gdnv_state_rho, gdnv_state_massfrac, gdnv_state_p, gdnv_state_e);
   const amrex::Real reo = gdnv_state_rho * gdnv_state_e;
-  eos.RPY2Cs(gdnv_state_rho, gdnv_state_p, gdnv_state_massfrac, gdnv_state_cs);
-  const amrex::Real co = gdnv_state_cs;
+  amrex::Real co;
+  eos.RPY2Cs(gdnv_state_rho, gdnv_state_p, gdnv_state_massfrac, co);
 
   const amrex::Real drho = (pstar - po) / (co * co);
   const amrex::Real rstar =
@@ -109,8 +101,8 @@ riemann(
   }
   eos.RYP2E(gdnv_state_rho, gdnv_state_massfrac, gdnv_state_p, gdnv_state_e);
   const amrex::Real estar = gdnv_state_rho * gdnv_state_e;
-  eos.RPY2Cs(gdnv_state_rho, gdnv_state_p, gdnv_state_massfrac, gdnv_state_cs);
-  const amrex::Real cstar = gdnv_state_cs;
+  amrex::Real cstar;
+  eos.RPY2Cs(gdnv_state_rho, gdnv_state_p, gdnv_state_massfrac, cstar);
 
   const amrex::Real sgnm = amrex::Math::copysign(1.0, ustar);
 


### PR DESCRIPTION
This PR:
- removes the uses of `gamma` in the Riemann solver. It was just used to compute `cs`. This is now a call to the eos.
- It also removes `rhoe` (which was an unused variable in the RS).
- These two changes led to a bunch of EOS calls being taken out 

I expect machine precision diffs.