### PR TITLE
Ensure div_rho == sum div_rhoY after SRD

### DIFF
--- a/Source/Diffusion.cpp
+++ b/Source/Diffusion.cpp
@@ -672,6 +672,14 @@ PeleC::getMOLSrcTerm(
               Dterm(i, j, k, n) = 0.0;
             }
           });
+        // Make sure rho div is same as sum rhoY div
+        amrex::ParallelFor(
+          vbox, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+            Dterm(i, j, k, URHO) = 0.0;
+            for (int n = 0; n < NUM_SPECIES; n++) {
+              Dterm(i, j, k, URHO) += Dterm(i, j, k, UFS + n);
+            }
+          });
       }
 #endif
 


### PR DESCRIPTION
Opening this one up for discussion. The key thing is to recognize that SRD can change the fluxes of rho and rhoY independently and that this leads to an inconsistency between them. Namely, div_rho != sum div_rhoY. This can be seen by running the EB-C8 case and monitoring the new diagnostics:

Without fix: 
```
TIME = 1.959e-06 density     MIN = 0.00011995296    MAX = 0.00096000263
TIME = 1.959e-06 x_velocity  MIN = -2.681075        MAX = 85828.955
TIME = 1.959e-06 y_velocity  MIN = -55.976432       MAX = 50433.182
TIME = 1.959e-06 z_velocity  MIN = 0                MAX = 0
TIME = 1.959e-06 eint_e      MIN = -2.9868212e+09   MAX = 2.9448682e+10
TIME = 1.959e-06 Temp        MIN = 401.05919        MAX = 3509.6252
TIME = 1.959e-06 pressure    MIN = 999335.75        MAX = 10000035
TIME = 1.959e-06 massfrac    MIN = -4.4810309e-05   MAX = 1.0009982
TIME = 1.959e-06 sumYminus1  MIN = -0.005339888     MAX = 0.017067679
TIME = 1.959e-06 H2          MIN = 0                MAX = 0
TIME = 1.959e-06 H           MIN = 0                MAX = 0
TIME = 1.959e-06 AR          MIN = 0                MAX = 0
TIME = 1.959e-06 N2          MIN = -4.4810309e-05   MAX = 1.0000251
TIME = 1.959e-06 HE          MIN = -6.3383097e-11   MAX = 1.0009982
TIME = 1.959e-06 O           MIN = 0                MAX = 0
TIME = 1.959e-06 OH          MIN = 0                MAX = 0
TIME = 1.959e-06 HCO         MIN = 0                MAX = 0
TIME = 1.959e-06 HO2         MIN = 0                MAX = 0
TIME = 1.959e-06 H2O         MIN = 0                MAX = 0
TIME = 1.959e-06 CO          MIN = 0                MAX = 0
TIME = 1.959e-06 O2          MIN = 0                MAX = 0
TIME = 1.959e-06 H2O2        MIN = 0                MAX = 0
TIME = 1.959e-06 CO2         MIN = 0                MAX = 0
```

With the fix:
```
TIME = 1.959e-06 density     MIN = 0.00011995296    MAX = 0.00096000263
TIME = 1.959e-06 x_velocity  MIN = -2.680229        MAX = 85829.385
TIME = 1.959e-06 y_velocity  MIN = -55.967503       MAX = 50433.474
TIME = 1.959e-06 z_velocity  MIN = 0                MAX = 0
TIME = 1.959e-06 eint_e      MIN = -2.9868207e+09   MAX = 2.9448682e+10
TIME = 1.959e-06 Temp        MIN = 401.05921        MAX = 3509.6252
TIME = 1.959e-06 pressure    MIN = 999335.85        MAX = 10000035
TIME = 1.959e-06 massfrac    MIN = -4.7026329e-05   MAX = 1.000047
TIME = 1.959e-06 sumYminus1  MIN = -4.5519144e-15   MAX = 4.8849813e-15
TIME = 1.959e-06 H2          MIN = 0                MAX = 0
TIME = 1.959e-06 H           MIN = 0                MAX = 0
TIME = 1.959e-06 AR          MIN = 0                MAX = 0
TIME = 1.959e-06 N2          MIN = -4.7026329e-05   MAX = 1
TIME = 1.959e-06 HE          MIN = -6.228652e-11    MAX = 1.000047
TIME = 1.959e-06 O           MIN = 0                MAX = 0
TIME = 1.959e-06 OH          MIN = 0                MAX = 0
TIME = 1.959e-06 HCO         MIN = 0                MAX = 0
TIME = 1.959e-06 HO2         MIN = 0                MAX = 0
TIME = 1.959e-06 H2O         MIN = 0                MAX = 0
TIME = 1.959e-06 CO          MIN = 0                MAX = 0
TIME = 1.959e-06 O2          MIN = 0                MAX = 0
TIME = 1.959e-06 H2O2        MIN = 0                MAX = 0
TIME = 1.959e-06 CO2         MIN = 0                MAX = 0
```

**Takeaways of using the fix in this PR:**
- the mass fractions always sum to 1 (we see them being 1e-2 off from 1 without this fix)
- the mass fraction bounds violations are still present but slightly less bad.

Questions/comments:
- another way to do this would be to hold `div_rho` as fixed and use a velocity correction like we do in PPM/PLM and redistribute the rhoY fluxes. Not keen on this idea because what we are really doing here is just fixing the SRD inconsistencies. Before SRD is applied we _know_ that div_rho = sum div_rhoY. And in doing a velocity correction we may even be undoing what SRD did.
- this is only applied to the divergences in boxes where there are cut cells. I think this is ok.
- this will cause diffs in all the EB regtests @jrood-nrel 
- can I get help testing this on other multi-species EB configurations? 