### PR TITLE
Enabling initialization from a plot file

### DIFF
--- a/CMake/BuildPeleCExe.cmake
+++ b/CMake/BuildPeleCExe.cmake
@@ -88,6 +88,13 @@ function(build_pelec_exe pelec_exe_name)
 
   target_sources(${pelec_exe_name}
     PRIVATE
+    ${PELE_PHYSICS_SRC_DIR}/Utility/PltFileManager/PltFileManager.cpp
+    ${PELE_PHYSICS_SRC_DIR}/Utility/PltFileManager/PltFileManager.H
+    ${PELE_PHYSICS_SRC_DIR}/Utility/PltFileManager/PltFileManagerBCfill.H)
+    target_include_directories(${pelec_exe_name} SYSTEM PRIVATE ${PELE_PHYSICS_SRC_DIR}/Utility/PltFileManager)
+
+  target_sources(${pelec_exe_name}
+    PRIVATE
       ${PELE_PHYSICS_SRC_DIR}/Reactions/ReactorArkode.H
       ${PELE_PHYSICS_SRC_DIR}/Reactions/ReactorArkode.cpp
       ${PELE_PHYSICS_SRC_DIR}/Reactions/ReactorBase.H

--- a/CMake/BuildPeleCExe.cmake
+++ b/CMake/BuildPeleCExe.cmake
@@ -90,7 +90,7 @@ function(build_pelec_exe pelec_exe_name)
     PRIVATE
     ${PELE_PHYSICS_SRC_DIR}/Utility/PltFileManager/PltFileManager.cpp
     ${PELE_PHYSICS_SRC_DIR}/Utility/PltFileManager/PltFileManager.H
-    ${PELE_PHYSICS_SRC_DIR}/Utility/PltFileManager/PltFileManagerBCfill.H)
+    ${PELE_PHYSICS_SRC_DIR}/Utility/PltFileManager/PltFileManagerBCFill.H)
     target_include_directories(${pelec_exe_name} SYSTEM PRIVATE ${PELE_PHYSICS_SRC_DIR}/Utility/PltFileManager)
 
   target_sources(${pelec_exe_name}

--- a/Docs/sphinx/InputFiles.rst
+++ b/Docs/sphinx/InputFiles.rst
@@ -177,6 +177,25 @@ These parameters, once read, are available in the `PeleC` object for use from c+
     
     # ---------------------------------------------------------------
 
+
+.. note::
+
+   It is possible to initialize a simulation using a plot file
+   (e.g. `pelec.init_pltfile = "plt00000"`). It uses :math:`\rho`,
+   :math:`u`, :math:`T`, :math:`Y` from a plot file to initialize a
+   new state. The species in the new simulation will be taken from the
+   plot file. The species that are not in the plot file will be set to
+   zero. The species that are in the plot file but are not in the new
+   simulation will be ignored (leading most probably to an error in
+   species not summing to 1). It is therefore assumed that the
+   non-zero species in the plot file used to initialize the simulation
+   form a subset of the species in the simulation. The code will
+   sanitize the species mass fractions to ensure that they fall within
+   the right bounds. It will error out if the species are too far out
+   of bounds (i.e., too far below 0, too far above 1, not summing to
+   1).
+
+
 Tagging criteria
 ~~~~~~~~~~~~~~~~
 

--- a/Docs/sphinx/InputFiles.rst
+++ b/Docs/sphinx/InputFiles.rst
@@ -193,7 +193,8 @@ These parameters, once read, are available in the `PeleC` object for use from c+
    sanitize the species mass fractions to ensure that they fall within
    the right bounds. It will error out if the species are too far out
    of bounds (i.e., too far below 0, too far above 1, not summing to
-   1).
+   1). This check is controlled with `pelec.init_pltfile_massfrac_tol`
+   and defaults to :math:`10^{-8}`.
 
 
 Tagging criteria

--- a/Docs/sphinx/InputFiles.rst
+++ b/Docs/sphinx/InputFiles.rst
@@ -151,7 +151,10 @@ These parameters, once read, are available in the `PeleC` object for use from c+
 
     #pick which all derived variables to plot
     amr.derive_plot_vars  = pressure x_velocity y_velocity
-    
+
+    # we can initialize a solution from a plot file
+    pelec.init_pltfile = "plt00000"
+
     # ---------------------------------------------------------------
     
     # ---------------------------------------------------------------

--- a/Exec/Make.PeleC
+++ b/Exec/Make.PeleC
@@ -32,6 +32,9 @@ endif
 Bpack += $(PELE_PHYSICS_HOME)/Utility/TurbInflow/Make.package
 Blocs += $(PELE_PHYSICS_HOME)/Utility/TurbInflow
 
+Bpack += $(PELE_PHYSICS_HOME)/Utility/PltFileManager/Make.package
+Blocs += $(PELE_PHYSICS_HOME)/Utility/PltFileManager
+
 ifeq ($(USE_EB), TRUE)
   DEFINES += -DPELEC_USE_EB
   ifeq ($(DIM), 1)

--- a/Source/IO.cpp
+++ b/Source/IO.cpp
@@ -433,32 +433,6 @@ PeleC::setPlotVariables()
 
   bool plot_massfrac = false;
   pp.query("plot_massfrac", plot_massfrac);
-  //    if (plot_massfrac)
-  //    {
-  //	if (plot_massfrac)
-  //	{
-  //	    //
-  //	    // Get the species names from the network model.
-  //	    //
-  //	    for (int i = 0; i < NUM_SPECIES; i++)
-  //	    {
-  //		int len = 20;
-  //		Vector<int> int_spec_names(len);
-  //		// This call return the actual length of each string in "len"
-  //		get_spec_names(int_spec_names.dataPtr(),&i,&len);
-  //		char* spec_name = new char[len+1];
-  //		for (int j = 0; j < len; j++)
-  //		    spec_name[j] = int_spec_names[j];
-  //		spec_name[len] = '\0';
-  //		string spec_string = "Y(";
-  //		spec_string += spec_name;
-  //		spec_string += ')';
-  //		parent->addDerivePlotVar(spec_string);
-  //		delete [] spec_name;
-  //	    }
-  //	}
-  //    }
-
   if (plot_massfrac) {
     amrex::Amr::addDerivePlotVar("massfrac");
   } else {
@@ -634,21 +608,6 @@ PeleC::writeJobInfo(const std::string& dir)
               << std::setw(7) << "Z"
               << "\n";
   jobInfoFile << OtherLine;
-  // Why is this here? It creates spec_name and deletes it?
-  //     int len = mlen;
-  //     amrex::Vector<int> int_spec_names(len * NUM_SPECIES);
-  //     CKSYMS(int_spec_names.dataPtr(),&len);
-  //     for (int i = 0; i < NUM_SPECIES; i++) {
-  //         int j = 0;
-  //         char* spec_name = new char[len];
-  //         for (j = 0; j < len; j++) {
-  //           spec_name[j] = int_spec_names[i*len + j];
-  //           if (spec_name[j] == ' ')
-  //             break;
-  //         }
-  //         spec_name[len] = '\0';
-  //         delete [] spec_name;
-  //     }
   jobInfoFile << "\n\n";
 
   // runtime parameters
@@ -1220,9 +1179,6 @@ PeleC::initLevelDataFromPlt(
   pltData.fillPatchFromPlt(lev, geom, vars["Temp"], UTEMP, 1, state);
 
   // Copy species from the plot file
-  amrex::Vector<std::string> spec_names;
-  pele::physics::eos::speciesNames<pele::physics::PhysicsType::eos_type>(
-    spec_names);
   for (int n = 0; n < spec_names.size(); n++) {
     const auto& spec = spec_names.at(n);
     const int pos = find_position(plt_vars, "Y(" + spec + ")");

--- a/Source/IO.cpp
+++ b/Source/IO.cpp
@@ -1233,11 +1233,11 @@ PeleC::initLevelDataFromPlt(
 
   // Sanity check the species, clean them up if they aren't too bad
   auto sarrs = state.arrays();
+  const auto tol = init_pltfile_massfrac_tol;
   amrex::ParallelFor(
     state, [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) noexcept {
       auto sarr = sarrs[nbx];
       amrex::Real sumY = 0.0;
-      const auto tol = constants::small_num();
 
       for (int n = 0; n < NUM_SPECIES; n++) {
         // if the species is not too far out of bounds, clip it
@@ -1262,7 +1262,9 @@ PeleC::initLevelDataFromPlt(
           sarr(i, j, k, UFS + n) /= sumY;
         }
       } else {
-        amrex::Abort("Species mass fraction don't sum to 1");
+        amrex::Abort(
+          "Species mass fraction don't sum to 1. The sum is: " +
+          std::to_string(sumY));
       }
     });
 

--- a/Source/IO.cpp
+++ b/Source/IO.cpp
@@ -1203,9 +1203,10 @@ PeleC::initLevelDataFromPlt(
             sarr(i, j, k, UFS + n) =
               amrex::min<amrex::Real>(1.0, amrex::max<amrex::Real>(0.0, mf));
           } else {
-            amrex::Abort(
-              "Species mass fraction is out of bounds (spec, value): ( " +
-              std::to_string(n) + ", " + std::to_string(mf) + ")");
+            AMREX_DEVICE_PRINTF(
+              "Species mass fraction is out of bounds (spec, value): (%d, %g)",
+              n, mf);
+            amrex::Abort();
           }
         }
 
@@ -1218,9 +1219,9 @@ PeleC::initLevelDataFromPlt(
           sarr(i, j, k, UFS + n) /= sumY;
         }
       } else {
-        amrex::Abort(
-          "Species mass fraction don't sum to 1. The sum is: " +
-          std::to_string(sumY));
+        AMREX_DEVICE_PRINTF(
+          "Species mass fraction don't sum to 1. The sum is: %g", sumY);
+        amrex::Abort();
       }
     });
 

--- a/Source/IO.cpp
+++ b/Source/IO.cpp
@@ -1203,10 +1203,16 @@ PeleC::initLevelDataFromPlt(
             sarr(i, j, k, UFS + n) =
               amrex::min<amrex::Real>(1.0, amrex::max<amrex::Real>(0.0, mf));
           } else {
+#ifdef AMREX_USE_GPU
             AMREX_DEVICE_PRINTF(
               "Species mass fraction is out of bounds (spec, value): (%d, %g)",
               n, mf);
             amrex::Abort();
+#else
+            amrex::Abort(
+              "Species mass fraction is out of bounds (spec, value): ( " +
+              std::to_string(n) + ", " + std::to_string(mf) + ")");
+#endif
           }
         }
 
@@ -1219,9 +1225,15 @@ PeleC::initLevelDataFromPlt(
           sarr(i, j, k, UFS + n) /= sumY;
         }
       } else {
+#ifdef AMREX_USE_GPU
         AMREX_DEVICE_PRINTF(
           "Species mass fraction don't sum to 1. The sum is: %g", sumY);
         amrex::Abort();
+#else
+        amrex::Abort(
+          "Species mass fraction don't sum to 1. The sum is: " +
+          std::to_string(sumY));
+#endif
       }
     });
 

--- a/Source/Params/_cpp_parameters
+++ b/Source/Params/_cpp_parameters
@@ -34,6 +34,9 @@ do_reflux                    int           1
 # do we average down the fine data onto the coarse?
 do_avg_down                  int           1
 
+# Initialize from a plot file
+init_pltfile              string          ""
+
 #-----------------------------------------------------------------------------
 # category: Processor Type
 #-----------------------------------------------------------------------------
@@ -261,7 +264,7 @@ hard_cfl_limit               int           1
 job_name                     string        ""
 
 #-----------------------------------------------------------------------------
-# category: misc combusiton
+# category: misc combustion
 #-----------------------------------------------------------------------------
 
 flame_trac_name              string        ""

--- a/Source/Params/_cpp_parameters
+++ b/Source/Params/_cpp_parameters
@@ -37,6 +37,9 @@ do_avg_down                  int           1
 # Initialize from a plot file
 init_pltfile              string          ""
 
+# Acceptable tolerance for species mass fraction when initializing from a plot file
+init_pltfile_massfrac_tol   Real         1e-8
+
 #-----------------------------------------------------------------------------
 # category: Processor Type
 #-----------------------------------------------------------------------------

--- a/Source/Params/param_includes/pelec_defaults.H
+++ b/Source/Params/param_includes/pelec_defaults.H
@@ -12,6 +12,7 @@ int PeleC::lin_limit_state_interp = 1;
 int PeleC::state_nghost = 0;
 int PeleC::do_reflux = 1;
 int PeleC::do_avg_down = 1;
+std::string PeleC::init_pltfile = "";
 amrex::Real PeleC::difmag = 0.1;
 amrex::Real PeleC::small_pres = 1.e-200;
 int PeleC::do_hydro = -1;

--- a/Source/Params/param_includes/pelec_defaults.H
+++ b/Source/Params/param_includes/pelec_defaults.H
@@ -13,6 +13,7 @@ int PeleC::state_nghost = 0;
 int PeleC::do_reflux = 1;
 int PeleC::do_avg_down = 1;
 std::string PeleC::init_pltfile = "";
+amrex::Real PeleC::init_pltfile_massfrac_tol = 1e-8;
 amrex::Real PeleC::difmag = 0.1;
 amrex::Real PeleC::small_pres = 1.e-200;
 int PeleC::do_hydro = -1;

--- a/Source/Params/param_includes/pelec_params.H
+++ b/Source/Params/param_includes/pelec_params.H
@@ -13,6 +13,7 @@ static int state_nghost;
 static int do_reflux;
 static int do_avg_down;
 static std::string init_pltfile;
+static amrex::Real init_pltfile_massfrac_tol;
 static amrex::Real difmag;
 static amrex::Real small_pres;
 static int do_hydro;

--- a/Source/Params/param_includes/pelec_params.H
+++ b/Source/Params/param_includes/pelec_params.H
@@ -12,6 +12,7 @@ static int lin_limit_state_interp;
 static int state_nghost;
 static int do_reflux;
 static int do_avg_down;
+static std::string init_pltfile;
 static amrex::Real difmag;
 static amrex::Real small_pres;
 static int do_hydro;

--- a/Source/Params/param_includes/pelec_queries.H
+++ b/Source/Params/param_includes/pelec_queries.H
@@ -12,6 +12,7 @@ pp.query("lin_limit_state_interp", lin_limit_state_interp);
 pp.query("state_nghost", state_nghost);
 pp.query("do_reflux", do_reflux);
 pp.query("do_avg_down", do_avg_down);
+pp.query("init_pltfile", init_pltfile);
 pp.query("difmag", difmag);
 pp.query("small_pres", small_pres);
 pp.query("do_hydro", do_hydro);

--- a/Source/Params/param_includes/pelec_queries.H
+++ b/Source/Params/param_includes/pelec_queries.H
@@ -13,6 +13,7 @@ pp.query("state_nghost", state_nghost);
 pp.query("do_reflux", do_reflux);
 pp.query("do_avg_down", do_avg_down);
 pp.query("init_pltfile", init_pltfile);
+pp.query("init_pltfile_massfrac_tol", init_pltfile_massfrac_tol);
 pp.query("difmag", difmag);
 pp.query("small_pres", small_pres);
 pp.query("do_hydro", do_hydro);

--- a/Source/PeleC.H
+++ b/Source/PeleC.H
@@ -113,6 +113,10 @@ public:
   void writeJobInfo(const std::string& dir);
   static void writeBuildInfo(std::ostream& os);
 
+  // Initialize level from plt file
+  void initLevelDataFromPlt(
+    const int lev, const std::string& pltFile, amrex::MultiFab& state);
+
   // Define data descriptors.
   static void variableSetUp();
 

--- a/Source/PeleC.H
+++ b/Source/PeleC.H
@@ -115,7 +115,7 @@ public:
 
   // Initialize level from plt file
   void initLevelDataFromPlt(
-    const int lev, const std::string& pltFile, amrex::MultiFab& state);
+    const int lev, const std::string& pltFile, amrex::MultiFab& S_new);
 
   // Define data descriptors.
   static void variableSetUp();

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -1743,12 +1743,7 @@ PeleC::errorEst(
 
       // Tagging flame tracer
       if (!flame_trac_name.empty()) {
-        int idx = -1;
-        for (int i = 0; i < spec_names.size(); ++i) {
-          if (flame_trac_name == spec_names[i]) {
-            idx = i;
-          }
-        }
+        int idx = find_position(spec_names, flame_trac_name);
 
         if (idx >= 0) {
           // const std::string name = "Y("+flame_trac_name+")";

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -335,7 +335,6 @@ PeleC::read_params()
 
   // Get some useful amr inputs
   amrex::ParmParse ppa("amr");
-
   // This turns on the lb stuff inside Amr, but we use our own flag to signal
   // whether to gather data
   ppa.query("loadbalance_with_workestimates", do_mol_load_balance);
@@ -657,22 +656,27 @@ PeleC::initData()
     get_new_data(Work_Estimate_Type).setVal(1.0);
   }
 
+  if (init_pltfile.empty()) {
 #ifdef _OPENMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
-  for (amrex::MFIter mfi(S_new, amrex::TilingIfNotGPU()); mfi.isValid();
-       ++mfi) {
-    const amrex::Box& box = mfi.tilebox();
-    auto sfab = S_new.array(mfi);
-    const auto geomdata = geom.data();
+    for (amrex::MFIter mfi(S_new, amrex::TilingIfNotGPU()); mfi.isValid();
+         ++mfi) {
+      const amrex::Box& box = mfi.tilebox();
+      auto sfab = S_new.array(mfi);
+      const auto geomdata = geom.data();
 
-    const ProbParmDevice* lprobparm = d_prob_parm_device;
+      const ProbParmDevice* lprobparm = d_prob_parm_device;
 
-    amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-      pc_initdata(i, j, k, sfab, geomdata, *lprobparm);
-      // Verify that the sum of (rho Y)_i = rho at every cell
-      pc_check_initial_species(i, j, k, sfab);
-    });
+      amrex::ParallelFor(
+        box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+          pc_initdata(i, j, k, sfab, geomdata, *lprobparm);
+          // Verify that the sum of (rho Y)_i = rho at every cell
+          pc_check_initial_species(i, j, k, sfab);
+        });
+    }
+  } else {
+    initLevelDataFromPlt(level, init_pltfile, S_new);
   }
 
   enforce_consistent_e(S_new);

--- a/Source/Setup.cpp
+++ b/Source/Setup.cpp
@@ -330,10 +330,8 @@ PeleC::variableSetUp()
   }
 
   // Get the species names from the network model
-  // Set it for Null mechanism let it be overwritten for others
-  spec_names.resize(1);
-  spec_names[0] = "Null";
-  CKSYMS_STR(spec_names);
+  pele::physics::eos::speciesNames<pele::physics::PhysicsType::eos_type>(
+    spec_names);
 
   if (amrex::ParallelDescriptor::IOProcessor()) {
     amrex::Print() << NUM_SPECIES << " Species: " << std::endl;

--- a/Source/Utilities.H
+++ b/Source/Utilities.H
@@ -484,6 +484,18 @@ unique(T input)
   return output;
 }
 
+// Find position of element in vector
+template <typename T>
+int
+find_position(const std::vector<T>& vec, const T& element)
+{
+  auto it = std::find(vec.begin(), vec.end(), element);
+  if (it != vec.end()) {
+    return distance(vec.begin(), it);
+  }
+  return -1;
+}
+
 std::string convertIntGG(int number);
 
 // Clean the mass fractions on state, given a mask


### PR DESCRIPTION
This PR allows for initialization from a plot file. Things to note:
- It uses `rho, u, T, Y` from a plot file to initialize a new state.
- The species in the new simulation will be taken from the plot file. Those that are not in the plot file will be set to zero. Those that are in the plot file but are not in the new simulation will be ignored (leading most probably to an error in species not summing to 1)
- It will sanitize the species mass fractions to ensure that they fall within the right bounds. 
- It will error out if the species are too far out of bounds
- This isn't quite like a restart. At the very least, the time stamp will restart at 0.

This is all explained in the documentation:
```  
   It is possible to initialize a simulation using a plot file
   (e.g. `pelec.init_pltfile = "plt00000"`). It uses :math:`\rho`,
   :math:`u`, :math:`T`, :math:`Y` from a plot file to initialize a
   new state. The species in the new simulation will be taken from the
   plot file. The species that are not in the plot file will be set to
   zero. The species that are in the plot file but are not in the new
   simulation will be ignored (leading most probably to an error in
   species not summing to 1). It is therefore assumed that the
   non-zero species in the plot file used to initialize the simulation
   form a subset of the species in the simulation. The code will
   sanitize the species mass fractions to ensure that they fall within
   the right bounds. It will error out if the species are too far out
   of bounds (i.e., too far below 0, too far above 1, not summing to
   1).
```

I tried restarting a simulation from the `air` mechanism using the `drm19` mechanism and it all looked fine.