### PR TITLE
Fix derived variables with gradients at EB's

### DIFF
--- a/Source/Derive.H
+++ b/Source/Derive.H
@@ -8,6 +8,56 @@
 using namespace MASA;
 #endif
 
+#ifdef PELEC_USE_EB
+#include "EB.H"
+#endif
+
+AMREX_GPU_DEVICE
+AMREX_FORCE_INLINE
+void
+get_idx(const int i, int& im, int& ip)
+{
+  im = i - 1;
+  ip = i + 1;
+}
+
+#ifdef PELEC_USE_EB
+AMREX_GPU_DEVICE
+AMREX_FORCE_INLINE
+void
+get_idx(
+  const int i,
+  const int dir,
+  const bool all_regular,
+  const amrex::EBCellFlag& flag,
+  int& im,
+  int& ip)
+{
+  if (all_regular) {
+    get_idx(i, im, ip);
+  } else {
+    if (flag.isCovered()) {
+      im = i;
+      ip = i;
+    } else {
+      const amrex::IntVect ivm = -amrex::IntVect::TheDimensionVector(dir);
+      const amrex::IntVect ivp = amrex::IntVect::TheDimensionVector(dir);
+      im = i - flag.isConnected(ivm);
+      ip = i + flag.isConnected(ivp);
+    }
+  }
+}
+#endif
+
+AMREX_GPU_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+get_weight(const int im, const int ip)
+{
+  const int diff = ip - im;
+  return diff == 0 ? 0.0 : (diff == 1 ? 1.0 : 0.5);
+}
+
 void pc_dervelx(
   const amrex::Box& bx,
   amrex::FArrayBox& derfab,

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -1547,7 +1547,8 @@ PeleC::errorEst(
 
   amrex::MultiFab S_data(
     get_new_data(State_Type).boxArray(),
-    get_new_data(State_Type).DistributionMap(), NVAR, 1);
+    get_new_data(State_Type).DistributionMap(), NVAR, 1, amrex::MFInfo(),
+    *m_factory);
   const amrex::Real cur_time = state[State_Type].curTime();
   FillPatch(
     *this, S_data, S_data.nGrow(), cur_time, State_Type, Density, NVAR, 0);


### PR DESCRIPTION
Quantities derived from gradients were incorrect at EB boundaries. They would use the state body values and we would see weirdness. This affected `divu`, `enstrophy`, and `magvort`. This PR fixes that.

A good illustration is the EB-C14 case (shock-ramp interaction).

Before this PR:
![Screen Shot 2021-09-15 at 3 54 06 PM](https://user-images.githubusercontent.com/15038415/133514955-e29f49e4-1c6a-45a2-8948-2388511fc476.png)

With this PR:

![Screen Shot 2021-09-15 at 3 52 25 PM](https://user-images.githubusercontent.com/15038415/133514766-c18c88f9-fa1a-4ef1-b58b-8a39b1333faf.png)

