### PR TITLE
Changing to turning off clean massfrac

### DIFF
--- a/Source/Params/_cpp_parameters
+++ b/Source/Params/_cpp_parameters
@@ -372,7 +372,7 @@ adaptrk_nsubsteps_guess      int           50                 n
 adaptrk_errtol               Real          1e-12              n
 
 #flag to clean massfractions before react/diffuse/convect
-clean_massfrac         int           1                  n
+clean_massfrac         int           0                  n
 
 #-----------------------------------------------------------------------------
 # category: parallelization

--- a/Source/Params/param_includes/pelec_defaults.H
+++ b/Source/Params/param_includes/pelec_defaults.H
@@ -102,7 +102,7 @@ int PeleC::adaptrk_nsubsteps_min = 20;
 int PeleC::adaptrk_nsubsteps_max = 300;
 int PeleC::adaptrk_nsubsteps_guess = 50;
 amrex::Real PeleC::adaptrk_errtol = 1e-12;
-int PeleC::clean_massfrac = 1;
+int PeleC::clean_massfrac = 0;
 int PeleC::bndry_func_thread_safe = 1;
 #ifdef AMREX_DEBUG
 int PeleC::print_energy_diagnostics = 1;


### PR DESCRIPTION
This has been shown to be no longer necessary with the new
redistribution stuff. I am expecting diffs in all EB cases.