### PR TITLE
Bound initial small temperature values in pc_rst_int_e

### DIFF
--- a/Source/Constants.H
+++ b/Source/Constants.H
@@ -18,7 +18,7 @@ small_num()
   return 1.0e-8;
 }
 AMREX_GPU_HOST_DEVICE constexpr amrex::Real
-real_small_num()
+very_small_num()
 {
   return std::numeric_limits<amrex::Real>::epsilon() * 1e-100;
 }

--- a/Source/Constants.H
+++ b/Source/Constants.H
@@ -17,5 +17,10 @@ small_num()
 {
   return 1.0e-8;
 }
+AMREX_GPU_HOST_DEVICE constexpr amrex::Real
+real_small_num()
+{
+  return std::numeric_limits<amrex::Real>::epsilon() * 1e-100;
+}
 } // namespace constants
 #endif

--- a/Source/Utilities.H
+++ b/Source/Utilities.H
@@ -48,7 +48,6 @@ pc_rst_int_e(
   }
   auto eos = pele::physics::PhysicsType::eos();
   if (allow_small_energy == 0) {
-    std::numeric_limits<amrex::Real>::epsilon() * 1e-100;
     const amrex::Real rhoInv = 1.0 / S(i, j, k, URHO);
     const amrex::Real Up = S(i, j, k, UMX) * rhoInv;
     const amrex::Real Vp = S(i, j, k, UMY) * rhoInv;

--- a/Source/Utilities.H
+++ b/Source/Utilities.H
@@ -48,7 +48,8 @@ pc_rst_int_e(
   }
   auto eos = pele::physics::PhysicsType::eos();
   if (allow_small_energy == 0) {
-    const amrex::Real small_num = std::numeric_limits<amrex::Real>::epsilon() * 1e-100;
+    const amrex::Real small_num =
+      std::numeric_limits<amrex::Real>::epsilon() * 1e-100;
     const amrex::Real rhoInv = 1.0 / S(i, j, k, URHO);
     const amrex::Real Up = S(i, j, k, UMX) * rhoInv;
     const amrex::Real Vp = S(i, j, k, UMY) * rhoInv;
@@ -117,7 +118,8 @@ pc_rst_int_e(
       if (
         S(i, j, k, UEINT) <
         (S(i, j, k, URHO) * std::numeric_limits<amrex::Real>::min())) {
-        const amrex::Real small_num = std::numeric_limits<amrex::Real>::epsilon() * 1e-100;
+        const amrex::Real small_num =
+          std::numeric_limits<amrex::Real>::epsilon() * 1e-100;
         const amrex::Real eos_state_T = small_num;
         amrex::Real eos_state_massfrac[NUM_SPECIES] = {0.0};
         amrex::Real eos_state_ei[NUM_SPECIES] = {0.0};
@@ -149,7 +151,8 @@ pc_rst_int_e(
       } else if (
         S(i, j, k, UEINT) <=
         (S(i, j, k, URHO) * std::numeric_limits<amrex::Real>::min())) {
-        const amrex::Real small_num = std::numeric_limits<amrex::Real>::epsilon() * 1e-100;
+        const amrex::Real small_num =
+          std::numeric_limits<amrex::Real>::epsilon() * 1e-100;
         const amrex::Real eos_state_T = small_num;
         amrex::Real eos_state_massfrac[NUM_SPECIES] = {0.0};
         amrex::Real eos_state_ei[NUM_SPECIES] = {0.0};

--- a/Source/Utilities.H
+++ b/Source/Utilities.H
@@ -48,15 +48,14 @@ pc_rst_int_e(
   }
   auto eos = pele::physics::PhysicsType::eos();
   if (allow_small_energy == 0) {
-    const amrex::Real small_num =
-      std::numeric_limits<amrex::Real>::epsilon() * 1e-100;
+    std::numeric_limits<amrex::Real>::epsilon() * 1e-100;
     const amrex::Real rhoInv = 1.0 / S(i, j, k, URHO);
     const amrex::Real Up = S(i, j, k, UMX) * rhoInv;
     const amrex::Real Vp = S(i, j, k, UMY) * rhoInv;
     const amrex::Real Wp = S(i, j, k, UMZ) * rhoInv;
     const amrex::Real ke = 0.5 * (Up * Up + Vp * Vp + Wp * Wp);
     const amrex::Real eden = S(i, j, k, UEDEN) * rhoInv;
-    const amrex::Real eos_state_T = small_num;
+    const amrex::Real eos_state_T = constants::real_small_num();
     amrex::Real eos_state_massfrac[NUM_SPECIES] = {0.0};
     amrex::Real eos_state_ei[NUM_SPECIES] = {0.0};
     eos.T2Ei(eos_state_T, eos_state_ei);
@@ -118,9 +117,7 @@ pc_rst_int_e(
       if (
         S(i, j, k, UEINT) <
         (S(i, j, k, URHO) * std::numeric_limits<amrex::Real>::min())) {
-        const amrex::Real small_num =
-          std::numeric_limits<amrex::Real>::epsilon() * 1e-100;
-        const amrex::Real eos_state_T = small_num;
+        const amrex::Real eos_state_T = constants::real_small_num();
         amrex::Real eos_state_massfrac[NUM_SPECIES] = {0.0};
         amrex::Real eos_state_ei[NUM_SPECIES] = {0.0};
         eos.T2Ei(eos_state_T, eos_state_ei);
@@ -151,9 +148,7 @@ pc_rst_int_e(
       } else if (
         S(i, j, k, UEINT) <=
         (S(i, j, k, URHO) * std::numeric_limits<amrex::Real>::min())) {
-        const amrex::Real small_num =
-          std::numeric_limits<amrex::Real>::epsilon() * 1e-100;
-        const amrex::Real eos_state_T = small_num;
+        const amrex::Real eos_state_T = constants::real_small_num();
         amrex::Real eos_state_massfrac[NUM_SPECIES] = {0.0};
         amrex::Real eos_state_ei[NUM_SPECIES] = {0.0};
         eos.T2Ei(eos_state_T, eos_state_ei);

--- a/Source/Utilities.H
+++ b/Source/Utilities.H
@@ -54,7 +54,7 @@ pc_rst_int_e(
     const amrex::Real Wp = S(i, j, k, UMZ) * rhoInv;
     const amrex::Real ke = 0.5 * (Up * Up + Vp * Vp + Wp * Wp);
     const amrex::Real eden = S(i, j, k, UEDEN) * rhoInv;
-    const amrex::Real eos_state_T = constants::real_small_num();
+    const amrex::Real eos_state_T = constants::very_small_num();
     amrex::Real eos_state_massfrac[NUM_SPECIES] = {0.0};
     amrex::Real eos_state_ei[NUM_SPECIES] = {0.0};
     eos.T2Ei(eos_state_T, eos_state_ei);
@@ -116,7 +116,7 @@ pc_rst_int_e(
       if (
         S(i, j, k, UEINT) <
         (S(i, j, k, URHO) * std::numeric_limits<amrex::Real>::min())) {
-        const amrex::Real eos_state_T = constants::real_small_num();
+        const amrex::Real eos_state_T = constants::very_small_num();
         amrex::Real eos_state_massfrac[NUM_SPECIES] = {0.0};
         amrex::Real eos_state_ei[NUM_SPECIES] = {0.0};
         eos.T2Ei(eos_state_T, eos_state_ei);
@@ -147,7 +147,7 @@ pc_rst_int_e(
       } else if (
         S(i, j, k, UEINT) <=
         (S(i, j, k, URHO) * std::numeric_limits<amrex::Real>::min())) {
-        const amrex::Real eos_state_T = constants::real_small_num();
+        const amrex::Real eos_state_T = constants::very_small_num();
         amrex::Real eos_state_massfrac[NUM_SPECIES] = {0.0};
         amrex::Real eos_state_ei[NUM_SPECIES] = {0.0};
         eos.T2Ei(eos_state_T, eos_state_ei);

--- a/Source/Utilities.H
+++ b/Source/Utilities.H
@@ -48,14 +48,14 @@ pc_rst_int_e(
   }
   auto eos = pele::physics::PhysicsType::eos();
   if (allow_small_energy == 0) {
+    const amrex::Real small_num = std::numeric_limits<amrex::Real>::epsilon() * 1e-100;
     const amrex::Real rhoInv = 1.0 / S(i, j, k, URHO);
     const amrex::Real Up = S(i, j, k, UMX) * rhoInv;
     const amrex::Real Vp = S(i, j, k, UMY) * rhoInv;
     const amrex::Real Wp = S(i, j, k, UMZ) * rhoInv;
     const amrex::Real ke = 0.5 * (Up * Up + Vp * Vp + Wp * Wp);
     const amrex::Real eden = S(i, j, k, UEDEN) * rhoInv;
-    // const amrex::Real eos_state_rho = S(i, j, k, URHO);
-    const amrex::Real eos_state_T = std::numeric_limits<amrex::Real>::min();
+    const amrex::Real eos_state_T = small_num;
     amrex::Real eos_state_massfrac[NUM_SPECIES] = {0.0};
     amrex::Real eos_state_ei[NUM_SPECIES] = {0.0};
     eos.T2Ei(eos_state_T, eos_state_ei);
@@ -117,8 +117,8 @@ pc_rst_int_e(
       if (
         S(i, j, k, UEINT) <
         (S(i, j, k, URHO) * std::numeric_limits<amrex::Real>::min())) {
-        // const amrex::Real eos_state_rho = S(i, j, k, URHO);
-        const amrex::Real eos_state_T = std::numeric_limits<amrex::Real>::min();
+        const amrex::Real small_num = std::numeric_limits<amrex::Real>::epsilon() * 1e-100;
+        const amrex::Real eos_state_T = small_num;
         amrex::Real eos_state_massfrac[NUM_SPECIES] = {0.0};
         amrex::Real eos_state_ei[NUM_SPECIES] = {0.0};
         eos.T2Ei(eos_state_T, eos_state_ei);
@@ -149,8 +149,8 @@ pc_rst_int_e(
       } else if (
         S(i, j, k, UEINT) <=
         (S(i, j, k, URHO) * std::numeric_limits<amrex::Real>::min())) {
-        // const amrex::Real eos_state_rho = S(i, j, k, URHO);
-        const amrex::Real eos_state_T = std::numeric_limits<amrex::Real>::min();
+        const amrex::Real small_num = std::numeric_limits<amrex::Real>::epsilon() * 1e-100;
+        const amrex::Real eos_state_T = small_num;
         amrex::Real eos_state_massfrac[NUM_SPECIES] = {0.0};
         amrex::Real eos_state_ei[NUM_SPECIES] = {0.0};
         eos.T2Ei(eos_state_T, eos_state_ei);
@@ -160,19 +160,6 @@ pc_rst_int_e(
           eos_state_e += eos_state_massfrac[sp] * eos_state_ei[sp];
         }
         const amrex::Real eint_new = eos_state_e;
-        /* Avoiding this for now due to GPU restricitions
-        if (verbose) {
-          amrex::Print() << std::endl;
-          amrex::Print()
-            << ">>> Warning: PeleC_util.F90::reset_internal_energy "
-            << " " << i << ", " << j << ", " << k << std::endl;
-          amrex::Print() << ">>> ... resetting neg. e from EOS using
-        std::numeric_limits<amrex::Real>::min()"
-                         << std::endl;
-          amrex::Print() << ">>> ... from ',S(i,j,k,UEINT)/S(i,j,k,URHO),' to "
-                         << std::endl;
-          amrex::Print() << eint_new << std::endl;
-        }*/
         if (dual_energy_update_E_from_e == 1) {
           S(i, j, k, UEDEN) = S(i, j, k, UEDEN) +
                               (S(i, j, k, URHO) * eint_new - S(i, j, k, UEINT));
@@ -234,11 +221,8 @@ pc_ctoprim(
     massfrac[sp] = q(i, j, k, sp + QFS);
   }
 
-  //    amrex::Real aux[NUM_AUX];
-  //    for(int ax = 0; ax < NUM_AUX; ++ax) aux[ax] = q(i,j,k,ax+QFX);
   amrex::Real dpdr_e, dpde, gam1, cs, wbar, p;
 
-  // Are all these EOS calls needed? Seems fairly convoluted.
   eos.Y2WBAR(massfrac, wbar);
   eos.REY2T(rho, e, massfrac, T);
   eos.RTY2P(rho, T, massfrac, p);


### PR DESCRIPTION
This avoid overflows with the Intel compiler. Also removed commented out code. I'm just making up `small_num` but at least it's still scaled by `numeric_limits`.