### PR TITLE
tag based on density ratio

### DIFF
--- a/Docs/sphinx/InputFiles.rst
+++ b/Docs/sphinx/InputFiles.rst
@@ -130,8 +130,10 @@ These parameters, once read, are available in the `PeleC` object for use from c+
     #------------------------
     tagging.denerr = 3             # density value
     tagging.dengrad = 0.01         # gradient of density value
+    tagging.denratio = 1.1         # ratio of adjacent cells density
     tagging.max_denerr_lev = 3     # maximum level at which to use density for tagging
     tagging.max_dengrad_lev = 3    # maximum level at which to use density gradient for tagging
+    tagging.max_denratio_lev = 3   # maximum level at which to use density ratio for tagging
 
     #------------------------
     # CHECKPOINT FILES
@@ -209,6 +211,13 @@ Tagging criteria are used to inform the refinement of flow features. They are ad
    \max(&|f_{i+1,j,k} - f_{i,j,k}|, |f_{i,j,k} - f_{i-1,j,k}|,\\
    &|f_{i,j+1,k} - f_{i,j,k}|, |f_{i,j,k} - f_{i,j-1,k}|,\\
    &|f_{i,j,k+1} - f_{i,j,k}|, |f_{i,j,k} - f_{i,j,k-1}|) \geq v
+
+- `*ratio`: tag cell for refinement when the maximum ratio of the field (currently only supported for density) exceeds this threshold value, i.e.
+
+.. math::
+   \max(&|f_{i+1,j,k} / f_{i,j,k}|, |f_{i,j,k} / f_{i-1,j,k}|,|f_{i,j,k} / f_{i+1,j,k}|, |f_{i-1,j,k} / f_{i,j,k}|,\\
+   &|f_{i,j+1,k} / f_{i,j,k}|, |f_{i,j,k} / f_{i,j-1,k}|,|f_{i,j,k} / f_{i,j+1,k}|, |f_{i,j-1,k} / f_{i,j,k}|,\\
+   &|f_{i,j,k+1} / f_{i,j,k}|, |f_{i,j,k} / f_{i,j,k-1}|,|f_{i,j,k} / f_{i,j,k+1}|, |f_{i,j,k-1} / f_{i,j,k}|) \geq v
 
 - `max_*_level`: maximum level for use of this tag (beyond this level, this tag will not be used for refinement).
 

--- a/Exec/RegTests/EB-C7/example.inp
+++ b/Exec/RegTests/EB-C7/example.inp
@@ -71,7 +71,7 @@ prob.angle = 30.0
 
 # TAGGING
 tagging.denerr = 3
-tagging.dengrad = 0.01
+tagging.denratio = 1.1
 tagging.max_denerr_lev = 3
 tagging.max_dengrad_lev = 3
 

--- a/Exec/RegTests/EB-C7/example.inp
+++ b/Exec/RegTests/EB-C7/example.inp
@@ -73,7 +73,7 @@ prob.angle = 30.0
 tagging.denerr = 3
 tagging.denratio = 1.1
 tagging.max_denerr_lev = 3
-tagging.max_dengrad_lev = 3
+tagging.max_denratio_lev = 3
 
 tagging.presserr = 3
 tagging.pressgrad = 0.01

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -1414,6 +1414,13 @@ PeleC::errorEst(
             tag_graderror(i, j, k, tag_arr, Sfab, captured_dengrad, tagval);
           });
       }
+      if (level < tagging_parm->max_denratio_lev) {
+        const amrex::Real captured_denratio = tagging_parm->denratio;
+        amrex::ParallelFor(
+          tilebox, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+            tag_ratioerror(i, j, k, tag_arr, Sfab, captured_denratio, tagval);
+          });
+      }
 
       // Tagging pressure
       S_derData.setVal<amrex::RunOn::Device>(0.0, datbox);

--- a/Source/Tagging.H
+++ b/Source/Tagging.H
@@ -9,6 +9,7 @@ struct TaggingParm
 {
   amrex::Real denerr = 1.0e10;
   amrex::Real dengrad = 1.0e10;
+  amrex::Real denratio = 1.0e10;
   amrex::Real presserr = 1.0e10;
   amrex::Real pressgrad = 1.0e10;
   amrex::Real velerr = 1.0e10;
@@ -24,6 +25,7 @@ struct TaggingParm
 
   int max_denerr_lev = 10;
   int max_dengrad_lev = 10;
+  int max_denratio_lev = 10;
   int max_presserr_lev = 10;
   int max_pressgrad_lev = 10;
   int max_velerr_lev = 10;
@@ -84,6 +86,45 @@ tag_graderror(
   if (amrex::max<amrex::Real>(AMREX_D_DECL(ax, ay, az)) >= fieldgrad)
 #elif AMREX_SPACEDIM == 1
   if (ax >= fieldgrad)
+#endif
+  {
+    tag(i, j, k) = tagval;
+  }
+}
+
+AMREX_GPU_DEVICE
+AMREX_FORCE_INLINE
+void
+tag_ratioerror(
+  const int i,
+  const int j,
+  const int k,
+  amrex::Array4<char> const& tag,
+  amrex::Array4<amrex::Real const> const& field,
+  const amrex::Real fieldratio,
+  char tagval) noexcept
+{
+  // Tag on regions of high ratio of adacent cell values in field
+  AMREX_D_TERM(
+    amrex::Real axp1 = amrex::Math::abs(field(i + 1, j, k) / field(i, j, k));
+    axp1 = amrex::max<amrex::Real>(axp1, 1.0/axp1);
+    amrex::Real axm1 = amrex::Math::abs(field(i - 1, j, k) / field(i, j, k));
+    axm1 = amrex::max<amrex::Real>(axm1, 1.0/axm1);
+    amrex::Real ax = amrex::max<amrex::Real>(axm1, axp1);
+    , amrex::Real ayp1 = amrex::Math::abs(field(i, j + 1, k) / field(i, j, k));
+    ayp1 = amrex::max<amrex::Real>(ayp1, 1.0/ayp1);
+    amrex::Real aym1 = amrex::Math::abs(field(i, j - 1, k) / field(i, j, k));
+    aym1 = amrex::max<amrex::Real>(aym1, 1.0/aym1);
+    amrex::Real ay = amrex::max<amrex::Real>(aym1, ayp1);
+    , amrex::Real azp1 = amrex::Math::abs(field(i, j, k + 1) / field(i, j, k));
+    azp1 = amrex::max<amrex::Real>(azp1, 1.0/azp1);
+    amrex::Real azm1 = amrex::Math::abs(field(i, j, k - 1) / field(i, j, k));
+    azm1 = amrex::max<amrex::Real>(azm1, 1.0/azm1);
+    amrex::Real az = amrex::max<amrex::Real>(azm1, azp1);)
+#if AMREX_SPACEDIM > 1
+  if (amrex::max<amrex::Real>(AMREX_D_DECL(ax, ay, az)) >= fieldratio)
+#elif AMREX_SPACEDIM == 1
+  if (ax >= fieldratio)
 #endif
   {
     tag(i, j, k) = tagval;

--- a/Source/Tagging.H
+++ b/Source/Tagging.H
@@ -107,19 +107,19 @@ tag_ratioerror(
   // Tag on regions of high ratio of adacent cell values in field
   AMREX_D_TERM(
     amrex::Real axp1 = amrex::Math::abs(field(i + 1, j, k) / field(i, j, k));
-    axp1 = amrex::max<amrex::Real>(axp1, 1.0/axp1);
+    axp1 = amrex::max<amrex::Real>(axp1, 1.0 / axp1);
     amrex::Real axm1 = amrex::Math::abs(field(i - 1, j, k) / field(i, j, k));
-    axm1 = amrex::max<amrex::Real>(axm1, 1.0/axm1);
+    axm1 = amrex::max<amrex::Real>(axm1, 1.0 / axm1);
     amrex::Real ax = amrex::max<amrex::Real>(axm1, axp1);
     , amrex::Real ayp1 = amrex::Math::abs(field(i, j + 1, k) / field(i, j, k));
-    ayp1 = amrex::max<amrex::Real>(ayp1, 1.0/ayp1);
+    ayp1 = amrex::max<amrex::Real>(ayp1, 1.0 / ayp1);
     amrex::Real aym1 = amrex::Math::abs(field(i, j - 1, k) / field(i, j, k));
-    aym1 = amrex::max<amrex::Real>(aym1, 1.0/aym1);
+    aym1 = amrex::max<amrex::Real>(aym1, 1.0 / aym1);
     amrex::Real ay = amrex::max<amrex::Real>(aym1, ayp1);
     , amrex::Real azp1 = amrex::Math::abs(field(i, j, k + 1) / field(i, j, k));
-    azp1 = amrex::max<amrex::Real>(azp1, 1.0/azp1);
+    azp1 = amrex::max<amrex::Real>(azp1, 1.0 / azp1);
     amrex::Real azm1 = amrex::Math::abs(field(i, j, k - 1) / field(i, j, k));
-    azm1 = amrex::max<amrex::Real>(azm1, 1.0/azm1);
+    azm1 = amrex::max<amrex::Real>(azm1, 1.0 / azm1);
     amrex::Real az = amrex::max<amrex::Real>(azm1, azp1);)
 #if AMREX_SPACEDIM > 1
   if (amrex::max<amrex::Real>(AMREX_D_DECL(ax, ay, az)) >= fieldratio)

--- a/Source/Tagging.cpp
+++ b/Source/Tagging.cpp
@@ -12,6 +12,8 @@ PeleC::read_tagging_params()
   pp.query("max_denerr_lev", tagging_parm->max_denerr_lev);
   pp.query("dengrad", tagging_parm->dengrad);
   pp.query("max_dengrad_lev", tagging_parm->max_dengrad_lev);
+  pp.query("denratio", tagging_parm->denratio);
+  pp.query("max_denratio_lev", tagging_parm->max_denratio_lev);
 
   pp.query("presserr", tagging_parm->presserr);
   pp.query("max_presserr_lev", tagging_parm->max_presserr_lev);


### PR DESCRIPTION
This enables tagging based on the density ratio in adjacent cells (rather than the density difference). There are a few reasons for this. 

- The density ratio is nondimensional and therefore easier to interpret and not dependent on problem specifics. For example, one needs to change the density difference threshold based on temperature, pressure, and composition, and without knowing characteristic densities for a particular simulation it is hard to assess how much refinement a particular threshold for density difference will cause. 

- There is also a physics-based rationale for this criterion. The continuity equation is `div u = -1/rho Drho/Dt = - D(ln rho)/Dt`. Therefore, the direct physical effect of density change between cells is a function of the density ratio rather than the density difference. 

Draft for now because I only did very basic testing. 