### PR TITLE
Fix rho after initial redistribution

### DIFF
--- a/Source/PeleC.H
+++ b/Source/PeleC.H
@@ -566,6 +566,12 @@ public:
 
   // static EB helper functions called from outside class
   static bool ebInitialized();
+
+  void InitialRedistribution(
+    const amrex::Real time,
+    const amrex::Vector<amrex::BCRec> bcs,
+    amrex::MultiFab& S_new);
+
 #else
   amrex::YAFluxRegister flux_reg;
 
@@ -648,8 +654,6 @@ protected:
 
   static amrex::Real
   clean_state(const amrex::MultiFab& S, amrex::MultiFab& S_old);
-
-  void InitialRedistribution();
 
   void buildMetrics();
 


### PR DESCRIPTION
In certain (rare) cases, the initial redistribution might change the `rho Y` at the EB. This ensures that `rho` is updated to reflect those changes (exactly like we do for the divergence of rho after state redistribution)