### PR TITLE
Specify exact hydro EB wall flux

### DIFF
--- a/Source/Diffusion.cpp
+++ b/Source/Diffusion.cpp
@@ -395,8 +395,8 @@ PeleC::getMOLSrcTerm(
             cbox, qar, qauxar, flx, area_arr, dx, plm_iorder
 #ifdef PELEC_USE_EB
             ,
-            eb_small_vfrac, vfrac.array(mfi), flags.array(mfi),
-            d_sv_eb_bndry_geom, Ncut, d_eb_flux_thdlocal, nFlux
+            flags.array(mfi), d_sv_eb_bndry_geom, Ncut, d_eb_flux_thdlocal,
+            nFlux
 #endif
           );
         }

--- a/Source/MOL.H
+++ b/Source/MOL.H
@@ -114,8 +114,6 @@ void pc_compute_hyp_mol_flux(
   const int plm_iorder
 #ifdef PELEC_USE_EB
   ,
-  const amrex::Real eb_small_vfrac,
-  const amrex::Array4<const amrex::Real>& vfrac,
   const amrex::Array4<amrex::EBCellFlag const>& flags,
   const EBBndryGeom* ebg,
   const int Nebg,

--- a/Source/MOL.cpp
+++ b/Source/MOL.cpp
@@ -16,8 +16,6 @@ pc_compute_hyp_mol_flux(
   const int plm_iorder
 #ifdef PELEC_USE_EB
   ,
-  const amrex::Real eb_small_vfrac,
-  const amrex::Array4<const amrex::Real>& vfrac,
   const amrex::Array4<amrex::EBCellFlag const>& flags,
   const EBBndryGeom* ebg,
   const int /*Nebg*/,

--- a/Source/Params/_cpp_parameters
+++ b/Source/Params/_cpp_parameters
@@ -257,8 +257,6 @@ PrT                          Real          1.0
 eb_boundary_T                Real         1.0
 eb_isothermal                int          1
 eb_noslip                    int          1
-# Small vfrac - values below this will be pseudo-merged
-eb_small_vfrac               Real         0.0
 redistribution_type          string       "StateRedist"
 
 #-----------------------------------------------------------------------------

--- a/Source/Params/param_includes/pelec_defaults.H
+++ b/Source/Params/param_includes/pelec_defaults.H
@@ -70,7 +70,6 @@ amrex::Real PeleC::PrT = 1.0;
 amrex::Real PeleC::eb_boundary_T = 1.0;
 int PeleC::eb_isothermal = 1;
 int PeleC::eb_noslip = 1;
-amrex::Real PeleC::eb_small_vfrac = 0.0;
 std::string PeleC::redistribution_type = "StateRedist";
 int PeleC::do_mms = 0;
 std::string PeleC::masa_solution_name = "ad_cns_3d_les";

--- a/Source/Params/param_includes/pelec_params.H
+++ b/Source/Params/param_includes/pelec_params.H
@@ -70,7 +70,6 @@ static amrex::Real PrT;
 static amrex::Real eb_boundary_T;
 static int eb_isothermal;
 static int eb_noslip;
-static amrex::Real eb_small_vfrac;
 static std::string redistribution_type;
 static int do_mms;
 static std::string masa_solution_name;

--- a/Source/Params/param_includes/pelec_queries.H
+++ b/Source/Params/param_includes/pelec_queries.H
@@ -70,7 +70,6 @@ pp.query("PrT", PrT);
 pp.query("eb_boundary_T", eb_boundary_T);
 pp.query("eb_isothermal", eb_isothermal);
 pp.query("eb_noslip", eb_noslip);
-pp.query("eb_small_vfrac", eb_small_vfrac);
 pp.query("redistribution_type", redistribution_type);
 pp.query("do_mms", do_mms);
 pp.query("masa_solution_name", masa_solution_name);


### PR DESCRIPTION
This PR:
- sets the hydrodynamic fluxes at the EB boundary to be `F = [0, p_nx, p_ny, p_nz, 0]` (for mass, momentum, energy). The current code would call a Riemann solver with opposing normal velocities.
- removes the use of `eb_small_vfrac` as it was only being used to merge quantities in small cells for computing MOL hydro fluxes. And even then, all our cases were setting that value to 0.0. 