### PR TITLE
Fixing FluxRedist

### DIFF
--- a/Source/Diffusion.cpp
+++ b/Source/Diffusion.cpp
@@ -645,6 +645,9 @@ PeleC::getMOLSrcTerm(
         auto ccc = fact.getCentroid().const_array(mfi);
 
         amrex::FArrayBox tmpfab(Dfab.box(), S.nComp());
+        if (redistribution_type == "FluxRedist") {
+          tmpfab.setVal<amrex::RunOn::Device>(1.0);
+        }
         amrex::Elixir tmpeli = tmpfab.elixir();
         amrex::Array4<amrex::Real> scratch = tmpfab.array();
 


### PR DESCRIPTION
Looks like I was missing something for the "FluxRedist". Apparently the `scratch` is used as weights so it should be initialized to something sane when using "FluxRedist". 

For the EB-C14 case (`inputs_ex-2d pelec.cfl=0.25 pelec.diffuse_temp=0 pelec.diffuse_vel=0 pelec.redistribution_type="FluxRedist"`) this means that it now runs for 400 steps and then crashes soon after the shock starts moving up the ramp. With `development` branch it would crash in 56 steps, before the shock even gets to the ramp.