### PR TITLE
Adds user defined inputs to set_problem_tags

### DIFF
--- a/Exec/RegTests/TG/prob.H
+++ b/Exec/RegTests/TG/prob.H
@@ -107,7 +107,8 @@ struct MyProbTagStruct
     const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> /*dx*/,
     const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> /*prob_lo*/,
     const amrex::Real /*time*/,
-    const int /*level*/) noexcept
+    const int /*level*/,
+    ProbParmDevice const& d_prob_parm_device) noexcept
   {
     // could do problem specific tagging here
   }

--- a/Exec/RegTests/TG/prob.H
+++ b/Exec/RegTests/TG/prob.H
@@ -108,7 +108,7 @@ struct MyProbTagStruct
     const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> /*prob_lo*/,
     const amrex::Real /*time*/,
     const int /*level*/,
-    ProbParmDevice const& d_prob_parm_device) noexcept
+    ProbParmDevice /*const& d_prob_parm_device*/) noexcept
   {
     // could do problem specific tagging here
   }

--- a/Exec/UnitTests/prob.H
+++ b/Exec/UnitTests/prob.H
@@ -46,7 +46,8 @@ struct MyProbTagStruct
     const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> /*dx*/,
     const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> /*prob_lo*/,
     const amrex::Real /*time*/,
-    const int /*level*/) noexcept
+    const int /*level*/,
+    ProbParmDevice const& d_prob_parm_device) noexcept
   {
     // could do problem specific tagging here
   }

--- a/Exec/UnitTests/prob.H
+++ b/Exec/UnitTests/prob.H
@@ -47,7 +47,7 @@ struct MyProbTagStruct
     const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> /*prob_lo*/,
     const amrex::Real /*time*/,
     const int /*level*/,
-    ProbParmDevice const& d_prob_parm_device) noexcept
+    ProbParmDevice const& /*d_prob_parm_device*/) noexcept
   {
     // could do problem specific tagging here
   }

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -1762,6 +1762,7 @@ PeleC::errorEst(
 #endif
 
       // Problem specific tagging
+      const ProbParmDevice* lprobparm = d_prob_parm_device;
       const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx =
         geom.CellSizeArray();
       const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo =
@@ -1770,7 +1771,8 @@ PeleC::errorEst(
       amrex::ParallelFor(
         tilebox, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
           set_problem_tags<ProblemTags>(
-            i, j, k, tag_arr, Sfab, tagval, dx, prob_lo, time, captured_level);
+            i, j, k, tag_arr, Sfab, tagval, dx, prob_lo, time, captured_level,
+            *lprobparm);
         });
 
       // Now update the tags in the TagBox.

--- a/Source/Tagging.H
+++ b/Source/Tagging.H
@@ -3,6 +3,7 @@
 
 #include <AMReX_FArrayBox.H>
 #include <AMReX_TagBox.H>
+#include "prob_parm.H"
 
 struct TaggingParm
 {
@@ -140,7 +141,8 @@ struct EmptyProbTagStruct
     const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> /*dx*/,
     const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> /*prob_lo*/,
     const amrex::Real /*time*/,
-    const int /*level*/) noexcept
+    const int /*level*/,
+    ProbParmDevice const& d_prob_parm_device) noexcept
   {
   }
 };

--- a/Source/Tagging.H
+++ b/Source/Tagging.H
@@ -142,7 +142,7 @@ struct EmptyProbTagStruct
     const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> /*prob_lo*/,
     const amrex::Real /*time*/,
     const int /*level*/,
-    ProbParmDevice const& d_prob_parm_device) noexcept
+    ProbParmDevice const& /*d_prob_parm_device*/) noexcept
   {
   }
 };


### PR DESCRIPTION
These changes make it possible to have user defined inputs (example: a Tensorflow model) for tagging. 