### PR TITLE
Tag all cut cells.

### DIFF
--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -1758,6 +1758,16 @@ PeleC::errorEst(
           tilebox, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
             tag_error_bounds(i, j, k, tag_arr, vfrac_arr, 0.0, 1.0, tagval);
           });
+
+        const int local_i = mfi.LocalIndex();
+        const int Nebg = (!eb_in_domain) ? 0 : sv_eb_bndry_geom[local_i].size();
+        EBBndryGeom* ebg = sv_eb_bndry_geom[local_i].data();
+        amrex::ParallelFor(Nebg, [=] AMREX_GPU_DEVICE(int L) {
+          const auto& iv = ebg[L].iv;
+          if (tilebox.contains(iv)) {
+            tag_arr(iv) = tagval;
+          }
+        });
       }
 #endif
 


### PR DESCRIPTION
The previous version of the code has issues for coordinate aligned EB geometry. 

For example: 
This box with coordinate aligned geometry does not get refined on the finer level. Because the current tagging is on 0<vfrac<1, the coarse level is never tagged for refinement. 
![Screen Shot 2021-09-14 at 10 28 01 AM](https://user-images.githubusercontent.com/15038415/133296865-daa1b1e7-da05-4b64-a9d7-d51bc66ab2e6.png)

However, this PR introduces an additional loop on cut cells and those are tagged for refinement. The same case now leads to this refinement:
![Screen Shot 2021-09-14 at 10 30 21 AM](https://user-images.githubusercontent.com/15038415/133297229-5dd300dd-443b-4f77-acd0-2fbab31fb74d.png)

