### PR TITLE
Track min and max of important quantities

### DIFF
--- a/Docs/sphinx/InputFiles.rst
+++ b/Docs/sphinx/InputFiles.rst
@@ -201,3 +201,9 @@ Additionally, tagging is supported for a user-specified species which can functi
 
 Users can specify their own tagging criteria in the `prob.H` of their case. An example of this is provided in the Taylor-Green regression test.
    
+Diagnostic Output
+~~~~~~~~~~~~~~~~~
+
+The verbosity flags `pelec.v` and `amr.v` control the extent of output related to the reacting flow solver and AMR grid printed during the simulation. When `pelec.v >= 1`, additional controls allow for fine tuning of the diagnostic output. The input flags `pelec.sum_interval` (number of coarse steps) and `pelec.sum_per` (simulation time) control how often integrals of conserved state quantities over the domain are computed and output. Additionally, if the `pelec.track_extrema` flag is set, the minima and maxima of several important derived quantities will be output whenever the integrals are output. By default, this includes the minimum and maximum across all massfractions, indicated by `massfrac`, but the `pelec.extrema_spec_name` can be set to `ALL` or an individual species name if this diagnostic for indiviudal species is of interest.
+
+To aid in the analysis of the diagnostic data, it can also be saved to log files. To do this, set `amr.data_log = datlog extremalog`, which will save the integrated values to `datlog` and the extrema to `extremalog`, if they are being computed based on the values of the flags described above. Additional problem-specific logs can also be created. Gridding information can also be recorded to a file specified with the `amr.grid_log` option. 

--- a/Exec/RegTests/EB-C1/prob.cpp
+++ b/Exec/RegTests/EB-C1/prob.cpp
@@ -230,10 +230,11 @@ PeleC::problem_post_timestep()
                      << " RHO*W RESIDUAL = " << rhow_residual << '\n';
       amrex::Print() << "TIME= " << time
                      << " RHO*E RESIDUAL = " << rhoE_residual << '\n';
+	
+      const int log_index = find_datalog_index("mmslog");
+      if (log_index >= 0) {
 
-      if (parent->NumDataLogs() > 1) {
-
-        std::ostream& data_log2 = parent->DataLog(1);
+        std::ostream& data_log2 = parent->DataLog(log_index);
 
         // Write the quantities at this time
         const int datwidth = 14;
@@ -279,9 +280,10 @@ PeleC::problem_post_init()
   amrex::Real time = state[State_Type].curTime();
 
   if (level == 0) {
-    if (amrex::ParallelDescriptor::IOProcessor()) {
-      if (parent->NumDataLogs() > 1) {
-        std::ostream& data_log2 = parent->DataLog(1);
+    if (amrex::ParallelDescriptor::IOProcessor()) {	
+      const int log_index = find_datalog_index("mmslog");
+      if (log_index >= 0) {
+        std::ostream& data_log2 = parent->DataLog(log_index);
         if (time == 0.0) {
           const int datwidth = 14;
           data_log2 << std::setw(datwidth) << "          time";

--- a/Exec/RegTests/EB-C1/prob.cpp
+++ b/Exec/RegTests/EB-C1/prob.cpp
@@ -230,7 +230,7 @@ PeleC::problem_post_timestep()
                      << " RHO*W RESIDUAL = " << rhow_residual << '\n';
       amrex::Print() << "TIME= " << time
                      << " RHO*E RESIDUAL = " << rhoE_residual << '\n';
-	
+
       const int log_index = find_datalog_index("mmslog");
       if (log_index >= 0) {
 
@@ -280,7 +280,7 @@ PeleC::problem_post_init()
   amrex::Real time = state[State_Type].curTime();
 
   if (level == 0) {
-    if (amrex::ParallelDescriptor::IOProcessor()) {	
+    if (amrex::ParallelDescriptor::IOProcessor()) {
       const int log_index = find_datalog_index("mmslog");
       if (log_index >= 0) {
         std::ostream& data_log2 = parent->DataLog(log_index);

--- a/Exec/RegTests/EB-C9/prob.cpp
+++ b/Exec/RegTests/EB-C9/prob.cpp
@@ -85,8 +85,10 @@ PeleC::problem_post_timestep()
 
     if (amrex::ParallelDescriptor::IOProcessor()) {
       amrex::Print() << "TIME= " << time << " RHO ERROR  = " << rho_err << '\n';
-      if (parent->NumDataLogs() > 1) {
-        std::ostream& data_log2 = parent->DataLog(1);
+
+      const int log_index = find_datalog_index("mmslog");
+      if (log_index >= 0) {
+        std::ostream& data_log2 = parent->DataLog(log_index);
 
         // Write the quantities at this time
         const int datwidth = 14;
@@ -111,8 +113,9 @@ PeleC::problem_post_init()
 
   if (level == 0) {
     if (amrex::ParallelDescriptor::IOProcessor()) {
-      if (parent->NumDataLogs() > 1) {
-        std::ostream& data_log2 = parent->DataLog(1);
+      const int log_index = find_datalog_index("mmslog");
+      if (log_index >= 0) {
+        std::ostream& data_log2 = parent->DataLog(log_index);
         if (time == 0.0) {
           const int datwidth = 14;
           data_log2 << std::setw(datwidth) << "          time";

--- a/Exec/RegTests/MMS/prob.cpp
+++ b/Exec/RegTests/MMS/prob.cpp
@@ -260,10 +260,10 @@ PeleC::problem_post_timestep()
                                     << rhow_residual << '\n';)
       amrex::Print() << "TIME= " << time
                      << " RHO*E RESIDUAL = " << rhoE_residual << '\n';
-
-      if (parent->NumDataLogs() > 1) {
-
-        std::ostream& data_log2 = parent->DataLog(1);
+	
+      const int log_index = find_datalog_index("mmslog");
+      if (log_index >= 0) {
+	std::ostream& data_log2 = parent->DataLog(log_index);
 
         // Write the quantities at this time
         const int datwidth = 14;
@@ -314,9 +314,9 @@ PeleC::problem_post_init()
   if (level == 0) {
     if (amrex::ParallelDescriptor::IOProcessor()) {
 
-      if (parent->NumDataLogs() > 1) {
-
-        std::ostream& data_log2 = parent->DataLog(1);
+      const int log_index = find_datalog_index("mmslog");
+      if (log_index >= 0) {
+	std::ostream& data_log2 = parent->DataLog(log_index);
         if (time == 0.0) {
           const int datwidth = 14;
           data_log2 << std::setw(datwidth) << "          time";

--- a/Exec/RegTests/MMS/prob.cpp
+++ b/Exec/RegTests/MMS/prob.cpp
@@ -260,10 +260,10 @@ PeleC::problem_post_timestep()
                                     << rhow_residual << '\n';)
       amrex::Print() << "TIME= " << time
                      << " RHO*E RESIDUAL = " << rhoE_residual << '\n';
-	
+
       const int log_index = find_datalog_index("mmslog");
       if (log_index >= 0) {
-	std::ostream& data_log2 = parent->DataLog(log_index);
+        std::ostream& data_log2 = parent->DataLog(log_index);
 
         // Write the quantities at this time
         const int datwidth = 14;
@@ -316,7 +316,7 @@ PeleC::problem_post_init()
 
       const int log_index = find_datalog_index("mmslog");
       if (log_index >= 0) {
-	std::ostream& data_log2 = parent->DataLog(log_index);
+        std::ostream& data_log2 = parent->DataLog(log_index);
         if (time == 0.0) {
           const int datwidth = 14;
           data_log2 << std::setw(datwidth) << "          time";

--- a/Exec/RegTests/PMF/example.inp
+++ b/Exec/RegTests/PMF/example.inp
@@ -45,6 +45,7 @@ amr.check_int               = 500    # number of timesteps between checkpoints
 amr.plot_files_output = 0
 amr.plot_file         = plt     # root name of plotfile
 amr.plot_int          = 10   # number of timesteps between plotfiles
+amr.data_log = extremalog
 
 # PROBLEM PARAMETERS
 prob.pamb = 1013250.0  
@@ -65,5 +66,7 @@ pelec.diffuse_spec=1
 pelec.diffuse_vel=1
 pelec.sdc_iters = 2
 pelec.flame_trac_name = HO2
+pelec.extrema_spec_name = H2O
+pelec.plot_massfrac = 1
 amrex.signal_handling=0
 #amrex.throw_handling=0

--- a/Source/Params/_cpp_parameters
+++ b/Source/Params/_cpp_parameters
@@ -396,10 +396,16 @@ track_grid_losses            int            0
 # how often (number of coarse timesteps) to compute integral sums (for runtime diagnostics)
 sum_interval                 int           -1
 
+# record extrema of certain variables along with the intergal sums
+track_extrema                int           1
+
+# track the extrema of this species in addition to other quantities
+extrema_spec_name            string	   ""
+
 # how often (simulation time) to compute integral sums (for runtime diagnostics)
 sum_per                      Real          -1.0e0
 
-# abort if we exceed CFL = 1 over the cource of a timestep
+# abort if we exceed CFL = 1 over the course of a timestep
 hard_cfl_limit               int           1
 
 # a string describing the simulation that will be copied into the

--- a/Source/Params/param_includes/pelec_defaults.H
+++ b/Source/Params/param_includes/pelec_defaults.H
@@ -108,6 +108,8 @@ int PeleC::print_energy_diagnostics = 0;
 #endif
 int PeleC::track_grid_losses = 0;
 int PeleC::sum_interval = -1;
+int PeleC::track_extrema = 1;
+std::string PeleC::extrema_spec_name = "";
 amrex::Real PeleC::sum_per = -1.0e0;
 int PeleC::hard_cfl_limit = 1;
 std::string PeleC::job_name = "";

--- a/Source/Params/param_includes/pelec_params.H
+++ b/Source/Params/param_includes/pelec_params.H
@@ -104,6 +104,8 @@ static int bndry_func_thread_safe;
 static int print_energy_diagnostics;
 static int track_grid_losses;
 static int sum_interval;
+static int track_extrema;
+static std::string extrema_spec_name;
 static amrex::Real sum_per;
 static int hard_cfl_limit;
 static std::string job_name;

--- a/Source/Params/param_includes/pelec_queries.H
+++ b/Source/Params/param_includes/pelec_queries.H
@@ -104,6 +104,8 @@ pp.query("bndry_func_thread_safe", bndry_func_thread_safe);
 pp.query("print_energy_diagnostics", print_energy_diagnostics);
 pp.query("track_grid_losses", track_grid_losses);
 pp.query("sum_interval", sum_interval);
+pp.query("track_extrema", track_extrema);
+pp.query("extrema_spec_name", extrema_spec_name);
 pp.query("sum_per", sum_per);
 pp.query("hard_cfl_limit", hard_cfl_limit);
 pp.query("job_name", job_name);

--- a/Source/PeleC.H
+++ b/Source/PeleC.H
@@ -616,6 +616,8 @@ protected:
   amrex::Real
   sumDerive(const std::string& name, amrex::Real time, bool local = false);
 
+  int find_datalog_index(const std::string& logname);
+  
   void sum_integrated_quantities();
 
   void monitor_extrema();

--- a/Source/PeleC.H
+++ b/Source/PeleC.H
@@ -481,6 +481,8 @@ public:
   volWgtSquaredSumDiff(int comp, amrex::Real time, bool local = false);
   amrex::Real
   maxDerive(const std::string& name, amrex::Real time, bool local = false);
+  amrex::Real
+  minDerive(const std::string& name, amrex::Real time, bool local = false);
 
   // static int NVAR;
   static int Density, Xmom, Ymom, Zmom, Eden, Eint, Temp;
@@ -615,6 +617,8 @@ protected:
   sumDerive(const std::string& name, amrex::Real time, bool local = false);
 
   void sum_integrated_quantities();
+
+  void monitor_extrema();
 
   void write_info();
 

--- a/Source/PeleC.H
+++ b/Source/PeleC.H
@@ -617,7 +617,7 @@ protected:
   sumDerive(const std::string& name, amrex::Real time, bool local = false);
 
   int find_datalog_index(const std::string& logname);
-  
+
   void sum_integrated_quantities();
 
   void monitor_extrema();

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -688,12 +688,11 @@ PeleC::initData()
 
     const ProbParmDevice* lprobparm = d_prob_parm_device;
 
-    amrex::ParallelFor(
-      box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-        pc_initdata(i, j, k, sfab, geomdata, *lprobparm);
-        // Verify that the sum of (rho Y)_i = rho at every cell
-        pc_check_initial_species(i, j, k, sfab);
-      });
+    amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+      pc_initdata(i, j, k, sfab, geomdata, *lprobparm);
+      // Verify that the sum of (rho Y)_i = rho at every cell
+      pc_check_initial_species(i, j, k, sfab);
+    });
   }
 
   enforce_consistent_e(S_new);
@@ -850,7 +849,7 @@ amrex::Real PeleC::estTimeStep(amrex::Real /*dt_old*/)
           ,
           const amrex::Array4<const amrex::EBCellFlag>& flag_arr
 #endif
-          ) noexcept->amrex::Real {
+          ) noexcept -> amrex::Real {
           return pc_estdt_hydro(
             bx, fab_arr,
 #ifdef PELEC_USE_EB
@@ -875,7 +874,7 @@ amrex::Real PeleC::estTimeStep(amrex::Real /*dt_old*/)
           ,
           const amrex::Array4<const amrex::EBCellFlag>& flag_arr
 #endif
-          ) noexcept->amrex::Real {
+          ) noexcept -> amrex::Real {
           return pc_estdt_veldif(
             bx, fab_arr,
 #ifdef PELEC_USE_EB
@@ -900,7 +899,7 @@ amrex::Real PeleC::estTimeStep(amrex::Real /*dt_old*/)
           ,
           const amrex::Array4<const amrex::EBCellFlag>& flag_arr
 #endif
-          ) noexcept->amrex::Real {
+          ) noexcept -> amrex::Real {
           return pc_estdt_tempdif(
             bx, fab_arr,
 #ifdef PELEC_USE_EB
@@ -925,7 +924,7 @@ amrex::Real PeleC::estTimeStep(amrex::Real /*dt_old*/)
           ,
           const amrex::Array4<const amrex::EBCellFlag>& flag_arr
 #endif
-          ) noexcept->amrex::Real {
+          ) noexcept -> amrex::Real {
           return pc_estdt_enthdif(
             bx, fab_arr,
 #ifdef PELEC_USE_EB
@@ -1165,8 +1164,6 @@ PeleC::post_timestep(int
 
     if (sum_int_test || sum_per_test) {
       sum_integrated_quantities();
-      if (track_extrema)
-        monitor_extrema();
     }
   }
 
@@ -1319,8 +1316,6 @@ void PeleC::post_init(amrex::Real /*stop_time*/)
 
   if (sum_int_test || sum_per_test) {
     sum_integrated_quantities();
-    if (track_extrema)
-      monitor_extrema();
   }
 }
 
@@ -2117,10 +2112,9 @@ PeleC::computeTemp(amrex::MultiFab& S, int ng)
 #endif
 
     const auto& sarr = S.array(mfi);
-    amrex::ParallelFor(
-      bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-        pc_cmpTemp(i, j, k, sarr);
-      });
+    amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+      pc_cmpTemp(i, j, k, sarr);
+    });
   }
 }
 

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -1164,6 +1164,8 @@ PeleC::post_timestep(int
 
     if (sum_int_test || sum_per_test) {
       sum_integrated_quantities();
+      if (track_extrema)
+	monitor_extrema();
     }
   }
 
@@ -1316,6 +1318,8 @@ void PeleC::post_init(amrex::Real /*stop_time*/)
 
   if (sum_int_test || sum_per_test) {
     sum_integrated_quantities();
+    if (track_extrema)
+      monitor_extrema();
   }
 }
 

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -1165,7 +1165,7 @@ PeleC::post_timestep(int
     if (sum_int_test || sum_per_test) {
       sum_integrated_quantities();
       if (track_extrema)
-	monitor_extrema();
+        monitor_extrema();
     }
   }
 

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -688,11 +688,12 @@ PeleC::initData()
 
     const ProbParmDevice* lprobparm = d_prob_parm_device;
 
-    amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-      pc_initdata(i, j, k, sfab, geomdata, *lprobparm);
-      // Verify that the sum of (rho Y)_i = rho at every cell
-      pc_check_initial_species(i, j, k, sfab);
-    });
+    amrex::ParallelFor(
+      box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+        pc_initdata(i, j, k, sfab, geomdata, *lprobparm);
+        // Verify that the sum of (rho Y)_i = rho at every cell
+        pc_check_initial_species(i, j, k, sfab);
+      });
   }
 
   enforce_consistent_e(S_new);
@@ -849,7 +850,7 @@ amrex::Real PeleC::estTimeStep(amrex::Real /*dt_old*/)
           ,
           const amrex::Array4<const amrex::EBCellFlag>& flag_arr
 #endif
-          ) noexcept -> amrex::Real {
+          ) noexcept->amrex::Real {
           return pc_estdt_hydro(
             bx, fab_arr,
 #ifdef PELEC_USE_EB
@@ -874,7 +875,7 @@ amrex::Real PeleC::estTimeStep(amrex::Real /*dt_old*/)
           ,
           const amrex::Array4<const amrex::EBCellFlag>& flag_arr
 #endif
-          ) noexcept -> amrex::Real {
+          ) noexcept->amrex::Real {
           return pc_estdt_veldif(
             bx, fab_arr,
 #ifdef PELEC_USE_EB
@@ -899,7 +900,7 @@ amrex::Real PeleC::estTimeStep(amrex::Real /*dt_old*/)
           ,
           const amrex::Array4<const amrex::EBCellFlag>& flag_arr
 #endif
-          ) noexcept -> amrex::Real {
+          ) noexcept->amrex::Real {
           return pc_estdt_tempdif(
             bx, fab_arr,
 #ifdef PELEC_USE_EB
@@ -924,7 +925,7 @@ amrex::Real PeleC::estTimeStep(amrex::Real /*dt_old*/)
           ,
           const amrex::Array4<const amrex::EBCellFlag>& flag_arr
 #endif
-          ) noexcept -> amrex::Real {
+          ) noexcept->amrex::Real {
           return pc_estdt_enthdif(
             bx, fab_arr,
 #ifdef PELEC_USE_EB
@@ -1164,6 +1165,8 @@ PeleC::post_timestep(int
 
     if (sum_int_test || sum_per_test) {
       sum_integrated_quantities();
+      if (track_extrema)
+        monitor_extrema();
     }
   }
 
@@ -1316,6 +1319,8 @@ void PeleC::post_init(amrex::Real /*stop_time*/)
 
   if (sum_int_test || sum_per_test) {
     sum_integrated_quantities();
+    if (track_extrema)
+      monitor_extrema();
   }
 }
 
@@ -2112,9 +2117,10 @@ PeleC::computeTemp(amrex::MultiFab& S, int ng)
 #endif
 
     const auto& sarr = S.array(mfi);
-    amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-      pc_cmpTemp(i, j, k, sarr);
-    });
+    amrex::ParallelFor(
+      bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+        pc_cmpTemp(i, j, k, sarr);
+      });
   }
 }
 

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -1164,8 +1164,9 @@ PeleC::post_timestep(int
 
     if (sum_int_test || sum_per_test) {
       sum_integrated_quantities();
-      if (track_extrema)
+      if (track_extrema) {
         monitor_extrema();
+      }
     }
   }
 
@@ -1318,8 +1319,9 @@ void PeleC::post_init(amrex::Real /*stop_time*/)
 
   if (sum_int_test || sum_per_test) {
     sum_integrated_quantities();
-    if (track_extrema)
+    if (track_extrema) {
       monitor_extrema();
+    }
   }
 }
 

--- a/Source/SumIQ.cpp
+++ b/Source/SumIQ.cpp
@@ -2,6 +2,16 @@
 
 #include "PeleC.H"
 
+int PeleC::find_datalog_index(const std::string& logname)
+{
+  for (int ii = 0; ii < parent->NumDataLogs(); ii++) {
+    if (logname == parent->DataLogName(ii)) {
+      return ii;
+    }
+  }
+  return -1; // Requested log not found
+}
+
 void
 PeleC::sum_integrated_quantities()
 {
@@ -10,7 +20,7 @@ PeleC::sum_integrated_quantities()
   if (verbose <= 0) {
     return;
   }
-
+  
   bool local_flag = true;
 
   int finest_level = parent->finestLevel();
@@ -85,11 +95,10 @@ PeleC::sum_integrated_quantities()
         //               << '\n';
         amrex::Print() << "TIME = " << time << " FUEL PROD   = " << fuel_prod
                        << '\n';
-        amrex::Print() << "TIME = " << time << " TEMP        = " << temp
-                       << '\n';
 
-        if (parent->NumDataLogs() > 0) {
-          std::ostream& data_log1 = parent->DataLog(0);
+	const int log_index = find_datalog_index("datalog");
+        if (log_index >= 0) {
+          std::ostream& data_log1 = parent->DataLog(log_index);
           if (data_log1.good()) {
             const int datwidth = 14;
             if (time == 0.0) {
@@ -259,8 +268,10 @@ PeleC::monitor_extrema()
                          << std::endl;
         }
 
-        if (parent->NumDataLogs() > 1) {
-          std::ostream& data_log1 = parent->DataLog(1);
+	
+	const int log_index = find_datalog_index("extremalog");
+        if (log_index >= 0) {
+          std::ostream& data_log1 = parent->DataLog(log_index);
           if (data_log1.good()) {
             const int datwidth = 17;
             if (time == 0.0) {

--- a/Source/SumIQ.cpp
+++ b/Source/SumIQ.cpp
@@ -2,16 +2,6 @@
 
 #include "PeleC.H"
 
-int PeleC::find_datalog_index(const std::string& logname)
-{
-  for (int ii = 0; ii < parent->NumDataLogs(); ii++) {
-    if (logname == parent->DataLogName(ii)) {
-      return ii;
-    }
-  }
-  return -1; // Requested log not found
-}
-
 void
 PeleC::sum_integrated_quantities()
 {
@@ -20,7 +10,7 @@ PeleC::sum_integrated_quantities()
   if (verbose <= 0) {
     return;
   }
-  
+
   bool local_flag = true;
 
   int finest_level = parent->finestLevel();
@@ -96,7 +86,7 @@ PeleC::sum_integrated_quantities()
         amrex::Print() << "TIME = " << time << " FUEL PROD   = " << fuel_prod
                        << '\n';
 
-	const int log_index = find_datalog_index("datalog");
+        const int log_index = find_datalog_index("datalog");
         if (log_index >= 0) {
           std::ostream& data_log1 = parent->DataLog(log_index);
           if (data_log1.good()) {
@@ -268,8 +258,7 @@ PeleC::monitor_extrema()
                          << std::endl;
         }
 
-	
-	const int log_index = find_datalog_index("extremalog");
+        const int log_index = find_datalog_index("extremalog");
         if (log_index >= 0) {
           std::ostream& data_log1 = parent->DataLog(log_index);
           if (data_log1.good()) {

--- a/Source/SumIQ.cpp
+++ b/Source/SumIQ.cpp
@@ -67,7 +67,8 @@ PeleC::sum_integrated_quantities()
         temp = foo[i++];
 
         amrex::Print() << '\n';
-        amrex::Print() << "TIME = " << time << " MASS        = " << mass << '\n';
+        amrex::Print() << "TIME = " << time << " MASS        = " << mass
+                       << '\n';
         amrex::Print() << "TIME = " << time << " XMOM        = " << mom[0]
                        << '\n';
         amrex::Print() << "TIME = " << time << " YMOM        = " << mom[1]
@@ -84,7 +85,8 @@ PeleC::sum_integrated_quantities()
         //               << '\n';
         amrex::Print() << "TIME = " << time << " FUEL PROD   = " << fuel_prod
                        << '\n';
-        amrex::Print() << "TIME = " << time << " TEMP        = " << temp << '\n';
+        amrex::Print() << "TIME = " << time << " TEMP        = " << temp
+                       << '\n';
 
         if (parent->NumDataLogs() > 0) {
           std::ostream& data_log1 = parent->DataLog(0);
@@ -152,16 +154,16 @@ PeleC::monitor_extrema()
   const int finest_level = parent->finestLevel();
   const amrex::Real time = state[State_Type].curTime();
   amrex::Vector<std::string> extrema_vars = {
-    "density", "x_velocity", "y_velocity", "z_velocity",
-    "eint_e",  "Temp",       "pressure",   "massfrac",
-    "sumYminus1"};
+    "density", "x_velocity", "y_velocity", "z_velocity", "eint_e",
+    "Temp",    "pressure",   "massfrac",   "sumYminus1"};
 
   int nspec_extrema = 2;
   bool use_all_spec = false;
   if (extrema_spec_name == "ALL") {
     use_all_spec = true;
     nspec_extrema += NUM_SPECIES;
-    extrema_vars.insert(extrema_vars.end(), PeleC::spec_names.begin(), PeleC::spec_names.end());
+    extrema_vars.insert(
+      extrema_vars.end(), PeleC::spec_names.begin(), PeleC::spec_names.end());
   } else {
     if (!fuel_name.empty()) {
       nspec_extrema++;
@@ -209,24 +211,24 @@ PeleC::monitor_extrema()
 
       // Get values for any individual species if relevant
       if (use_all_spec) {
-	const int idx_spec = idx_massfrac + ispec + 2;
-	maxima[idx_spec] = amrex::max(maxima[idx_spec], maxval);
-	minima[idx_spec] = amrex::min(minima[idx_spec], minval);
+        const int idx_spec = idx_massfrac + ispec + 2;
+        maxima[idx_spec] = amrex::max(maxima[idx_spec], maxval);
+        minima[idx_spec] = amrex::min(minima[idx_spec], minval);
       } else {
-	for (int iext = 0; iext < nspec_extrema - 2; iext++) {
-	  const int idx_spec = idx_massfrac + iext + 2;
-	  if (extrema_vars[idx_spec] == PeleC::spec_names[ispec]) {
-	    maxima[idx_spec] = amrex::max(maxima[idx_spec], maxval);
-	    minima[idx_spec] = amrex::min(minima[idx_spec], minval);
-	  }
-	}
+        for (int iext = 0; iext < nspec_extrema - 2; iext++) {
+          const int idx_spec = idx_massfrac + iext + 2;
+          if (extrema_vars[idx_spec] == PeleC::spec_names[ispec]) {
+            maxima[idx_spec] = amrex::max(maxima[idx_spec], maxval);
+            minima[idx_spec] = amrex::min(minima[idx_spec], minval);
+          }
+        }
       }
     }
     // sum of mass fractions
-    maxima[idx_massfrac+1] = amrex::max(maxima[idx_massfrac+1],
-					sumY.max(0, 0, local_flag) - 1.0);
-    minima[idx_massfrac+1] = amrex::min(minima[idx_massfrac+1],
-					sumY.min(0, 0, local_flag) - 1.0);
+    maxima[idx_massfrac + 1] =
+      amrex::max(maxima[idx_massfrac + 1], sumY.max(0, 0, local_flag) - 1.0);
+    minima[idx_massfrac + 1] =
+      amrex::min(minima[idx_massfrac + 1], sumY.min(0, 0, local_flag) - 1.0);
   }
 
   if (verbose > 0) {
@@ -245,22 +247,22 @@ PeleC::monitor_extrema()
 
         amrex::Print() << std::endl;
         for (int ii = 0; ii < nextrema; ++ii) {
-          const int datwidth = 14;
-	  const int datwidth_txt = 10;
+          const int datwidth = 15;
+          const int datwidth_txt = 10;
           const int datprecision = 8;
-          amrex::Print() << "TIME = " << time
-			 << " " << std::left << std::setw(datwidth_txt) << extrema_vars[ii]
-			 << "  MIN = " << std::setw(datwidth)
+          amrex::Print() << "TIME = " << time << " " << std::left
+                         << std::setw(datwidth_txt) << extrema_vars[ii]
+                         << "  MIN = " << std::setw(datwidth)
                          << std::setprecision(datprecision) << minima[ii]
-			 << "  MAX = " << std::setw(datwidth)
+                         << "  MAX = " << std::setw(datwidth)
                          << std::setprecision(datprecision) << maxima[ii]
-			 << std::endl;
+                         << std::endl;
         }
 
         if (parent->NumDataLogs() > 1) {
           std::ostream& data_log1 = parent->DataLog(1);
           if (data_log1.good()) {
-            const int datwidth = 16;
+            const int datwidth = 17;
             if (time == 0.0) {
               data_log1 << std::setw(datwidth) << "          time";
               for (int ii = 0; ii < nextrema; ++ii) {

--- a/Source/SumIQ.cpp
+++ b/Source/SumIQ.cpp
@@ -67,24 +67,24 @@ PeleC::sum_integrated_quantities()
         temp = foo[i++];
 
         amrex::Print() << '\n';
-        amrex::Print() << "TIME= " << time << " MASS        = " << mass << '\n';
-        amrex::Print() << "TIME= " << time << " XMOM        = " << mom[0]
+        amrex::Print() << "TIME = " << time << " MASS        = " << mass << '\n';
+        amrex::Print() << "TIME = " << time << " XMOM        = " << mom[0]
                        << '\n';
-        amrex::Print() << "TIME= " << time << " YMOM        = " << mom[1]
+        amrex::Print() << "TIME = " << time << " YMOM        = " << mom[1]
                        << '\n';
-        amrex::Print() << "TIME= " << time << " ZMOM        = " << mom[2]
+        amrex::Print() << "TIME = " << time << " ZMOM        = " << mom[2]
                        << '\n';
-        amrex::Print() << "TIME= " << time << " RHO*e       = " << rho_e
+        amrex::Print() << "TIME = " << time << " RHO*e       = " << rho_e
                        << '\n';
-        amrex::Print() << "TIME= " << time << " RHO*K       = " << rho_K
+        amrex::Print() << "TIME = " << time << " RHO*K       = " << rho_K
                        << '\n';
-        amrex::Print() << "TIME= " << time << " RHO*E       = " << rho_E
+        amrex::Print() << "TIME = " << time << " RHO*E       = " << rho_E
                        << '\n';
         // amrex::Print() << "TIME= " << time << " ENSTROPHY   = " << enstr
         //               << '\n';
-        amrex::Print() << "TIME= " << time << " FUEL PROD   = " << fuel_prod
+        amrex::Print() << "TIME = " << time << " FUEL PROD   = " << fuel_prod
                        << '\n';
-        amrex::Print() << "TIME= " << time << " TEMP        = " << temp << '\n';
+        amrex::Print() << "TIME = " << time << " TEMP        = " << temp << '\n';
 
         if (parent->NumDataLogs() > 0) {
           std::ostream& data_log1 = parent->DataLog(0);
@@ -142,43 +142,45 @@ PeleC::sum_integrated_quantities()
 void
 PeleC::monitor_extrema()
 {
-  BL_PROFILE("PeleC::sum_integrated_quantities()");
+  BL_PROFILE("PeleC::monitor_extrema()");
 
   if (verbose <= 0) {
     return;
   }
 
-  bool local_flag = true;
-
-  int finest_level = parent->finestLevel();
-  amrex::Real time = state[State_Type].curTime();
+  const bool local_flag = true;
+  const int finest_level = parent->finestLevel();
+  const amrex::Real time = state[State_Type].curTime();
   amrex::Vector<std::string> extrema_vars = {
     "density", "x_velocity", "y_velocity", "z_velocity",
-    "eint_e",  "Temp",       "pressure",   "massfrac"};
+    "eint_e",  "Temp",       "pressure",   "massfrac",
+    "sumYminus1"};
 
-  int nspec_extrema = 1;
-  if (!fuel_name.empty()) {
-    nspec_extrema += 1;
-    extrema_vars.push_back(fuel_name);
+  int nspec_extrema = 2;
+  bool use_all_spec = false;
+  if (extrema_spec_name == "ALL") {
+    use_all_spec = true;
+    nspec_extrema += NUM_SPECIES;
+    extrema_vars.insert(extrema_vars.end(), PeleC::spec_names.begin(), PeleC::spec_names.end());
+  } else {
+    if (!fuel_name.empty()) {
+      nspec_extrema++;
+      extrema_vars.push_back(fuel_name);
+    }
+    if (!flame_trac_name.empty()) {
+      nspec_extrema++;
+      extrema_vars.push_back(flame_trac_name);
+    }
+    if (!extrema_spec_name.empty()) {
+      nspec_extrema++;
+      extrema_vars.push_back(extrema_spec_name);
+    }
   }
-  if (!flame_trac_name.empty()) {
-    nspec_extrema += 1;
-    extrema_vars.push_back(flame_trac_name);
-  }
-  if (!extrema_spec_name.empty()) {
-    nspec_extrema += 1;
-    extrema_vars.push_back(extrema_spec_name);
-  }
+
   auto nextrema = extrema_vars.size();
   constexpr amrex::Real neg_huge = std::numeric_limits<amrex::Real>::lowest();
   constexpr amrex::Real huge = std::numeric_limits<amrex::Real>::max();
-  amrex::Vector<amrex::Real> minima, maxima;
-  minima.resize(nextrema);
-  maxima.resize(nextrema);
-  for (int ii = 0; ii < nextrema; ++ii) {
-    maxima[ii] = neg_huge;
-    minima[ii] = huge;
-  }
+  amrex::Vector<amrex::Real> minima(nextrema, huge), maxima(nextrema, neg_huge);
 
   for (int lev = 0; lev <= finest_level; lev++) {
     PeleC& pc_lev = getLevel(lev);
@@ -192,24 +194,39 @@ PeleC::monitor_extrema()
     // Handle species seperately
     auto mf = derive("massfrac", time, 0);
     BL_ASSERT(!(mf == nullptr));
-    int idx_massfrac = nextrema - nspec_extrema;
-    bool local = true;
+    amrex::MultiFab sumY(grids, dmap, 1, 0);
+    sumY.setVal(0.0);
+    const int idx_massfrac = nextrema - nspec_extrema;
+
     for (int ispec = 0; ispec < NUM_SPECIES; ispec++) {
-      amrex::Real maxval = mf->max(ispec, 0, local);
-      amrex::Real minval = mf->min(ispec, 0, local);
+      amrex::Real maxval = mf->max(ispec, 0, local_flag);
+      amrex::Real minval = mf->min(ispec, 0, local_flag);
+      amrex::MultiFab::Add(sumY, *mf, ispec, 0, 1, 0);
+
       // "massfrac" gets the extrema across all mass fractions
       maxima[idx_massfrac] = amrex::max(maxima[idx_massfrac], maxval);
       minima[idx_massfrac] = amrex::min(minima[idx_massfrac], minval);
 
       // Get values for any individual species if relevant
-      for (int iext = 0; iext < nspec_extrema - 1; iext++) {
-        int idx_spec = idx_massfrac + iext + 1;
-        if (extrema_vars[idx_spec].compare(PeleC::spec_names[ispec]) == 0) {
-          maxima[idx_spec] = amrex::max(maxima[idx_spec], maxval);
-          minima[idx_spec] = amrex::min(minima[idx_spec], minval);
-        }
+      if (use_all_spec) {
+	const int idx_spec = idx_massfrac + ispec + 2;
+	maxima[idx_spec] = amrex::max(maxima[idx_spec], maxval);
+	minima[idx_spec] = amrex::min(minima[idx_spec], minval);
+      } else {
+	for (int iext = 0; iext < nspec_extrema - 2; iext++) {
+	  const int idx_spec = idx_massfrac + iext + 2;
+	  if (extrema_vars[idx_spec] == PeleC::spec_names[ispec]) {
+	    maxima[idx_spec] = amrex::max(maxima[idx_spec], maxval);
+	    minima[idx_spec] = amrex::min(minima[idx_spec], minval);
+	  }
+	}
       }
     }
+    // sum of mass fractions
+    maxima[idx_massfrac+1] = amrex::max(maxima[idx_massfrac+1],
+					sumY.max(0, 0, local_flag) - 1.0);
+    minima[idx_massfrac+1] = amrex::min(minima[idx_massfrac+1],
+					sumY.min(0, 0, local_flag) - 1.0);
   }
 
   if (verbose > 0) {
@@ -228,15 +245,16 @@ PeleC::monitor_extrema()
 
         amrex::Print() << std::endl;
         for (int ii = 0; ii < nextrema; ++ii) {
-          const int datwidth = 22;
-          const int datprecision = 14;
-          amrex::Print() << "TIME= " << time;
-          amrex::Print() << std::setw(datwidth) << extrema_vars[ii];
-          amrex::Print() << " MIN= " << std::setw(datwidth)
-                         << std::setprecision(datprecision) << minima[ii];
-          amrex::Print() << " MAX= " << std::setw(datwidth)
-                         << std::setprecision(datprecision) << maxima[ii];
-          amrex::Print() << std::endl;
+          const int datwidth = 14;
+	  const int datwidth_txt = 10;
+          const int datprecision = 8;
+          amrex::Print() << "TIME = " << time
+			 << " " << std::left << std::setw(datwidth_txt) << extrema_vars[ii]
+			 << "  MIN = " << std::setw(datwidth)
+                         << std::setprecision(datprecision) << minima[ii]
+			 << "  MAX = " << std::setw(datwidth)
+                         << std::setprecision(datprecision) << maxima[ii]
+			 << std::endl;
         }
 
         if (parent->NumDataLogs() > 1) {
@@ -255,7 +273,7 @@ PeleC::monitor_extrema()
             }
 
             // Write the quantities at this time
-            const int datprecision = 8;
+            const int datprecision = 10;
             data_log1 << std::setw(datwidth) << time;
             for (int ii = 0; ii < nextrema; ++ii) {
               data_log1 << std::setw(datwidth)

--- a/Source/SumUtils.cpp
+++ b/Source/SumUtils.cpp
@@ -165,14 +165,21 @@ PeleC::volWgtSumMF(
 amrex::Real
 PeleC::maxDerive(const std::string& name, amrex::Real time, bool local)
 {
+  // Note: Includes all cells in MF, even those covered by finer grids or EB
   auto mf = derive(name, time, 0);
 
   BL_ASSERT(!(mf == nullptr));
 
-  if (level < parent->finestLevel()) {
-    const amrex::MultiFab& mask = getLevel(level + 1).build_fine_mask();
-    amrex::MultiFab::Multiply(*mf, mask, 0, 0, 1, 0);
-  }
-
   return mf->max(0, 0, local);
+}
+
+amrex::Real
+PeleC::minDerive(const std::string& name, amrex::Real time, bool local)
+{
+  // Note: Includes all cells in MF, even those covered by finer grids or EB
+  auto mf = derive(name, time, 0);
+
+  BL_ASSERT(!(mf == nullptr));
+
+  return mf->min(0, 0, local);
 }

--- a/Source/SumUtils.cpp
+++ b/Source/SumUtils.cpp
@@ -183,3 +183,14 @@ PeleC::minDerive(const std::string& name, amrex::Real time, bool local)
 
   return mf->min(0, 0, local);
 }
+
+int
+PeleC::find_datalog_index(const std::string& logname)
+{
+  for (int ii = 0; ii < parent->NumDataLogs(); ii++) {
+    if (logname == parent->DataLogName(ii)) {
+      return ii;
+    }
+  }
+  return -1; // Requested log not found
+}


### PR DESCRIPTION
I made some modifications so the terminal output and datalog files track extrema of important quantities (e.g., species mass fractions) for debugging purposes and thought it might be generally useful. This tracking occurs at the same intervals as tracking integrated quantities but can be turned off independently. 

Some notes:
- I modified the function `maxDerive`, which in the previous implementation ignored coarse cells covered by fine cells (good), but assumed maxima were positive (bad, e.g. for eint). The new implementation does not ignore covered cells, but this should be okay - average down is always called before the tracking, so covered cells should never have more extreme values than the cells covering them.
- "massfrac" reports extrema across all mass fractions. The individual extrema for the species mass fractions corresponding to `pelec.fuel_name`, `pelec.ftrac_spec_name`, and a new input called `pelec.extrema_spec_name` are also reported if these input parameters are specified.