### PR TITLE
Enable restarting from inert run and other fixes

### DIFF
--- a/Source/Derive.cpp
+++ b/Source/Derive.cpp
@@ -247,7 +247,7 @@ pc_dermagvort(
   const auto& flag_fab = amrex::getEBCellFlagFab(derfab);
   const auto& typ = flag_fab.getType(bx);
   if (typ == amrex::FabType::covered) {
-    derfab.setVal<amrex::RunOn::Device>(0.0);
+    derfab.setVal<amrex::RunOn::Device>(0.0, bx);
     return;
   }
   const auto& flags = flag_fab.const_array();
@@ -320,7 +320,7 @@ pc_derdivu(
   const auto& flag_fab = amrex::getEBCellFlagFab(derfab);
   const auto& typ = flag_fab.getType(bx);
   if (typ == amrex::FabType::covered) {
-    derfab.setVal<amrex::RunOn::Device>(0.0);
+    derfab.setVal<amrex::RunOn::Device>(0.0, bx);
     return;
   }
   const auto& flags = flag_fab.const_array();
@@ -386,7 +386,7 @@ pc_derenstrophy(
   const auto& flag_fab = amrex::getEBCellFlagFab(derfab);
   const auto& typ = flag_fab.getType(bx);
   if (typ == amrex::FabType::covered) {
-    derfab.setVal<amrex::RunOn::Device>(0.0);
+    derfab.setVal<amrex::RunOn::Device>(0.0, bx);
     return;
   }
   const auto& flags = flag_fab.const_array();

--- a/Source/Derive.cpp
+++ b/Source/Derive.cpp
@@ -244,8 +244,8 @@ pc_dermagvort(
   auto larr = local.array();
 
 #ifdef PELEC_USE_EB
-  const auto& flag_fab = amrex::getEBCellFlagFab(datfab);
-  const auto& typ = flag_fab.getType(gbx);
+  const auto& flag_fab = amrex::getEBCellFlagFab(derfab);
+  const auto& typ = flag_fab.getType(bx);
   if (typ == amrex::FabType::covered) {
     derfab.setVal<amrex::RunOn::Device>(0.0);
     return;
@@ -317,9 +317,8 @@ pc_derdivu(
   auto divu = derfab.array();
 
 #ifdef PELEC_USE_EB
-  const amrex::Box& gbx = amrex::grow(bx, 1);
-  const auto& flag_fab = amrex::getEBCellFlagFab(datfab);
-  const auto& typ = flag_fab.getType(gbx);
+  const auto& flag_fab = amrex::getEBCellFlagFab(derfab);
+  const auto& typ = flag_fab.getType(bx);
   if (typ == amrex::FabType::covered) {
     derfab.setVal<amrex::RunOn::Device>(0.0);
     return;
@@ -384,8 +383,8 @@ pc_derenstrophy(
   auto larr = local.array();
 
 #ifdef PELEC_USE_EB
-  const auto& flag_fab = amrex::getEBCellFlagFab(datfab);
-  const auto& typ = flag_fab.getType(gbx);
+  const auto& flag_fab = amrex::getEBCellFlagFab(derfab);
+  const auto& typ = flag_fab.getType(bx);
   if (typ == amrex::FabType::covered) {
     derfab.setVal<amrex::RunOn::Device>(0.0);
     return;

--- a/Source/Diffusion.cpp
+++ b/Source/Diffusion.cpp
@@ -528,7 +528,7 @@ PeleC::getMOLSrcTerm(
           if (fr_as_fine) {
             dm_as_fine.resize(amrex::grow(vbox, 1), NVAR);
             dm_as_fine_eli = dm_as_fine.elixir();
-            dm_as_fine.setVal<amrex::RunOn::Device>(0.0);
+            dm_as_fine.setVal<amrex::RunOn::Device>(0.0, amrex::grow(vbox, 1));
           }
           if (Ncut > 0) {
             BL_PROFILE("PeleC::pc_eb_div()");
@@ -541,7 +541,7 @@ PeleC::getMOLSrcTerm(
 
         if (do_reflux && flux_factor != 0) {
           for (auto& dir : flux_ec) {
-            dir.mult<amrex::RunOn::Device>(flux_factor);
+            dir.mult<amrex::RunOn::Device>(flux_factor, dir.box());
           }
 
           if (fr_as_crse) {
@@ -645,7 +645,7 @@ PeleC::getMOLSrcTerm(
 
         amrex::FArrayBox tmpfab(Dfab.box(), S.nComp());
         if (redistribution_type == "FluxRedist") {
-          tmpfab.setVal<amrex::RunOn::Device>(1.0);
+          tmpfab.setVal<amrex::RunOn::Device>(1.0, tmpfab.box());
         }
         amrex::Elixir tmpeli = tmpfab.elixir();
         amrex::Array4<amrex::Real> scratch = tmpfab.array();

--- a/Source/EB.H
+++ b/Source/EB.H
@@ -66,12 +66,11 @@ pc_set_body_state(
   const int j,
   const int k,
   const int n,
-  const amrex::Array4<const int>& mask,
+  const amrex::Array4<const amrex::EBCellFlag>& flags,
   const amrex::GpuArray<amrex::Real, NVAR> body_state,
-  const int covered_val,
   const amrex::Array4<amrex::Real>& S)
 {
-  if (mask(i, j, k) == covered_val) {
+  if (flags(i, j, k).isCovered()) {
     S(i, j, k, n) = body_state[n];
   }
 }

--- a/Source/IO.cpp
+++ b/Source/IO.cpp
@@ -64,12 +64,6 @@ PeleC::check_state_in_checkpoint(const StateType state_type)
       }
     }
   }
-  if (amrex::ParallelDescriptor::IOProcessor()) {
-    amrex::Warning(
-      "StateType " + std::to_string(state_type) +
-      " was not found in checkpoint " + filename + " at level " +
-      std::to_string(level) + ". Ensure this was intended");
-  }
   return false;
 }
 

--- a/Source/IO.cpp
+++ b/Source/IO.cpp
@@ -226,6 +226,11 @@ PeleC::set_state_in_checkpoint(amrex::Vector<int>& state_in_checkpoint)
   for (int i = 0; i < num_state_type; ++i) {
     state_in_checkpoint[i] = 1;
 
+    const bool reactions_type_not_in_chk = true;
+    if ((i == Reactions_Type) && (reactions_type_not_in_chk)) {
+      state_in_checkpoint[i] = 0;
+    }
+
     if (i == Work_Estimate_Type) {
       state_in_checkpoint[i] = 0;
     }

--- a/Source/IO.cpp
+++ b/Source/IO.cpp
@@ -257,7 +257,7 @@ PeleC::set_state_in_checkpoint(amrex::Vector<int>& state_in_checkpoint)
 
     if (i == State_Type) {
       state_in_checkpoint[i] = 1;
-      if (!is_present) {
+      if ((!is_present) && (level == 0)) {
         amrex::Abort("State_Type is not present in the checkpoint file");
       }
     } else if (i == Reactions_Type) {

--- a/Source/IO.cpp
+++ b/Source/IO.cpp
@@ -108,6 +108,7 @@ PeleC::restart(amrex::Amr& papa, std::istream& is, bool bReadSpecial)
       state[i].define(
         geom.Domain(), grids, dmap, desc_lst[i], ctime, parent->dtLevel(level),
         *m_factory);
+      get_new_data(i).setVal(0.0);
     }
   }
   buildMetrics();

--- a/Source/IO.cpp
+++ b/Source/IO.cpp
@@ -265,15 +265,15 @@ PeleC::set_state_in_checkpoint(amrex::Vector<int>& state_in_checkpoint)
       if (!is_present) {
         amrex::Abort("State_Type is not present in the checkpoint file");
       }
-    } else if (i == Work_Estimate_Type) {
-      // Never use work estimate checkpoint
-      state_in_checkpoint[i] = 0;
     } else if (i == Reactions_Type) {
       if (do_react == 0) {
         state_in_checkpoint[i] = 0;
       } else {
         state_in_checkpoint[i] = is_present ? 1 : 0;
       }
+    } else if (i == Work_Estimate_Type) {
+      // Never use work estimate checkpoint
+      state_in_checkpoint[i] = 0;
     } else {
       amrex::Abort("Unknown StateType");
     }

--- a/Source/IO.cpp
+++ b/Source/IO.cpp
@@ -51,7 +51,7 @@ PeleC::check_state_in_checkpoint(const StateType state_type)
   bool bExitOnError(false); // ---- dont exit if this file does not exist
   amrex::ParallelDescriptor::ReadAndBcastFile(
     faHeaderFilesName, faHeaderFileChars, bExitOnError);
-  if (faHeaderFileChars.size() > 0) { // ---- headers were read
+  if (!faHeaderFileChars.empty()) { // ---- headers were read
     std::string faFileCharPtrString(faHeaderFileChars.dataPtr());
     std::istringstream fais(faFileCharPtrString, std::istringstream::in);
     while (!fais.eof()) {

--- a/Source/IO.cpp
+++ b/Source/IO.cpp
@@ -107,7 +107,7 @@ PeleC::restart(amrex::Amr& papa, std::istream& is, bool bReadSpecial)
       const amrex::Real ctime = state[i - 1].curTime();
       state[i].define(
         geom.Domain(), grids, dmap, desc_lst[i], ctime, parent->dtLevel(level),
-        *m_factory);
+        Factory());
       get_new_data(i).setVal(0.0);
     }
   }

--- a/Source/IO.cpp
+++ b/Source/IO.cpp
@@ -401,6 +401,12 @@ PeleC::setPlotVariables()
     amrex::Amr::addDerivePlotVar("WorkEstimate");
   }
 
+  if (do_react == 0) {
+    for (int i = 0; i < desc_lst[Reactions_Type].nComp(); i++) {
+      amrex::Amr::deleteStatePlotVar(desc_lst[Reactions_Type].name(i));
+    }
+  }
+
   bool plot_rhoy = true;
   pp.query("plot_rhoy", plot_rhoy);
   if (plot_rhoy) {

--- a/Source/PeleC.H
+++ b/Source/PeleC.H
@@ -93,6 +93,7 @@ public:
   // This is called only when we restart from an old checkpoint.
   virtual void
   set_state_in_checkpoint(amrex::Vector<int>& state_in_checkpoint) override;
+  bool check_state_in_checkpoint(const StateType state_type);
 
   // Call AmrLevel::checkPoint and then add radiation info
   virtual void checkPoint(

--- a/Source/PeleC.H
+++ b/Source/PeleC.H
@@ -696,7 +696,6 @@ protected:
 
 #ifdef PELEC_USE_EB
 
-  amrex::FabArray<amrex::BaseFab<int>> ebmask;
   static amrex::GpuArray<amrex::Real, NVAR> body_state;
   static bool body_state_set;
   static bool eb_initialized;

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -1597,7 +1597,7 @@ PeleC::errorEst(
       }
 
       // Tagging pressure
-      S_derData.setVal<amrex::RunOn::Device>(0.0);
+      S_derData.setVal<amrex::RunOn::Device>(0.0, datbox);
       pc_derpres(
         datbox, S_derData, ncp, Sfab.nComp(), S_data[mfi], geom, time, bc,
         level);
@@ -1618,7 +1618,7 @@ PeleC::errorEst(
       }
 
       // Tagging vel_x
-      S_derData.setVal<amrex::RunOn::Device>(0.0);
+      S_derData.setVal<amrex::RunOn::Device>(0.0, datbox);
       pc_dervelx(
         datbox, S_derData, ncp, Sfab.nComp(), S_data[mfi], geom, time, bc,
         level);
@@ -1638,7 +1638,7 @@ PeleC::errorEst(
       }
 
       // Tagging vel_y
-      S_derData.setVal<amrex::RunOn::Device>(0.0);
+      S_derData.setVal<amrex::RunOn::Device>(0.0, datbox);
       pc_dervely(
         datbox, S_derData, ncp, Sfab.nComp(), S_data[mfi], geom, time, bc,
         level);
@@ -1658,7 +1658,7 @@ PeleC::errorEst(
       }
 
       // Tagging vel_z
-      S_derData.setVal<amrex::RunOn::Device>(0.0);
+      S_derData.setVal<amrex::RunOn::Device>(0.0, datbox);
       pc_dervelz(
         datbox, S_derData, ncp, Sfab.nComp(), S_data[mfi], geom, time, bc,
         level);
@@ -1678,7 +1678,7 @@ PeleC::errorEst(
       }
 
       // Tagging magnitude of vorticity
-      S_derData.setVal<amrex::RunOn::Device>(0.0);
+      S_derData.setVal<amrex::RunOn::Device>(0.0, datbox);
       pc_dermagvort(
         tilebox, S_derData, ncp, Sfab.nComp(), S_data[mfi], geom, time, bc,
         level);
@@ -1692,7 +1692,7 @@ PeleC::errorEst(
       }
 
       // Tagging temperature
-      S_derData.setVal<amrex::RunOn::Device>(0.0);
+      S_derData.setVal<amrex::RunOn::Device>(0.0, datbox);
       pc_dertemp(
         datbox, S_derData, ncp, Sfab.nComp(), S_data[mfi], geom, time, bc,
         level);
@@ -1726,7 +1726,7 @@ PeleC::errorEst(
           // if (amrex::ParallelDescriptor::IOProcessor())
           // amrex::Print() << " Flame tracer will be " << name << '\n';
 
-          S_derData.setVal<amrex::RunOn::Device>(0.0);
+          S_derData.setVal<amrex::RunOn::Device>(0.0, datbox);
           pc_derspectrac(
             datbox, S_derData, ncp, Sfab.nComp(), S_data[mfi], geom, time, bc,
             level, idx);

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -1549,7 +1549,7 @@ PeleC::errorEst(
   amrex::MultiFab S_data(
     get_new_data(State_Type).boxArray(),
     get_new_data(State_Type).DistributionMap(), NVAR, 1, amrex::MFInfo(),
-    *m_factory);
+    Factory());
   const amrex::Real cur_time = state[State_Type].curTime();
   FillPatch(
     *this, S_data, S_data.nGrow(), cur_time, State_Type, Density, NVAR, 0);
@@ -1891,7 +1891,7 @@ void
 PeleC::init_les()
 {
   // Fill with default coefficient values
-  LES_Coeffs.define(grids, dmap, nCompC, 1);
+  LES_Coeffs.define(grids, dmap, nCompC, 1, amrex::MFInfo(), Factory());
   LES_Coeffs.setVal(0.0);
   LES_Coeffs.setVal(Cs * Cs, comp_Cs2, 1, LES_Coeffs.nGrow());
   LES_Coeffs.setVal(CI, comp_CI, 1, LES_Coeffs.nGrow());

--- a/Source/Setup.cpp
+++ b/Source/Setup.cpp
@@ -286,7 +286,7 @@ PeleC::variableSetUp()
 
   // Components 0:Numspec-1 are rho.omega_i
   // Component NUM_SPECIES is rho.edot = (rho.eout-rho.ein)
-  store_in_checkpoint = (do_react == 1) ? true : false;
+  store_in_checkpoint = (do_react == 1);
   desc_lst.addDescriptor(
     Reactions_Type, amrex::IndexType::TheCellType(),
     amrex::StateDescriptor::Point, 0, NUM_SPECIES + 2, interp,
@@ -411,9 +411,11 @@ PeleC::variableSetUp()
   desc_lst.setComponent(Reactions_Type, 0, react_name, react_bcs, bndryfunc2);
 
   if (do_react_load_balance || do_mol_load_balance) {
+    store_in_checkpoint = false;
     desc_lst.addDescriptor(
       Work_Estimate_Type, amrex::IndexType::TheCellType(),
-      amrex::StateDescriptor::Point, 0, 1, &amrex::pc_interp);
+      amrex::StateDescriptor::Point, 0, 1, &amrex::pc_interp, state_data_extrap,
+      store_in_checkpoint);
     // Because we use piecewise constant interpolation, we do not use bc and
     // BndryFunc.
     desc_lst.setComponent(

--- a/Source/Setup.cpp
+++ b/Source/Setup.cpp
@@ -286,13 +286,11 @@ PeleC::variableSetUp()
 
   // Components 0:Numspec-1 are rho.omega_i
   // Component NUM_SPECIES is rho.edot = (rho.eout-rho.ein)
-  if (do_react) {
-    store_in_checkpoint = true;
-    desc_lst.addDescriptor(
-      Reactions_Type, amrex::IndexType::TheCellType(),
-      amrex::StateDescriptor::Point, 0, NUM_SPECIES + 2, interp,
-      state_data_extrap, store_in_checkpoint);
-  }
+  store_in_checkpoint = true;
+  desc_lst.addDescriptor(
+    Reactions_Type, amrex::IndexType::TheCellType(),
+    amrex::StateDescriptor::Point, 0, NUM_SPECIES + 2, interp,
+    state_data_extrap, store_in_checkpoint);
   amrex::Vector<amrex::BCRec> bcs(NVAR);
   amrex::Vector<std::string> name(NVAR);
   amrex::Vector<amrex::BCRec> react_bcs(NUM_SPECIES + 2);
@@ -410,9 +408,7 @@ PeleC::variableSetUp()
   amrex::StateDescriptor::BndryFunc bndryfunc2(pc_reactfill_hyp);
   bndryfunc2.setRunOnGPU(true);
 
-  if (do_react) {
-    desc_lst.setComponent(Reactions_Type, 0, react_name, react_bcs, bndryfunc2);
-  }
+  desc_lst.setComponent(Reactions_Type, 0, react_name, react_bcs, bndryfunc2);
 
   if (do_react_load_balance || do_mol_load_balance) {
     desc_lst.addDescriptor(

--- a/Source/Setup.cpp
+++ b/Source/Setup.cpp
@@ -411,11 +411,9 @@ PeleC::variableSetUp()
   desc_lst.setComponent(Reactions_Type, 0, react_name, react_bcs, bndryfunc2);
 
   if (do_react_load_balance || do_mol_load_balance) {
-    store_in_checkpoint = false;
     desc_lst.addDescriptor(
       Work_Estimate_Type, amrex::IndexType::TheCellType(),
-      amrex::StateDescriptor::Point, 0, 1, &amrex::pc_interp, state_data_extrap,
-      store_in_checkpoint);
+      amrex::StateDescriptor::Point, 0, 1, &amrex::pc_interp);
     // Because we use piecewise constant interpolation, we do not use bc and
     // BndryFunc.
     desc_lst.setComponent(

--- a/Source/Setup.cpp
+++ b/Source/Setup.cpp
@@ -286,7 +286,7 @@ PeleC::variableSetUp()
 
   // Components 0:Numspec-1 are rho.omega_i
   // Component NUM_SPECIES is rho.edot = (rho.eout-rho.ein)
-  store_in_checkpoint = true;
+  store_in_checkpoint = (do_react == 1) ? true : false;
   desc_lst.addDescriptor(
     Reactions_Type, amrex::IndexType::TheCellType(),
     amrex::StateDescriptor::Point, 0, NUM_SPECIES + 2, interp,

--- a/Source/Setup.cpp
+++ b/Source/Setup.cpp
@@ -286,12 +286,13 @@ PeleC::variableSetUp()
 
   // Components 0:Numspec-1 are rho.omega_i
   // Component NUM_SPECIES is rho.edot = (rho.eout-rho.ein)
-  store_in_checkpoint = true;
-  desc_lst.addDescriptor(
-    Reactions_Type, amrex::IndexType::TheCellType(),
-    amrex::StateDescriptor::Point, 0, NUM_SPECIES + 2, interp,
-    state_data_extrap, store_in_checkpoint);
-
+  if (do_react) {
+    store_in_checkpoint = true;
+    desc_lst.addDescriptor(
+      Reactions_Type, amrex::IndexType::TheCellType(),
+      amrex::StateDescriptor::Point, 0, NUM_SPECIES + 2, interp,
+      state_data_extrap, store_in_checkpoint);
+  }
   amrex::Vector<amrex::BCRec> bcs(NVAR);
   amrex::Vector<std::string> name(NVAR);
   amrex::Vector<amrex::BCRec> react_bcs(NUM_SPECIES + 2);
@@ -409,7 +410,9 @@ PeleC::variableSetUp()
   amrex::StateDescriptor::BndryFunc bndryfunc2(pc_reactfill_hyp);
   bndryfunc2.setRunOnGPU(true);
 
-  desc_lst.setComponent(Reactions_Type, 0, react_name, react_bcs, bndryfunc2);
+  if (do_react) {
+    desc_lst.setComponent(Reactions_Type, 0, react_name, react_bcs, bndryfunc2);
+  }
 
   if (do_react_load_balance || do_mol_load_balance) {
     desc_lst.addDescriptor(


### PR DESCRIPTION
- Enabling restarting with `do_react=1` from a simulation with `do_react=0` (and vice versa)
- Removing Reactions_Type from plt and chk files when `do_react=0`
- Remove `ebmask` in favor of directly using `flag_fab` (it's been a TODO since forever)
- Fix the FAB ops (particularly the setval) to operate on the box we want and not on the FAB (this is important because tiling)

Closes #304 