### PR TITLE
Add warning coverage and fix new warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
         run: cmake --build build-${{matrix.cuda_pkg}} --parallel ${{env.NPROCS}}
   cppcheck:
     needs: Formatting
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.6.0
@@ -205,8 +205,7 @@ jobs:
           submodules: true
       - name: Dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y cppcheck
+          brew install cppcheck
       - name: Configure
         run: |
           cmake -B${{runner.workspace}}/build-cppcheck \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,7 @@ jobs:
       - name: PMF debug make
         working-directory: ./Exec/RegTests/PMF
         run: |
+          echo "::add-matcher::.github/problem-matchers/gcc.json"
           make COMP=gnu USE_MPI=FALSE DEBUG=TRUE TPL
           make -j ${{env.NPROCS}} COMP=gnu USE_MPI=FALSE DEBUG=TRUE
       - name: PMF debug test
@@ -144,7 +145,9 @@ jobs:
         run: ./PeleC3d.gnu.DEBUG.ex pmf-lidryer-arkode.inp max_step=2 amr.plot_files_output=0 amr.checkpoint_files_output=0
       - name: EB debug build
         working-directory: ./Exec/RegTests/EB-C10
-        run: make -j ${{env.NPROCS}} COMP=gnu USE_MPI=FALSE DEBUG=TRUE
+        run: |
+          echo "::add-matcher::.github/problem-matchers/gcc.json"
+          make -j ${{env.NPROCS}} COMP=gnu USE_MPI=FALSE DEBUG=TRUE
       - name: EB debug test
         working-directory: ./Exec/RegTests/EB-C10
         run: ./PeleC3d.gnu.DEBUG.ex eb-c10.inp max_step=2 amr.plot_files_output=0 amr.checkpoint_files_output=0

--- a/CMake/PeleCUtils.cmake
+++ b/CMake/PeleCUtils.cmake
@@ -40,7 +40,7 @@ macro(init_code_checks)
           # cppcheck ignores -isystem directories, so we change them to regular -I include directories (with no spaces either)
           COMMAND sed "s/isystem /I/g" compile_commands.json > cppcheck/cppcheck_compile_commands.json
           COMMAND ${CPPCHECK_EXE} --version
-          COMMAND ${CPPCHECK_EXE} --template=gcc --inline-suppr --suppress=unusedFunction --suppress=useStlAlgorithm --suppress=unmatchedSuppression --std=c++14 --language=c++ --enable=all --project=cppcheck/cppcheck_compile_commands.json --cppcheck-build-dir=cppcheck/cppcheck-wd -i ${CMAKE_SOURCE_DIR}/Submodules/AMReX/Src -i ${CMAKE_SOURCE_DIR}/Submodules/GoogleTest --output-file=cppcheck/cppcheck-full-report.txt -j ${NP}
+          COMMAND ${CPPCHECK_EXE} --template=gcc --inline-suppr --suppress=unusedFunction --suppress=useStlAlgorithm --std=c++14 --language=c++ --enable=all --project=cppcheck/cppcheck_compile_commands.json --cppcheck-build-dir=cppcheck/cppcheck-wd -i ${CMAKE_SOURCE_DIR}/Submodules/AMReX/Src -i ${CMAKE_SOURCE_DIR}/Submodules/GoogleTest --output-file=cppcheck/cppcheck-full-report.txt -j ${NP}
           # Currently we filter analysis from submodules after cppcheck has run
           #COMMAND awk -v nlines=2 "/Submodules\/AMReX/ || /Submodules\/GoogleTest/ {for (i=0; i<nlines; i++) {getline}; next} 1" < cppcheck/cppcheck-full-report.txt > cppcheck/cppcheck-short-report.txt
           COMMAND awk -v nlines=2 "/Submodules/ {for (i=0; i<nlines; i++) {getline}; next} 1" < cppcheck/cppcheck-full-report.txt > cppcheck/cppcheck-short-report.txt

--- a/Exec/RegTests/HIT/prob.H
+++ b/Exec/RegTests/HIT/prob.H
@@ -44,7 +44,7 @@ pc_initdata(
   state(i, j, k, URHO) = prob_parm.rho0;
   state(i, j, k, UEINT) = prob_parm.rho0 * prob_parm.eint0;
   state(i, j, k, UTEMP) = prob_parm.T0;
-  amrex::Real massfrac[NUM_SPECIES] = {1.0};
+  const amrex::Real massfrac[NUM_SPECIES] = {1.0};
   for (int n = 0; n < NUM_SPECIES; n++)
     state(i, j, k, UFS + n) = prob_parm.rho0 * massfrac[n];
 

--- a/Exec/RegTests/PMF-SRK/prob.cpp
+++ b/Exec/RegTests/PMF-SRK/prob.cpp
@@ -51,14 +51,14 @@ read_pmf(const std::string& myfile)
     pos1 = pos2 + 1;
   }
 
-  //amrex::Vector<std::string> pmf_names;
-  //pmf_names.resize(variable_count);
+  // amrex::Vector<std::string> pmf_names;
+  // pmf_names.resize(variable_count);
   pos1 = 0;
   // pos2 = 0;
   for (int i = 0; i < variable_count; i++) {
     pos1 = firstline.find('"', pos1);
     pos2 = firstline.find('"', pos1 + 1);
-    //pmf_names[i] = firstline.substr(pos1 + 1, pos2 - (pos1 + 1));
+    // pmf_names[i] = firstline.substr(pos1 + 1, pos2 - (pos1 + 1));
     pos1 = pos2 + 1;
   }
 

--- a/Exec/RegTests/PMF-SRK/prob.cpp
+++ b/Exec/RegTests/PMF-SRK/prob.cpp
@@ -51,14 +51,14 @@ read_pmf(const std::string& myfile)
     pos1 = pos2 + 1;
   }
 
-  amrex::Vector<std::string> pmf_names;
-  pmf_names.resize(variable_count);
+  //amrex::Vector<std::string> pmf_names;
+  //pmf_names.resize(variable_count);
   pos1 = 0;
   // pos2 = 0;
   for (int i = 0; i < variable_count; i++) {
     pos1 = firstline.find('"', pos1);
     pos2 = firstline.find('"', pos1 + 1);
-    pmf_names[i] = firstline.substr(pos1 + 1, pos2 - (pos1 + 1));
+    //pmf_names[i] = firstline.substr(pos1 + 1, pos2 - (pos1 + 1));
     pos1 = pos2 + 1;
   }
 

--- a/Exec/RegTests/PMF/prob.cpp
+++ b/Exec/RegTests/PMF/prob.cpp
@@ -51,14 +51,14 @@ read_pmf(const std::string& myfile)
     pos1 = pos2 + 1;
   }
 
-  //amrex::Vector<std::string> pmf_names;
-  //pmf_names.resize(variable_count);
+  // amrex::Vector<std::string> pmf_names;
+  // pmf_names.resize(variable_count);
   pos1 = 0;
   // pos2 = 0;
   for (int i = 0; i < variable_count; i++) {
     pos1 = firstline.find('"', pos1);
     pos2 = firstline.find('"', pos1 + 1);
-    //pmf_names[i] = firstline.substr(pos1 + 1, pos2 - (pos1 + 1));
+    // pmf_names[i] = firstline.substr(pos1 + 1, pos2 - (pos1 + 1));
     pos1 = pos2 + 1;
   }
 

--- a/Exec/RegTests/PMF/prob.cpp
+++ b/Exec/RegTests/PMF/prob.cpp
@@ -51,14 +51,14 @@ read_pmf(const std::string& myfile)
     pos1 = pos2 + 1;
   }
 
-  amrex::Vector<std::string> pmf_names;
-  pmf_names.resize(variable_count);
+  //amrex::Vector<std::string> pmf_names;
+  //pmf_names.resize(variable_count);
   pos1 = 0;
   // pos2 = 0;
   for (int i = 0; i < variable_count; i++) {
     pos1 = firstline.find('"', pos1);
     pos2 = firstline.find('"', pos1 + 1);
-    pmf_names[i] = firstline.substr(pos1 + 1, pos2 - (pos1 + 1));
+    //pmf_names[i] = firstline.substr(pos1 + 1, pos2 - (pos1 + 1));
     pos1 = pos2 + 1;
   }
 

--- a/Exec/UnitTests/test-config.cpp
+++ b/Exec/UnitTests/test-config.cpp
@@ -15,7 +15,6 @@ const char* buildInfoGetGitHash(int i);
 
 namespace pelec_tests {
 
-// cppcheck-suppress missingOverride
 TEST(Configuration, Build)
 {
   const char* pc_git = amrex::buildInfoGetGitHash(1);
@@ -24,7 +23,6 @@ TEST(Configuration, Build)
                  << "AMReX SHA = " << amrex_git << std::endl;
 }
 
-// cppcheck-suppress missingOverride
 TEST(Configuration, MPI)
 {
 #ifdef AMREX_USE_MPI
@@ -41,7 +39,6 @@ TEST(Configuration, MPI)
 #endif
 }
 
-// cppcheck-suppress missingOverride
 TEST(Configuration, CUDA)
 {
 #ifdef AMREX_USE_CUDA

--- a/Source/Advance.cpp
+++ b/Source/Advance.cpp
@@ -61,7 +61,6 @@ PeleC::do_mol_advance(
   }
 
   // get old and new state
-  // cppcheck-suppress constVariable
   amrex::MultiFab& S_old = get_old_data(State_Type);
   amrex::MultiFab& S_new = get_new_data(State_Type);
 

--- a/Source/Advance.cpp
+++ b/Source/Advance.cpp
@@ -61,7 +61,7 @@ PeleC::do_mol_advance(
   }
 
   // get old and new state
-  amrex::MultiFab& S_old = get_old_data(State_Type);
+  const amrex::MultiFab& S_old = get_old_data(State_Type);
   amrex::MultiFab& S_new = get_new_data(State_Type);
 
   // define sourceterm

--- a/Source/Advance.cpp
+++ b/Source/Advance.cpp
@@ -61,7 +61,7 @@ PeleC::do_mol_advance(
   }
 
   // get old and new state
-  const amrex::MultiFab& S_old = get_old_data(State_Type);
+  amrex::MultiFab& S_old = get_old_data(State_Type);
   amrex::MultiFab& S_new = get_new_data(State_Type);
 
   // define sourceterm

--- a/Source/EB.H
+++ b/Source/EB.H
@@ -139,11 +139,11 @@ AMREX_FORCE_INLINE
 void
 get_weightvec(
   AMREX_D_DECL(
-    amrex::Real delta_x_i[NLSPTS],
-    amrex::Real delta_y_i[NLSPTS],
-    amrex::Real delta_z_i[NLSPTS]),
+    const amrex::Real delta_x_i[NLSPTS],
+    const amrex::Real delta_y_i[NLSPTS],
+    const amrex::Real delta_z_i[NLSPTS]),
   int N,
-  amrex::Real qmat[NEL_TRIMAT],
+  const amrex::Real qmat[NEL_TRIMAT],
   amrex::Real wvec[NLSPTS][AMREX_SPACEDIM])
 {
   amrex::Real r11 = qmat[0];

--- a/Source/EB.cpp
+++ b/Source/EB.cpp
@@ -268,7 +268,7 @@ pc_fill_bndry_grad_stencil_ls(
       const amrex::Real n[AMREX_SPACEDIM] = {AMREX_D_DECL(
         ebg[L].eb_normal[0], ebg[L].eb_normal[1], ebg[L].eb_normal[2])};
 
-      amrex::Real centcoord[AMREX_SPACEDIM] = {AMREX_D_DECL(
+      const amrex::Real centcoord[AMREX_SPACEDIM] = {AMREX_D_DECL(
         ebg[L].eb_centroid[0], ebg[L].eb_centroid[1], ebg[L].eb_centroid[2])};
 
       const int ivs[AMREX_SPACEDIM] = {

--- a/Source/Hydro.cpp
+++ b/Source/Hydro.cpp
@@ -62,19 +62,19 @@ PeleC::construct_hydro_source(
     amrex::MultiFab& S_new = get_new_data(State_Type);
 
     // note: the radiation consup currently does not fill these
-    amrex::Real E_added_flux = 0.;    // cppcheck-suppress variableScope
-    amrex::Real mass_added_flux = 0.; // cppcheck-suppress variableScope
-    amrex::Real xmom_added_flux = 0.; // cppcheck-suppress variableScope
-    amrex::Real ymom_added_flux = 0.; // cppcheck-suppress variableScope
-    amrex::Real zmom_added_flux = 0.; // cppcheck-suppress variableScope
-    amrex::Real mass_lost = 0.;       // cppcheck-suppress variableScope
-    amrex::Real xmom_lost = 0.;       // cppcheck-suppress variableScope
-    amrex::Real ymom_lost = 0.;       // cppcheck-suppress variableScope
-    amrex::Real zmom_lost = 0.;       // cppcheck-suppress variableScope
-    amrex::Real eden_lost = 0.;       // cppcheck-suppress variableScope
-    amrex::Real xang_lost = 0.;       // cppcheck-suppress variableScope
-    amrex::Real yang_lost = 0.;       // cppcheck-suppress variableScope
-    amrex::Real zang_lost = 0.;       // cppcheck-suppress variableScope
+    amrex::Real E_added_flux = 0.;
+    amrex::Real mass_added_flux = 0.;
+    amrex::Real xmom_added_flux = 0.;
+    amrex::Real ymom_added_flux = 0.;
+    amrex::Real zmom_added_flux = 0.;
+    amrex::Real mass_lost = 0.;
+    amrex::Real xmom_lost = 0.;
+    amrex::Real ymom_lost = 0.;
+    amrex::Real zmom_lost = 0.;
+    amrex::Real eden_lost = 0.;
+    amrex::Real xang_lost = 0.;
+    amrex::Real yang_lost = 0.;
+    amrex::Real zang_lost = 0.;
 
     BL_PROFILE_VAR("PeleC::advance_hydro_pc_umdrv()", PC_UMDRV);
 

--- a/Source/IO.cpp
+++ b/Source/IO.cpp
@@ -117,7 +117,7 @@ PeleC::restart(amrex::Amr& papa, std::istream& is, bool bReadSpecial)
   init_eb(geom, grids, dmap);
 #endif
 
-  amrex::MultiFab& S_new = get_new_data(State_Type);
+  const amrex::MultiFab& S_new = get_new_data(State_Type);
 
   for (int n = 0; n < src_list.size(); ++n) {
     int oldGrow = numGrow();

--- a/Source/InitEB.cpp
+++ b/Source/InitEB.cpp
@@ -379,7 +379,7 @@ PeleC::set_body_state(const amrex::MultiFab& S)
 #endif
   for (amrex::MFIter mfi(S, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
     const amrex::Box& vbox = mfi.tilebox();
-    const auto const& Sar = S.array(mfi);
+    auto const& Sar = S.array(mfi);
     auto const& flag_arr = flags.const_array(mfi);
     auto const captured_body_state = body_state;
     amrex::ParallelFor(

--- a/Source/InitEB.cpp
+++ b/Source/InitEB.cpp
@@ -359,7 +359,7 @@ PeleC::define_body_state()
 }
 
 void
-PeleC::set_body_state(amrex::MultiFab& S)
+PeleC::set_body_state(const amrex::MultiFab& S)
 {
   BL_PROFILE("PeleC::set_body_state()");
 

--- a/Source/InitEB.cpp
+++ b/Source/InitEB.cpp
@@ -359,7 +359,7 @@ PeleC::define_body_state()
 }
 
 void
-PeleC::set_body_state(const amrex::MultiFab& S)
+PeleC::set_body_state(amrex::MultiFab& S)
 {
   BL_PROFILE("PeleC::set_body_state()");
 
@@ -379,9 +379,9 @@ PeleC::set_body_state(const amrex::MultiFab& S)
 #endif
   for (amrex::MFIter mfi(S, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
     const amrex::Box& vbox = mfi.tilebox();
-    const auto& Sar = S.array(mfi);
-    const auto& flag_arr = flags.const_array(mfi);
-    const auto captured_body_state = body_state;
+    auto const& Sar = S.array(mfi);
+    auto const& flag_arr = flags.const_array(mfi);
+    auto const captured_body_state = body_state;
     amrex::ParallelFor(
       vbox, NVAR, [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) noexcept {
         pc_set_body_state(i, j, k, n, flag_arr, captured_body_state, Sar);
@@ -407,8 +407,8 @@ PeleC::zero_in_body(amrex::MultiFab& S) const
 #endif
   for (amrex::MFIter mfi(S, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
     const amrex::Box& vbox = mfi.tilebox();
-    const auto& Sar = S.array(mfi);
-    const auto& flag_arr = flags.const_array(mfi);
+    auto const& Sar = S.array(mfi);
+    auto const& flag_arr = flags.const_array(mfi);
     amrex::ParallelFor(
       vbox, NVAR, [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) noexcept {
         pc_set_body_state(i, j, k, n, flag_arr, zeros, Sar);

--- a/Source/InitEB.cpp
+++ b/Source/InitEB.cpp
@@ -379,9 +379,9 @@ PeleC::set_body_state(const amrex::MultiFab& S)
 #endif
   for (amrex::MFIter mfi(S, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
     const amrex::Box& vbox = mfi.tilebox();
-    auto const& Sar = S.array(mfi);
-    auto const& flag_arr = flags.const_array(mfi);
-    auto const captured_body_state = body_state;
+    const auto& Sar = S.array(mfi);
+    const auto& flag_arr = flags.const_array(mfi);
+    const auto captured_body_state = body_state;
     amrex::ParallelFor(
       vbox, NVAR, [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) noexcept {
         pc_set_body_state(i, j, k, n, flag_arr, captured_body_state, Sar);
@@ -407,8 +407,8 @@ PeleC::zero_in_body(amrex::MultiFab& S) const
 #endif
   for (amrex::MFIter mfi(S, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
     const amrex::Box& vbox = mfi.tilebox();
-    auto const& Sar = S.array(mfi);
-    auto const& flag_arr = flags.const_array(mfi);
+    const auto& Sar = S.array(mfi);
+    const auto& flag_arr = flags.const_array(mfi);
     amrex::ParallelFor(
       vbox, NVAR, [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) noexcept {
         pc_set_body_state(i, j, k, n, flag_arr, zeros, Sar);

--- a/Source/InitEB.cpp
+++ b/Source/InitEB.cpp
@@ -379,7 +379,7 @@ PeleC::set_body_state(const amrex::MultiFab& S)
 #endif
   for (amrex::MFIter mfi(S, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
     const amrex::Box& vbox = mfi.tilebox();
-    auto const& Sar = S.array(mfi);
+    const auto const& Sar = S.array(mfi);
     auto const& flag_arr = flags.const_array(mfi);
     auto const captured_body_state = body_state;
     amrex::ParallelFor(

--- a/Source/PeleC.H
+++ b/Source/PeleC.H
@@ -644,7 +644,7 @@ protected:
   static amrex::Real
   enforce_min_density(amrex::MultiFab& S_old, const amrex::MultiFab& S_new);
 
-  amrex::Real clean_state(amrex::MultiFab& S);
+  amrex::Real clean_state(const amrex::MultiFab& S);
 
   static amrex::Real
   clean_state(const amrex::MultiFab& S, amrex::MultiFab& S_old);

--- a/Source/PeleC.H
+++ b/Source/PeleC.H
@@ -225,7 +225,7 @@ public:
 
   void define_body_state();
 
-  void set_body_state(const amrex::MultiFab& S);
+  void set_body_state(amrex::MultiFab& S);
 
   void zero_in_body(amrex::MultiFab& S) const;
 #endif

--- a/Source/PeleC.H
+++ b/Source/PeleC.H
@@ -225,7 +225,7 @@ public:
 
   void define_body_state();
 
-  void set_body_state(amrex::MultiFab& S);
+  void set_body_state(const amrex::MultiFab& S);
 
   void zero_in_body(amrex::MultiFab& S) const;
 #endif

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -396,7 +396,7 @@ PeleC::PeleC(
   init_eb(level_geom, bl, dm);
 #endif
 
-  amrex::MultiFab& S_new = get_new_data(State_Type);
+  const amrex::MultiFab& S_new = get_new_data(State_Type);
 
   for (int n = 0; n < src_list.size(); ++n) {
     int oldGrow = numGrow();

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -582,17 +582,17 @@ PeleC::setGridInfo()
     const int nlevs = max_level + 1;
     const int size = 3 * nlevs;
 
-    //amrex::Vector<amrex::Real> dx_level(size);
+    // amrex::Vector<amrex::Real> dx_level(size);
     amrex::Vector<int> domlo_level(size);
     amrex::Vector<int> domhi_level(size);
 
-    //const amrex::Real* dx_coarse = geom.CellSize();
+    // const amrex::Real* dx_coarse = geom.CellSize();
 
     const int* domlo_coarse = geom.Domain().loVect();
     const int* domhi_coarse = geom.Domain().hiVect();
 
     for (int dir = 0; dir < 3; dir++) {
-      //dx_level[dir] = (ZFILL(dx_coarse))[dir];
+      // dx_level[dir] = (ZFILL(dx_coarse))[dir];
 
       domlo_level[dir] = (ARLIM_3D(domlo_coarse))[dir];
       domhi_level[dir] = (ARLIM_3D(domhi_coarse))[dir];
@@ -608,14 +608,15 @@ PeleC::setGridInfo()
 
       for (int dir = 0; dir < 3; dir++) {
         if (dir < AMREX_SPACEDIM) {
-          //dx_level[3 * lev + dir] = dx_level[3 * (lev - 1) + dir] / ref_ratio[dir];
+          // dx_level[3 * lev + dir] = dx_level[3 * (lev - 1) + dir] /
+          // ref_ratio[dir];
           int ncell = (domhi_level[3 * (lev - 1) + dir] -
                        domlo_level[3 * (lev - 1) + dir] + 1) *
                       ref_ratio[dir];
           domlo_level[3 * lev + dir] = domlo_level[dir];
           domhi_level[3 * lev + dir] = domlo_level[3 * lev + dir] + ncell - 1;
         } else {
-          //dx_level[3 * lev + dir] = 0.0;
+          // dx_level[3 * lev + dir] = 0.0;
           domlo_level[3 * lev + dir] = 0;
           domhi_level[3 * lev + dir] = 0;
         }

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -582,17 +582,17 @@ PeleC::setGridInfo()
     const int nlevs = max_level + 1;
     const int size = 3 * nlevs;
 
-    amrex::Vector<amrex::Real> dx_level(size);
+    //amrex::Vector<amrex::Real> dx_level(size);
     amrex::Vector<int> domlo_level(size);
     amrex::Vector<int> domhi_level(size);
 
-    const amrex::Real* dx_coarse = geom.CellSize();
+    //const amrex::Real* dx_coarse = geom.CellSize();
 
     const int* domlo_coarse = geom.Domain().loVect();
     const int* domhi_coarse = geom.Domain().hiVect();
 
     for (int dir = 0; dir < 3; dir++) {
-      dx_level[dir] = (ZFILL(dx_coarse))[dir];
+      //dx_level[dir] = (ZFILL(dx_coarse))[dir];
 
       domlo_level[dir] = (ARLIM_3D(domlo_coarse))[dir];
       domhi_level[dir] = (ARLIM_3D(domhi_coarse))[dir];
@@ -608,15 +608,14 @@ PeleC::setGridInfo()
 
       for (int dir = 0; dir < 3; dir++) {
         if (dir < AMREX_SPACEDIM) {
-          dx_level[3 * lev + dir] =
-            dx_level[3 * (lev - 1) + dir] / ref_ratio[dir];
+          //dx_level[3 * lev + dir] = dx_level[3 * (lev - 1) + dir] / ref_ratio[dir];
           int ncell = (domhi_level[3 * (lev - 1) + dir] -
                        domlo_level[3 * (lev - 1) + dir] + 1) *
                       ref_ratio[dir];
           domlo_level[3 * lev + dir] = domlo_level[dir];
           domhi_level[3 * lev + dir] = domlo_level[3 * lev + dir] + ncell - 1;
         } else {
-          dx_level[3 * lev + dir] = 0.0;
+          //dx_level[3 * lev + dir] = 0.0;
           domlo_level[3 * lev + dir] = 0;
           domhi_level[3 * lev + dir] = 0;
         }
@@ -837,6 +836,7 @@ amrex::Real PeleC::estTimeStep(amrex::Real /*dt_old*/)
     amrex::Real AMREX_D_DECL(dx1 = dx[0], dx2 = dx[1], dx3 = dx[2]);
 
     if (do_hydro) {
+      // cppcheck-suppress uninitvar
       amrex::Real dt = amrex::ReduceMin(
         stateMF,
 #ifdef PELEC_USE_EB
@@ -862,6 +862,7 @@ amrex::Real PeleC::estTimeStep(amrex::Real /*dt_old*/)
 
     if (diffuse_vel) {
       auto const* ltransparm = trans_parms.device_trans_parm();
+      // cppcheck-suppress uninitvar
       amrex::Real dt = amrex::ReduceMin(
         stateMF,
 #ifdef PELEC_USE_EB
@@ -887,6 +888,7 @@ amrex::Real PeleC::estTimeStep(amrex::Real /*dt_old*/)
 
     if (diffuse_temp) {
       auto const* ltransparm = trans_parms.device_trans_parm();
+      // cppcheck-suppress uninitvar
       amrex::Real dt = amrex::ReduceMin(
         stateMF,
 #ifdef PELEC_USE_EB
@@ -912,6 +914,7 @@ amrex::Real PeleC::estTimeStep(amrex::Real /*dt_old*/)
 
     if (diffuse_enth) {
       auto const* ltransparm = trans_parms.device_trans_parm();
+      // cppcheck-suppress uninitvar
       amrex::Real dt = amrex::ReduceMin(
         stateMF,
 #ifdef PELEC_USE_EB
@@ -1459,9 +1462,9 @@ PeleC::enforce_min_density(
   // is meaningless.
 
   amrex::Real dens_change = 1.0;
-  amrex::Real mass_added = 0.0; // cppcheck-suppress variableScope
-  amrex::Real eint_added = 0.0; // cppcheck-suppress variableScope
-  amrex::Real eden_added = 0.0; // cppcheck-suppress variableScope
+  amrex::Real mass_added = 0.0;
+  amrex::Real eint_added = 0.0;
+  amrex::Real eden_added = 0.0;
 
 #ifdef PELEC_USE_EB
   auto const& fact =
@@ -1541,7 +1544,7 @@ PeleC::avgDown(int state_indx)
   }
 
   amrex::MultiFab& S_crse = get_new_data(state_indx);
-  amrex::MultiFab& S_fine = getLevel(level + 1).get_new_data(state_indx);
+  const amrex::MultiFab& S_fine = getLevel(level + 1).get_new_data(state_indx);
 
 #ifdef PELEC_USE_EB
   PeleC& fine_lev = getLevel(level + 1);
@@ -2210,7 +2213,7 @@ PeleC::build_interior_boundary_mask(int ng)
 }
 
 amrex::Real
-PeleC::clean_state(amrex::MultiFab& S)
+PeleC::clean_state(const amrex::MultiFab& S)
 {
   // Enforce a minimum density.
 

--- a/Source/Setup.cpp
+++ b/Source/Setup.cpp
@@ -181,6 +181,7 @@ PeleC::variableSetUp()
   NumAdv = 0;
 #endif
 
+  // cppcheck-suppress knownConditionTrueFalse
   if (NumAdv > 0) {
     FirstAdv = cnt;
     cnt += NumAdv;


### PR DESCRIPTION
This switches to the latest `cppcheck` and fixes or suppresses newly reported warnings.