### PR TITLE
Adding Lax Friedrich's flux

### DIFF
--- a/Source/Diffusion.cpp
+++ b/Source/Diffusion.cpp
@@ -391,7 +391,7 @@ PeleC::getMOLSrcTerm(
 #endif
           // auto const& vol = volume.array(mfi);
           pc_compute_hyp_mol_flux(
-            cbox, qar, qauxar, flx, area_arr, dx, plm_iorder
+            cbox, qar, qauxar, flx, area_arr, dx, plm_iorder,use_laxf_flux
 #ifdef PELEC_USE_EB
             ,
             flags.array(mfi), d_sv_eb_bndry_geom, Ncut, d_eb_flux_thdlocal,

--- a/Source/Diffusion.cpp
+++ b/Source/Diffusion.cpp
@@ -391,7 +391,7 @@ PeleC::getMOLSrcTerm(
 #endif
           // auto const& vol = volume.array(mfi);
           pc_compute_hyp_mol_flux(
-            cbox, qar, qauxar, flx, area_arr, dx, plm_iorder,use_laxf_flux
+            cbox, qar, qauxar, flx, area_arr, dx, plm_iorder, use_laxf_flux
 #ifdef PELEC_USE_EB
             ,
             flags.array(mfi), d_sv_eb_bndry_geom, Ncut, d_eb_flux_thdlocal,

--- a/Source/MOL.H
+++ b/Source/MOL.H
@@ -111,7 +111,8 @@ void pc_compute_hyp_mol_flux(
   const amrex::GpuArray<const amrex::Array4<const amrex::Real>, AMREX_SPACEDIM>
     area,
   const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> del,
-  const int plm_iorder
+  const int plm_iorder,
+  const int use_laxf_flux
 #ifdef PELEC_USE_EB
   ,
   const amrex::Array4<amrex::EBCellFlag const>& flags,

--- a/Source/MOL.cpp
+++ b/Source/MOL.cpp
@@ -153,8 +153,7 @@ pc_compute_hyp_mol_flux(
             qtempl[R_P], spl, qtempr[R_RHO], qtempr[R_UN], qtempr[R_UT1],
             qtempr[R_UT2], qtempr[R_P], spr, bc_test_val, cavg, ustar,
             flux_tmp[URHO], flux_tmp[f_idx[0]], flux_tmp[f_idx[1]],
-            flux_tmp[f_idx[2]], flux_tmp[UEDEN], flux_tmp[UEINT], tmp0, tmp1,
-            tmp2, tmp3, tmp4);
+            flux_tmp[f_idx[2]], flux_tmp[UEDEN], flux_tmp[UEINT]);
         }
 
         for (int n = 0; n < NUM_SPECIES; n++) {

--- a/Source/MOL.cpp
+++ b/Source/MOL.cpp
@@ -139,25 +139,22 @@ pc_compute_hyp_mol_flux(
         amrex::Real tmp3 = 0.0;
         amrex::Real tmp4 = 0.0;
 
-        if(!use_laxf_flux)
-        {
+        if (!use_laxf_flux) {
           riemann(
-          qtempl[R_RHO], qtempl[R_UN], qtempl[R_UT1], qtempl[R_UT2],
-          qtempl[R_P], spl, qtempr[R_RHO], qtempr[R_UN], qtempr[R_UT1],
-          qtempr[R_UT2], qtempr[R_P], spr, bc_test_val, cavg, ustar,
-          flux_tmp[URHO], flux_tmp[f_idx[0]], flux_tmp[f_idx[1]],
-          flux_tmp[f_idx[2]], flux_tmp[UEDEN], flux_tmp[UEINT], tmp0, tmp1,
-          tmp2, tmp3, tmp4);
-        }
-        else
-        {
+            qtempl[R_RHO], qtempl[R_UN], qtempl[R_UT1], qtempl[R_UT2],
+            qtempl[R_P], spl, qtempr[R_RHO], qtempr[R_UN], qtempr[R_UT1],
+            qtempr[R_UT2], qtempr[R_P], spr, bc_test_val, cavg, ustar,
+            flux_tmp[URHO], flux_tmp[f_idx[0]], flux_tmp[f_idx[1]],
+            flux_tmp[f_idx[2]], flux_tmp[UEDEN], flux_tmp[UEINT], tmp0, tmp1,
+            tmp2, tmp3, tmp4);
+        } else {
           laxfriedrich_flux(
-          qtempl[R_RHO], qtempl[R_UN], qtempl[R_UT1], qtempl[R_UT2],
-          qtempl[R_P], spl, qtempr[R_RHO], qtempr[R_UN], qtempr[R_UT1],
-          qtempr[R_UT2], qtempr[R_P], spr, bc_test_val, cavg, ustar,
-          flux_tmp[URHO], flux_tmp[f_idx[0]], flux_tmp[f_idx[1]],
-          flux_tmp[f_idx[2]], flux_tmp[UEDEN], flux_tmp[UEINT], tmp0, tmp1,
-          tmp2, tmp3, tmp4);
+            qtempl[R_RHO], qtempl[R_UN], qtempl[R_UT1], qtempl[R_UT2],
+            qtempl[R_P], spl, qtempr[R_RHO], qtempr[R_UN], qtempr[R_UT1],
+            qtempr[R_UT2], qtempr[R_P], spr, bc_test_val, cavg, ustar,
+            flux_tmp[URHO], flux_tmp[f_idx[0]], flux_tmp[f_idx[1]],
+            flux_tmp[f_idx[2]], flux_tmp[UEDEN], flux_tmp[UEINT], tmp0, tmp1,
+            tmp2, tmp3, tmp4);
         }
 
         for (int n = 0; n < NUM_SPECIES; n++) {

--- a/Source/MOL.cpp
+++ b/Source/MOL.cpp
@@ -13,7 +13,8 @@ pc_compute_hyp_mol_flux(
     del
 #endif
   ,
-  const int plm_iorder
+  const int plm_iorder,
+  const int use_laxf_flux
 #ifdef PELEC_USE_EB
   ,
   const amrex::Array4<amrex::EBCellFlag const>& flags,
@@ -137,13 +138,27 @@ pc_compute_hyp_mol_flux(
         amrex::Real tmp2 = 0.0;
         amrex::Real tmp3 = 0.0;
         amrex::Real tmp4 = 0.0;
-        riemann(
+
+        if(!use_laxf_flux)
+        {
+          riemann(
           qtempl[R_RHO], qtempl[R_UN], qtempl[R_UT1], qtempl[R_UT2],
           qtempl[R_P], spl, qtempr[R_RHO], qtempr[R_UN], qtempr[R_UT1],
           qtempr[R_UT2], qtempr[R_P], spr, bc_test_val, cavg, ustar,
           flux_tmp[URHO], flux_tmp[f_idx[0]], flux_tmp[f_idx[1]],
           flux_tmp[f_idx[2]], flux_tmp[UEDEN], flux_tmp[UEINT], tmp0, tmp1,
           tmp2, tmp3, tmp4);
+        }
+        else
+        {
+          laxfriedrich_flux(
+          qtempl[R_RHO], qtempl[R_UN], qtempl[R_UT1], qtempl[R_UT2],
+          qtempl[R_P], spl, qtempr[R_RHO], qtempr[R_UN], qtempr[R_UT1],
+          qtempr[R_UT2], qtempr[R_P], spr, bc_test_val, cavg, ustar,
+          flux_tmp[URHO], flux_tmp[f_idx[0]], flux_tmp[f_idx[1]],
+          flux_tmp[f_idx[2]], flux_tmp[UEDEN], flux_tmp[UEINT], tmp0, tmp1,
+          tmp2, tmp3, tmp4);
+        }
 
         for (int n = 0; n < NUM_SPECIES; n++) {
           flux_tmp[UFS + n] = (ustar > 0.0) ? flux_tmp[URHO] * qtempl[R_Y + n]

--- a/Source/Params/_cpp_parameters
+++ b/Source/Params/_cpp_parameters
@@ -123,6 +123,9 @@ hybrid_riemann               int           0
 # this is deprecated---use {\tt riemann\_solver} instead
 use_colglaz                  int           -1
 
+# Lax Friedrich's flux
+use_laxf_flux                int            0
+
 # which Riemann solver do we use:
 # 0: Colella, Glaz, \& Ferguson (a two-shock solver);
 # 1: Colella \& Glaz (a two-shock solver)

--- a/Source/Params/param_includes/pelec_defaults.H
+++ b/Source/Params/param_includes/pelec_defaults.H
@@ -35,6 +35,7 @@ int PeleC::ppm_reference_eigenvectors = 0;
 int PeleC::plm_iorder = 2;
 int PeleC::hybrid_riemann = 0;
 int PeleC::use_colglaz = -1;
+int PeleC::use_laxf_flux = 0;
 int PeleC::riemann_solver = 0;
 int PeleC::cg_maxiter = 12;
 amrex::Real PeleC::cg_tol = 1.0e-5;
@@ -93,11 +94,7 @@ amrex::Real PeleC::react_T_max = 1.e200;
 amrex::Real PeleC::react_rho_min = 0.0;
 amrex::Real PeleC::react_rho_max = 1.e200;
 int PeleC::disable_shock_burning = 0;
-#ifdef USE_SUNDIALS_PP
-int PeleC::chem_integrator = 2;
-#else
 int PeleC::chem_integrator = 1;
-#endif
 int PeleC::adaptrk_nsubsteps_min = 20;
 int PeleC::adaptrk_nsubsteps_max = 300;
 int PeleC::adaptrk_nsubsteps_guess = 50;

--- a/Source/Params/param_includes/pelec_defaults.H
+++ b/Source/Params/param_includes/pelec_defaults.H
@@ -94,7 +94,11 @@ amrex::Real PeleC::react_T_max = 1.e200;
 amrex::Real PeleC::react_rho_min = 0.0;
 amrex::Real PeleC::react_rho_max = 1.e200;
 int PeleC::disable_shock_burning = 0;
+#ifdef USE_SUNDIALS_PP
+int PeleC::chem_integrator = 2;
+#else
 int PeleC::chem_integrator = 1;
+#endif
 int PeleC::adaptrk_nsubsteps_min = 20;
 int PeleC::adaptrk_nsubsteps_max = 300;
 int PeleC::adaptrk_nsubsteps_guess = 50;

--- a/Source/Params/param_includes/pelec_params.H
+++ b/Source/Params/param_includes/pelec_params.H
@@ -35,6 +35,7 @@ static int ppm_reference_eigenvectors;
 static int plm_iorder;
 static int hybrid_riemann;
 static int use_colglaz;
+static int use_laxf_flux;
 static int riemann_solver;
 static int cg_maxiter;
 static amrex::Real cg_tol;

--- a/Source/Params/param_includes/pelec_queries.H
+++ b/Source/Params/param_includes/pelec_queries.H
@@ -35,6 +35,7 @@ pp.query("ppm_reference_eigenvectors", ppm_reference_eigenvectors);
 pp.query("plm_iorder", plm_iorder);
 pp.query("hybrid_riemann", hybrid_riemann);
 pp.query("use_colglaz", use_colglaz);
+pp.query("use_laxf_flux", use_laxf_flux);
 pp.query("riemann_solver", riemann_solver);
 pp.query("cg_maxiter", cg_maxiter);
 pp.query("cg_tol", cg_tol);

--- a/Source/Riemann.H
+++ b/Source/Riemann.H
@@ -187,8 +187,8 @@ laxfriedrich_flux(
   const amrex::Real v2r,
   const amrex::Real pr,
   const amrex::Real spr[NUM_SPECIES],
-  const int bc_test_val,
-  const amrex::Real cav,
+  const int,
+  const amrex::Real,
   amrex::Real& ustar,
   amrex::Real& uflx_rho,
   amrex::Real& uflx_u,
@@ -196,11 +196,11 @@ laxfriedrich_flux(
   amrex::Real& uflx_w,
   amrex::Real& uflx_eden,
   amrex::Real& uflx_eint,
-  amrex::Real& qint_iu,
-  amrex::Real& qint_iv1,
-  amrex::Real& qint_iv2,
-  amrex::Real& qint_gdpres,
-  amrex::Real& qint_gdgame)
+  amrex::Real&,
+  amrex::Real&,
+  amrex::Real&,
+  amrex::Real&,
+  amrex::Real&)
 {
 
   const amrex::Real wsmall = std::numeric_limits<amrex::Real>::min();
@@ -240,7 +240,7 @@ laxfriedrich_flux(
   ustar = mask ? 0.0 : ustar;
 
   amrex::Real chalf = 0.5 * (cr + cl);
-  amrex::Real max_wavespd = abs(ustar) + chalf;
+  amrex::Real max_wavespd = amrex::Math::abs(ustar) + chalf;
 
   // density eqn
   uflx_rho = 0.5 * ((rl * ul + rr * ur) - max_wavespd * (rr - rl));

--- a/Source/Riemann.H
+++ b/Source/Riemann.H
@@ -195,12 +195,7 @@ laxfriedrich_flux(
   amrex::Real& uflx_v,
   amrex::Real& uflx_w,
   amrex::Real& uflx_eden,
-  amrex::Real& uflx_eint,
-  amrex::Real&,
-  amrex::Real&,
-  amrex::Real&,
-  amrex::Real&,
-  amrex::Real&)
+  amrex::Real& uflx_eint)
 {
 
   const amrex::Real wsmall = std::numeric_limits<amrex::Real>::min();

--- a/Source/Riemann.H
+++ b/Source/Riemann.H
@@ -171,4 +171,88 @@ riemann(
   uflx_eint = qint_iu * regd;
 }
 
+AMREX_GPU_DEVICE
+AMREX_FORCE_INLINE
+void
+laxfriedrich_flux(
+  const amrex::Real rl,
+  const amrex::Real ul,
+  const amrex::Real vl,
+  const amrex::Real v2l,
+  const amrex::Real pl,
+  const amrex::Real spl[NUM_SPECIES],
+  const amrex::Real rr,
+  const amrex::Real ur,
+  const amrex::Real vr,
+  const amrex::Real v2r,
+  const amrex::Real pr,
+  const amrex::Real spr[NUM_SPECIES],
+  const int bc_test_val,
+  const amrex::Real cav,
+  amrex::Real& ustar,
+  amrex::Real& uflx_rho,
+  amrex::Real& uflx_u,
+  amrex::Real& uflx_v,
+  amrex::Real& uflx_w,
+  amrex::Real& uflx_eden,
+  amrex::Real& uflx_eint,
+  amrex::Real& qint_iu,
+  amrex::Real& qint_iv1,
+  amrex::Real& qint_iv2,
+  amrex::Real& qint_gdpres,
+  amrex::Real& qint_gdgame)
+{
+
+  const amrex::Real wsmall = std::numeric_limits<amrex::Real>::min();
+
+  auto eos = pele::physics::PhysicsType::eos();
+
+  amrex::Real cl = 0.0;
+  amrex::Real mfrac_l[NUM_SPECIES];
+  amrex::Real mfrac_r[NUM_SPECIES];
+  for (int n = 0; n < NUM_SPECIES; n++) {
+    mfrac_l[n] = spl[n];
+    mfrac_r[n] = spr[n];
+  }
+  eos.RPY2Cs(rl, pl, mfrac_l, cl);
+
+  amrex::Real cr = 0.0;
+  eos.RPY2Cs(rr, pr, mfrac_r, cr);
+
+  amrex::Real el = 0.0;
+  eos.RYP2E(rl, mfrac_l, pl, el);
+
+  amrex::Real er = 0.0;
+  eos.RYP2E(rr, mfrac_r, pr, er);
+
+  //rho e total
+  amrex::Real r_elt =rl*(el + 0.5*(ul*ul + vl*vl + v2l*v2l));
+  amrex::Real r_ert =rr*(er + 0.5*(ur*ur + vr*vr + v2r*v2r));
+
+  const amrex::Real wl = amrex::max<amrex::Real>(wsmall, cl * rl);
+  const amrex::Real wr = amrex::max<amrex::Real>(wsmall, cr * rr);
+  ustar = ((wl * ul + wr * ur) + (pl - pr)) / (wl + wr);
+
+  bool mask = amrex::Math::abs(ustar) < constants::smallu() * 0.5 *
+       (amrex::Math::abs(ul) + amrex::Math::abs(ur)) || ustar == 0.0;
+  ustar = mask ? 0.0 : ustar;
+
+  amrex::Real chalf=0.5*(cr+cl);
+  amrex::Real max_wavespd=abs(ustar)+chalf;
+
+  //density eqn
+  uflx_rho = 0.5* ( (rl*ul + rr*ur)                  - max_wavespd*(rr-rl));
+
+  //three momentum eqns
+  uflx_u   = 0.5* ( (rl*ul*ul  + pl + rr*ur*ur + pr) - max_wavespd*  (rr*ur-rl*ul));
+  uflx_v   = 0.5* ( (rl*vl*ul  + rr*vr*ur)           - max_wavespd*  (rr*vr-rl*vl));
+  uflx_w   = 0.5* ( (rl*v2l*ul + rr*v2r*ur)          - max_wavespd*(rr*v2r-rl*v2l));
+  
+  //total energy eqn
+  uflx_eden = 0.5*(( (r_elt + pl)*ul + (r_ert + pr)*ur ) - max_wavespd*(r_ert-r_elt) );
+
+  //not really used
+  uflx_eint = 0.5*( (rl*el*ul + rr*er*ur) - max_wavespd*(rr*er-rl*el) );
+
+}
 #endif

--- a/Source/Riemann.H
+++ b/Source/Riemann.H
@@ -225,34 +225,40 @@ laxfriedrich_flux(
   amrex::Real er = 0.0;
   eos.RYP2E(rr, mfrac_r, pr, er);
 
-  //rho e total
-  amrex::Real r_elt =rl*(el + 0.5*(ul*ul + vl*vl + v2l*v2l));
-  amrex::Real r_ert =rr*(er + 0.5*(ur*ur + vr*vr + v2r*v2r));
+  // rho e total
+  amrex::Real r_elt = rl * (el + 0.5 * (ul * ul + vl * vl + v2l * v2l));
+  amrex::Real r_ert = rr * (er + 0.5 * (ur * ur + vr * vr + v2r * v2r));
 
   const amrex::Real wl = amrex::max<amrex::Real>(wsmall, cl * rl);
   const amrex::Real wr = amrex::max<amrex::Real>(wsmall, cr * rr);
   ustar = ((wl * ul + wr * ur) + (pl - pr)) / (wl + wr);
 
-  bool mask = amrex::Math::abs(ustar) < constants::smallu() * 0.5 *
-       (amrex::Math::abs(ul) + amrex::Math::abs(ur)) || ustar == 0.0;
+  bool mask =
+    amrex::Math::abs(ustar) < constants::smallu() * 0.5 *
+                                (amrex::Math::abs(ul) + amrex::Math::abs(ur)) ||
+    ustar == 0.0;
   ustar = mask ? 0.0 : ustar;
 
-  amrex::Real chalf=0.5*(cr+cl);
-  amrex::Real max_wavespd=abs(ustar)+chalf;
+  amrex::Real chalf = 0.5 * (cr + cl);
+  amrex::Real max_wavespd = abs(ustar) + chalf;
 
-  //density eqn
-  uflx_rho = 0.5* ( (rl*ul + rr*ur)                  - max_wavespd*(rr-rl));
+  // density eqn
+  uflx_rho = 0.5 * ((rl * ul + rr * ur) - max_wavespd * (rr - rl));
 
-  //three momentum eqns
-  uflx_u   = 0.5* ( (rl*ul*ul  + pl + rr*ur*ur + pr) - max_wavespd*  (rr*ur-rl*ul));
-  uflx_v   = 0.5* ( (rl*vl*ul  + rr*vr*ur)           - max_wavespd*  (rr*vr-rl*vl));
-  uflx_w   = 0.5* ( (rl*v2l*ul + rr*v2r*ur)          - max_wavespd*(rr*v2r-rl*v2l));
-  
-  //total energy eqn
-  uflx_eden = 0.5*(( (r_elt + pl)*ul + (r_ert + pr)*ur ) - max_wavespd*(r_ert-r_elt) );
+  // three momentum eqns
+  uflx_u = 0.5 * ((rl * ul * ul + pl + rr * ur * ur + pr) -
+                  max_wavespd * (rr * ur - rl * ul));
+  uflx_v =
+    0.5 * ((rl * vl * ul + rr * vr * ur) - max_wavespd * (rr * vr - rl * vl));
+  uflx_w = 0.5 * ((rl * v2l * ul + rr * v2r * ur) -
+                  max_wavespd * (rr * v2r - rl * v2l));
 
-  //not really used
-  uflx_eint = 0.5*( (rl*el*ul + rr*er*ur) - max_wavespd*(rr*er-rl*el) );
+  // total energy eqn
+  uflx_eden = 0.5 * (((r_elt + pl) * ul + (r_ert + pr) * ur) -
+                     max_wavespd * (r_ert - r_elt));
 
+  // not really used
+  uflx_eint =
+    0.5 * ((rl * el * ul + rr * er * ur) - max_wavespd * (rr * er - rl * el));
 }
 #endif


### PR DESCRIPTION
It is only slightly more diffusive than MOL. This scheme could be more robust with complicated EOSs. See below for SOD shock tube density solution with a close up at the contact discontinuty.

![compare](https://user-images.githubusercontent.com/7399475/132397011-51efde98-aa86-48e3-9220-f25d13711be2.png)
![fig1](https://user-images.githubusercontent.com/7399475/132397120-1bc9bd43-60f5-4168-89a2-ce1c695210f1.png)
