### PR TITLE
No chem source in E eqn in docs

### DIFF
--- a/Docs/sphinx/Equations.rst
+++ b/Docs/sphinx/Equations.rst
@@ -24,7 +24,7 @@ PeleC advances the following set of fully compressible equations for the conserv
 
   \frac{\partial (\rho \mathbf{u})}{\partial t} &=& - \nabla \cdot (\rho \mathbf{u} \mathbf{u} -p{\mathcal I} + \Pi) - \nabla p +\rho \mathbf{g} + \mathbf{S}_{{\rm ext},\rho\mathbf{u}},
 
-  \frac{\partial (\rho E)}{\partial t} &=& - \nabla \cdot (\rho \mathbf{u} E + p \mathbf{u}) + \rho \mathbf{u} \cdot \mathbf{g} - \sum_k {\rho q_k \dot\omega_k} + \nabla\cdot \boldsymbol{\mathcal{Q}}+ S_{{\rm ext},\rho E},
+  \frac{\partial (\rho E)}{\partial t} &=& - \nabla \cdot (\rho \mathbf{u} E + p \mathbf{u}) + \rho \mathbf{u} \cdot \mathbf{g} + \nabla\cdot \boldsymbol{\mathcal{Q}}+ S_{{\rm ext},\rho E},
 
   \frac{\partial (\rho Y_k)}{\partial t} &=& - \nabla \cdot (\rho \mathbf{u} Y_k)
   - \nabla \cdot \boldsymbol{\mathcal{F}}_{k} + \rho \dot\omega_k + S_{{\rm ext},\rho Y_k},

--- a/Docs/sphinx/Equations.rst
+++ b/Docs/sphinx/Equations.rst
@@ -36,9 +36,11 @@ PeleC advances the following set of fully compressible equations for the conserv
 
 
 Here :math:`\rho, \mathbf{u}, T`, and :math:`p` are the density, velocity,
-temperature and pressure, respectively, and :math:`E
+temperature and pressure, respectively. :math:`E
 = e + \mathbf{u} \cdot \mathbf{u} / 2` is the total energy with :math:`e` representing the
-internal energy.  :math:`Y_k` is the mass fraction of the :math:`k^{\rm th}` species,
+internal energy, which is defined as in the CHEMKIN standard to include both sensible
+and chemical energy (species heats of formation) and is conserved across chemical reactions.
+:math:`Y_k` is the mass fraction of the :math:`k^{\rm th}` species,
 with associated production rate, :math:`\dot\omega_k`.  Here :math:`\mathbf{g}` is the gravitational vector, and
 :math:`S_{{\rm ext},\rho}, \mathbf{S}_{{\rm ext},\rho\mathbf{u}}`, etc., are user-specified
 source terms.  :math:`A_k` is an advected quantity, i.e., a tracer.  Also


### PR DESCRIPTION
The chemical reaction term in the energy equation in the documentation seems to be extraneous, so this PR removes it. 

On a related note, we compute an entry in I_R for total energy: https://github.com/AMReX-Combustion/PeleC/blob/8f248555c1e7d809597049a18d024c4045c5d1c9/Source/React.cpp#L288, but as far as I can tell it reduces to 0 (within numerical precision), as I would expect, at least for a purely gas phase system. Is there any reason not to simplify the code and simply set the value to 0 directly?