### PR TITLE
Using parmparsed difmag (remove a todo)

### DIFF
--- a/Source/Godunov.H
+++ b/Source/Godunov.H
@@ -656,7 +656,6 @@ pc_artif_visc(
     div1 = difmag * amrex::min<amrex::Real>(0.0, div1);
     for (int n = 0; n < NVAR; ++n) {
       if (n != UTEMP) {
-        // Passing in difmag TODO not pass in.
         flx(i, j, k, n) += dx * div1 * (u(i, j, k, n) - u(i - 1, j, k, n));
       }
     }

--- a/Source/Godunov.H
+++ b/Source/Godunov.H
@@ -641,7 +641,7 @@ pc_artif_visc(
   const int j,
   const int k,
   amrex::Array4<amrex::Real> const& flx,
-  amrex::Array4<const amrex::Real> const& div,
+  amrex::Array4<const amrex::Real> const& divu,
   amrex::Array4<const amrex::Real> const& u,
   amrex::Real const dx,
   amrex::Real const difmag,
@@ -660,15 +660,15 @@ pc_artif_visc(
   const amrex::IntVect ivpp(
     iv + amrex::IntVect::TheDimensionVector(l_idx[1]) +
     amrex::IntVect::TheDimensionVector(l_idx[2]));
-  const amrex::Real div1 =
+  const amrex::Real div =
     difmag * amrex::min<amrex::Real>(
                0.0, AMREX_D_PICK(
-                      div(iv), 0.5 * (div(iv) + div(ivpj)),
-                      0.25 * (div(iv) + div(ivpj) + div(ivpk) + div(ivpp))));
+                      divu(iv), 0.5 * (divu(iv) + divu(ivpj)),
+                      0.25 * (divu(iv) + divu(ivpj) + divu(ivpk) + divu(ivpp))));
 
   for (int n = 0; n < NVAR; ++n) {
     if (n != UTEMP) {
-      flx(iv, n) += dx * div1 * (u(iv, n) - u(ivm, n));
+      flx(iv, n) += dx * div * (u(iv, n) - u(ivm, n));
     }
   }
   flx(iv, UTEMP) = 0.0;

--- a/Source/Godunov.H
+++ b/Source/Godunov.H
@@ -661,10 +661,11 @@ pc_artif_visc(
     iv + amrex::IntVect::TheDimensionVector(l_idx[1]) +
     amrex::IntVect::TheDimensionVector(l_idx[2]));
   const amrex::Real div =
-    difmag * amrex::min<amrex::Real>(
-               0.0, AMREX_D_PICK(
-                      divu(iv), 0.5 * (divu(iv) + divu(ivpj)),
-                      0.25 * (divu(iv) + divu(ivpj) + divu(ivpk) + divu(ivpp))));
+    difmag *
+    amrex::min<amrex::Real>(
+      0.0, AMREX_D_PICK(
+             divu(iv), 0.5 * (divu(iv) + divu(ivpj)),
+             0.25 * (divu(iv) + divu(ivpj) + divu(ivpk) + divu(ivpp))));
 
   for (int n = 0; n < NVAR; ++n) {
     if (n != UTEMP) {

--- a/Source/Godunov.H
+++ b/Source/Godunov.H
@@ -661,10 +661,10 @@ pc_artif_visc(
     iv + amrex::IntVect::TheDimensionVector(l_idx[1]) +
     amrex::IntVect::TheDimensionVector(l_idx[2]));
   const amrex::Real div1 =
-    difmag *
-    amrex::min<amrex::Real>(
-      0.0, AMREX_D_PICK(div(iv), 0.5 * (div(iv) + div(ivpj)),
-                        0.25 * (div(iv) + div(ivpj) + div(ivpk) + div(ivpp))));
+    difmag * amrex::min<amrex::Real>(
+               0.0, AMREX_D_PICK(
+                      div(iv), 0.5 * (div(iv) + div(ivpj)),
+                      0.25 * (div(iv) + div(ivpj) + div(ivpk) + div(ivpp))));
 
   for (int n = 0; n < NVAR; ++n) {
     if (n != UTEMP) {

--- a/Source/Godunov.H
+++ b/Source/Godunov.H
@@ -657,15 +657,20 @@ pc_artif_visc(
 
   const amrex::IntVect ivpj(iv + amrex::IntVect::TheDimensionVector(l_idx[1]));
   const amrex::IntVect ivpk(iv + amrex::IntVect::TheDimensionVector(l_idx[2]));
-  const amrex::IntVect ivpp(iv + amrex::IntVect::TheDimensionVector(l_idx[1]) + amrex::IntVect::TheDimensionVector(l_idx[2]));
-  const amrex::Real div1 = difmag * amrex::min<amrex::Real>(0.0,AMREX_D_PICK(div(iv), 0.5 * (div(iv) + div(ivpj)), 0.25 * (div(iv) + div(ivpj) +
-                                                                                                                                       div(ivpk) + div(ivpp));));
-  
-    for (int n = 0; n < NVAR; ++n) {
-      if (n != UTEMP) {
-        flx(iv, n) += dx * div1 * (u(iv, n) - u(ivm, n));
-      }
+  const amrex::IntVect ivpp(
+    iv + amrex::IntVect::TheDimensionVector(l_idx[1]) +
+    amrex::IntVect::TheDimensionVector(l_idx[2]));
+  const amrex::Real div1 =
+    difmag *
+    amrex::min<amrex::Real>(
+      0.0, AMREX_D_PICK(div(iv), 0.5 * (div(iv) + div(ivpj)),
+                        0.25 * (div(iv) + div(ivpj) + div(ivpk) + div(ivpp));));
+
+  for (int n = 0; n < NVAR; ++n) {
+    if (n != UTEMP) {
+      flx(iv, n) += dx * div1 * (u(iv, n) - u(ivm, n));
     }
+  }
   flx(iv, UTEMP) = 0.0;
 }
 

--- a/Source/Godunov.H
+++ b/Source/Godunov.H
@@ -664,7 +664,7 @@ pc_artif_visc(
     difmag *
     amrex::min<amrex::Real>(
       0.0, AMREX_D_PICK(div(iv), 0.5 * (div(iv) + div(ivpj)),
-                        0.25 * (div(iv) + div(ivpj) + div(ivpk) + div(ivpp));));
+                        0.25 * (div(iv) + div(ivpj) + div(ivpk) + div(ivpp))));
 
   for (int n = 0; n < NVAR; ++n) {
     if (n != UTEMP) {

--- a/Source/Godunov.H
+++ b/Source/Godunov.H
@@ -647,41 +647,26 @@ pc_artif_visc(
   amrex::Real const difmag,
   const int dir)
 {
-  amrex::Real div1;
-  if (dir == 0) { // X direction
-    AMREX_D_PICK(div1 = div(i, j, k);
-                 , div1 = 0.5 * (div(i, j, k) + div(i, j + 1, k));
-                 , div1 = 0.25 * (div(i, j, k) + div(i, j + 1, k) +
-                                  div(i, j, k + 1) + div(i, j + 1, k + 1)););
-    div1 = difmag * amrex::min<amrex::Real>(0.0, div1);
+  const amrex::IntVect iv{AMREX_D_DECL(i, j, k)};
+  const amrex::IntVect ivm(iv - amrex::IntVect::TheDimensionVector(dir));
+  const amrex::GpuArray<const int, 3> bdim{{dir == 0, dir == 1, dir == 2}};
+  const amrex::GpuArray<const int, 3> l_idx{
+    {bdim[0] * 0 + bdim[1] * 1 + bdim[2] * 2,
+     bdim[0] * 1 + bdim[1] * 0 + bdim[2] * 0,
+     bdim[0] * 2 + bdim[1] * 2 + bdim[2] * 1}};
+
+  const amrex::IntVect ivpj(iv + amrex::IntVect::TheDimensionVector(l_idx[1]));
+  const amrex::IntVect ivpk(iv + amrex::IntVect::TheDimensionVector(l_idx[2]));
+  const amrex::IntVect ivpp(iv + amrex::IntVect::TheDimensionVector(l_idx[1]) + amrex::IntVect::TheDimensionVector(l_idx[2]));
+  const amrex::Real div1 = difmag * amrex::min<amrex::Real>(0.0,AMREX_D_PICK(div(iv), 0.5 * (div(iv) + div(ivpj)), 0.25 * (div(iv) + div(ivpj) +
+                                                                                                                                       div(ivpk) + div(ivpp));));
+  
     for (int n = 0; n < NVAR; ++n) {
       if (n != UTEMP) {
-        flx(i, j, k, n) += dx * div1 * (u(i, j, k, n) - u(i - 1, j, k, n));
+        flx(iv, n) += dx * div1 * (u(iv, n) - u(ivm, n));
       }
     }
-  } else if (dir == 1) { // Y direction
-    AMREX_D_PICK(, div1 = 0.5 * (div(i, j, k) + div(i + 1, j, k));
-                 , div1 = 0.25 * (div(i, j, k) + div(i + 1, j, k) +
-                                  div(i, j, k + 1) + div(i + 1, j, k + 1)););
-    div1 = difmag * amrex::min<amrex::Real>(0.0, div1);
-    for (int n = 0; n < NVAR; ++n) {
-      if (n != UTEMP) {
-        flx(i, j, k, n) +=
-          dx * div1 * (u(i, j, k, n) - u(i, j - 1, k, n)); // Here dx is dy
-      }
-    }
-  } else { // Z direction
-    div1 = 0.25 * (div(i, j, k) + div(i + 1, j, k) + div(i, j + 1, k) +
-                   div(i + 1, j + 1, k));
-    div1 = difmag * amrex::min<amrex::Real>(0.0, div1);
-    for (int n = 0; n < NVAR; ++n) {
-      if (n != UTEMP) {
-        flx(i, j, k, n) +=
-          dx * div1 * (u(i, j, k, n) - u(i, j, k - 1, n)); // Here dx is dz
-      }
-    }
-  }
-  flx(i, j, k, UTEMP) = 0.0;
+  flx(iv, UTEMP) = 0.0;
 }
 
 // Host Functions

--- a/Source/Hydro.H
+++ b/Source/Hydro.H
@@ -169,6 +169,7 @@ void pc_umdrv(
   const amrex::Real dt,
   const int ppm_type,
   const int use_flattening,
+  const amrex::Real difmag,
   const amrex::GpuArray<const amrex::Array4<amrex::Real>, AMREX_SPACEDIM> flx,
   const amrex::GpuArray<const amrex::Array4<const amrex::Real>, AMREX_SPACEDIM>
     a,

--- a/Source/Hydro.cpp
+++ b/Source/Hydro.cpp
@@ -217,7 +217,7 @@ PeleC::construct_hydro_source(
         pc_umdrv(
           is_finest_level, time, fbx, domain_lo, domain_hi, phys_bc.lo(),
           phys_bc.hi(), s, hyd_src, qarr, qauxar, srcqarr, dx, dt, ppm_type,
-          use_flattening, flx_arr, a, volume.array(mfi), cflLoc);
+          use_flattening, difmag, flx_arr, a, volume.array(mfi), cflLoc);
         BL_PROFILE_VAR_STOP(purm);
 
         BL_PROFILE_VAR("courno + flux reg", crno);
@@ -352,6 +352,7 @@ pc_umdrv(
   const amrex::Real dt,
   const int ppm_type,
   const int use_flattening,
+  const amrex::Real difmag,
   const amrex::GpuArray<const amrex::Array4<amrex::Real>, AMREX_SPACEDIM> flx,
   const amrex::GpuArray<const amrex::Array4<const amrex::Real>, AMREX_SPACEDIM>
     a,
@@ -408,7 +409,6 @@ pc_umdrv(
   });
 
   // consup
-  amrex::Real difmag = 0.1;
   pc_consup(bx, uin, uout, flx, a, vol, divarr, pdivuarr, dx, difmag);
 }
 

--- a/Source/Hydro.cpp
+++ b/Source/Hydro.cpp
@@ -376,7 +376,7 @@ pc_umdrv(
   amrex::FArrayBox pdivu(bx, 1);
   amrex::Elixir divueli = divu.elixir();
   amrex::Elixir pdiveli = pdivu.elixir();
-  auto const& divarr = divu.array();
+  auto const& divuarr = divu.array();
   auto const& pdivuarr = pdivu.array();
 
   BL_PROFILE_VAR("PeleC::umeth()", umeth);
@@ -405,11 +405,11 @@ pc_umdrv(
   AMREX_D_TERM(const amrex::Real dx0 = dx[0];, const amrex::Real dx1 = dx[1];
                , const amrex::Real dx2 = dx[2];);
   amrex::ParallelFor(bxg2, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-    pc_divu(i, j, k, q, AMREX_D_DECL(dx0, dx1, dx2), divarr);
+    pc_divu(i, j, k, q, AMREX_D_DECL(dx0, dx1, dx2), divuarr);
   });
 
   // consup
-  pc_consup(bx, uin, uout, flx, a, vol, divarr, pdivuarr, dx, difmag);
+  pc_consup(bx, uin, uout, flx, a, vol, divuarr, pdivuarr, dx, difmag);
 }
 
 void
@@ -421,7 +421,7 @@ pc_consup(
   const amrex::GpuArray<const amrex::Array4<const amrex::Real>, AMREX_SPACEDIM>
     a,
   amrex::Array4<const amrex::Real> const& vol,
-  amrex::Array4<const amrex::Real> const& div,
+  amrex::Array4<const amrex::Real> const& divu,
   amrex::Array4<const amrex::Real> const& pdivu,
   amrex::Real const* del,
   amrex::Real const difmag)
@@ -431,7 +431,7 @@ pc_consup(
     amrex::Box const& fbx = surroundingNodes(bx, dir);
     const amrex::Real dx = del[dir];
     amrex::ParallelFor(fbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-      pc_artif_visc(i, j, k, flx[dir], div, u, dx, difmag, dir);
+      pc_artif_visc(i, j, k, flx[dir], divu, u, dx, difmag, dir);
       // Normalize Species Flux
       pc_norm_spec_flx(i, j, k, flx[dir]);
       // Make flux extensive


### PR DESCRIPTION
We weren't passing in the user input `difmag` to the place where it was actually used... 