### PR TITLE
Add readability-implicit-bool-conversion check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,16 @@
 ---
-Checks:          'bugprone-*,clang-diagnostic-*,clang-analyzer-*,corecppguidelines-*,modernize-*,readability-*,-readability-magic-numbers,-readability-identifier-naming,-modernize-avoid-c-arrays,-modernize-use-trailing-return-type,-readability-implicit-bool-conversion,-readability-isolate-declaration,-readability-avoid-const-params-in-decls'
+Checks: 'bugprone-*,
+         clang-diagnostic-*,
+         clang-analyzer-*,
+         corecppguidelines-*,
+         modernize-*,
+         -modernize-avoid-c-arrays,
+         -modernize-use-trailing-return-type,
+         readability-*,
+         -readability-magic-numbers,
+         -readability-identifier-naming,
+         -readability-isolate-declaration,
+         -readability-avoid-const-params-in-decls'
 WarningsAsErrors: ''
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false

--- a/CMake/BuildPeleCExe.cmake
+++ b/CMake/BuildPeleCExe.cmake
@@ -3,7 +3,7 @@ function(build_pelec_exe pelec_exe_name)
   add_executable(${pelec_exe_name} "")
 
   if(CLANG_TIDY_EXE)
-    set_target_properties(${pelec_exe_name} PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY_EXE})
+    set_target_properties(${pelec_exe_name} PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_EXE};-fix")
   endif()
 
   target_sources(${pelec_exe_name}

--- a/CMake/BuildPeleCExe.cmake
+++ b/CMake/BuildPeleCExe.cmake
@@ -3,7 +3,7 @@ function(build_pelec_exe pelec_exe_name)
   add_executable(${pelec_exe_name} "")
 
   if(CLANG_TIDY_EXE)
-    set_target_properties(${pelec_exe_name} PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_EXE};-fix")
+    set_target_properties(${pelec_exe_name} PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY_EXE})
   endif()
 
   target_sources(${pelec_exe_name}

--- a/Exec/RegTests/PMF-SRK/prob.H
+++ b/Exec/RegTests/PMF-SRK/prob.H
@@ -24,7 +24,7 @@ pmf(
   amrex::GpuArray<amrex::Real, NUM_SPECIES + 4>& y_vector,
   ProbParmDevice const& prob_parm)
 {
-  if (prob_parm.pmf_do_average) {
+  if (prob_parm.pmf_do_average != 0) {
     int lo_loside = 0;
     int lo_hiside = 0;
     int hi_loside = 0;

--- a/Exec/RegTests/PMF/prob.H
+++ b/Exec/RegTests/PMF/prob.H
@@ -24,7 +24,7 @@ pmf(
   amrex::GpuArray<amrex::Real, NUM_SPECIES + 4>& y_vector,
   const ProbParmDevice& prob_parm)
 {
-  if (prob_parm.pmf_do_average) {
+  if (prob_parm.pmf_do_average != 0) {
     int lo_loside = 0;
     int lo_hiside = 0;
     int hi_loside = 0;

--- a/Source/Advance.cpp
+++ b/Source/Advance.cpp
@@ -20,7 +20,7 @@ PeleC::advance(
 
   int finest_level = parent->finestLevel();
 
-  if (level < finest_level && do_reflux) {
+  if (level < finest_level && (do_reflux != 0)) {
     getFluxReg(level + 1).reset();
 
     if (!amrex::DefaultGeometry().IsCartesian()) {
@@ -30,7 +30,7 @@ PeleC::advance(
   }
 
   amrex::Real dt_new;
-  if (do_mol) {
+  if (do_mol != 0) {
     dt_new = do_mol_advance(time, dt, amr_iteration, amr_ncycle);
   } else {
     dt_new = do_sdc_advance(time, dt, amr_iteration, amr_ncycle);
@@ -50,7 +50,7 @@ PeleC::do_mol_advance(
   // into MOL advance yet");
 
   for (int i = 0; i < num_state_type; ++i) {
-    if (!(i == Reactions_Type && do_react)) {
+    if (!(i == Reactions_Type && (do_react != 0))) {
       state[i].allocOldData();
       state[i].swapTimeLevels(dt);
     }
@@ -89,7 +89,7 @@ PeleC::do_mol_advance(
 #endif
 
   // Compute S^{n} = MOLRhs(U^{n})
-  if (verbose) {
+  if (verbose != 0) {
     amrex::Print() << "... Computing MOL source term at t^{n} " << std::endl;
   }
   FillPatch(*this, Sborder, numGrow() + nGrowF, time, State_Type, 0, NVAR);
@@ -129,7 +129,7 @@ PeleC::do_mol_advance(
   computeTemp(S_new, 0);
 
   // Compute S^{n+1} = MOLRhs(U^{n+1,*})
-  if (verbose) {
+  if (verbose != 0) {
     amrex::Print() << "... Computing MOL source term at t^{n+1} " << std::endl;
   }
   FillPatch(*this, Sborder, numGrow() + nGrowF, time + dt, State_Type, 0, NVAR);
@@ -179,7 +179,7 @@ PeleC::do_mol_advance(
 
   if (do_react == 1) {
     for (int mol_iter = 2; mol_iter <= mol_iters; ++mol_iter) {
-      if (verbose) {
+      if (verbose != 0) {
         amrex::Print() << "... Re-computing MOL source term at t^{n+1} (iter = "
                        << mol_iter << " of " << mol_iters << ")" << std::endl;
       }
@@ -331,7 +331,7 @@ PeleC::do_sdc_iteration(
   int nGrow_Sborder = 0;
   bool fill_Sborder = false;
 
-  if (do_hydro) {
+  if (do_hydro != 0) {
     fill_Sborder = true;
     nGrow_Sborder = numGrow() + nGrowF;
   } else if (do_diffuse) {
@@ -464,7 +464,7 @@ PeleC::do_sdc_iteration(
     // Get diffusion source separate from other sources, since it requires grow
     // cells, and we may want to reuse what we fill-patched for hydro
     if (do_diffuse) {
-      if (verbose) {
+      if (verbose != 0) {
         amrex::Print() << "... Computing diffusion terms at t^(n)" << std::endl;
       }
       AMREX_ASSERT(
@@ -482,7 +482,7 @@ PeleC::do_sdc_iteration(
   }
 
   // Construct hydro source, will use old and current iterate of new sources.
-  if (do_hydro) {
+  if (do_hydro != 0) {
     construct_hydro_source(
       Sborder, time, dt, amr_iteration, amr_ncycle, sub_iteration, sub_ncycle);
   }
@@ -496,7 +496,7 @@ PeleC::do_sdc_iteration(
   // Now update t_new sources (diffusion separate because it requires a fill
   // patch)
   if (do_diffuse) {
-    if (verbose) {
+    if (verbose != 0) {
       amrex::Print() << "... Computing diffusion terms at t^(n+1,"
                      << sub_iteration + 1 << ")" << std::endl;
     }
@@ -575,7 +575,7 @@ PeleC::construct_Snew(
     amrex::MultiFab::Saxpy(
       S_new, 0.5 * dt, *old_sources[src_list[n]], 0, 0, NVAR, ng);
   }
-  if (do_hydro) {
+  if (do_hydro != 0) {
     amrex::MultiFab::Saxpy(S_new, dt, hydro_source, 0, 0, NVAR, ng);
   }
 
@@ -601,7 +601,7 @@ PeleC::initialize_sdc_iteration(
   frac_change = 1;
 
   // Reset the grid loss tracking.
-  if (track_grid_losses) {
+  if (track_grid_losses != 0) {
     for (amrex::Real& i : material_lost_through_boundary_temp) {
       i = 0.0;
     }
@@ -653,7 +653,7 @@ PeleC::finalize_sdc_advance(
   BL_PROFILE("PeleC::finalize_sdc_advance()");
 
   // Add the material lost in this timestep to the cumulative losses.
-  if (track_grid_losses) {
+  if (track_grid_losses != 0) {
     amrex::ParallelDescriptor::ReduceRealSum(
       material_lost_through_boundary_temp, n_lost);
 

--- a/Source/Derive.H
+++ b/Source/Derive.H
@@ -42,8 +42,8 @@ get_idx(
     } else {
       const amrex::IntVect ivm = -amrex::IntVect::TheDimensionVector(dir);
       const amrex::IntVect ivp = amrex::IntVect::TheDimensionVector(dir);
-      im = i - flag.isConnected(ivm);
-      ip = i + flag.isConnected(ivp);
+      im = i - static_cast<int>(flag.isConnected(ivm));
+      ip = i + static_cast<int>(flag.isConnected(ivp));
     }
   }
 }

--- a/Source/EB.cpp
+++ b/Source/EB.cpp
@@ -755,7 +755,7 @@ pc_eb_clean_massfrac(
     bx, state.nComp(),
     [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) noexcept {
       const amrex::IntVect iv{AMREX_D_DECL(i, j, k)};
-      if (mask_arr(iv)) {
+      if (mask_arr(iv) != 0) {
         div(iv, n) = (scratch(iv, n) - state(iv, n)) / dt;
       }
     });

--- a/Source/External.cpp
+++ b/Source/External.cpp
@@ -10,7 +10,7 @@ PeleC::construct_old_ext_source(amrex::Real time, amrex::Real dt)
 
   old_sources[ext_src]->setVal(0.0);
 
-  if (!add_ext_src) {
+  if (add_ext_src == 0) {
     return;
   }
 
@@ -29,7 +29,7 @@ PeleC::construct_new_ext_source(amrex::Real time, amrex::Real dt)
 
   new_sources[ext_src]->setVal(0.0);
 
-  if (!add_ext_src) {
+  if (add_ext_src == 0) {
     return;
   }
 

--- a/Source/Forcing.cpp
+++ b/Source/Forcing.cpp
@@ -10,7 +10,7 @@ void
 
   old_sources[forcing_src]->setVal(0.0);
 
-  if (!add_forcing_src) {
+  if (add_forcing_src == 0) {
     return;
   }
 
@@ -29,7 +29,7 @@ void
 
   new_sources[forcing_src]->setVal(0.0);
 
-  if (!add_forcing_src) {
+  if (add_forcing_src == 0) {
     return;
   }
 

--- a/Source/Godunov.H
+++ b/Source/Godunov.H
@@ -355,7 +355,9 @@ pc_transdd(
   const amrex::IntVect iv{AMREX_D_DECL(i, j, k)};
   const int qvidx0 = (dir == 0) ? GDV : GDU;
   const int qvidx1 = (dir == 2) ? GDV : GDW;
-  const amrex::GpuArray<const int, 3> bdim{{dir == 0, dir == 1, dir == 2}};
+  const amrex::GpuArray<const int, 3> bdim{
+    {static_cast<const int>(dir == 0), static_cast<const int>(dir == 1),
+     static_cast<const int>(dir == 2)}};
   const amrex::GpuArray<const int, 3> l_idx{
     {bdim[0] * 0 + bdim[1] * 1 + bdim[2] * 2,
      bdim[0] * 1 + bdim[1] * 0 + bdim[2] * 0,
@@ -642,7 +644,9 @@ pc_artif_visc(
 {
   const amrex::IntVect iv{AMREX_D_DECL(i, j, k)};
   const amrex::IntVect ivm(iv - amrex::IntVect::TheDimensionVector(dir));
-  const amrex::GpuArray<const int, 3> bdim{{dir == 0, dir == 1, dir == 2}};
+  const amrex::GpuArray<const int, 3> bdim{
+    {static_cast<const int>(dir == 0), static_cast<const int>(dir == 1),
+     static_cast<const int>(dir == 2)}};
   const amrex::GpuArray<const int, 3> l_idx{
     {bdim[0] * 0 + bdim[1] * 1 + bdim[2] * 2,
      bdim[0] * 1 + bdim[1] * 0 + bdim[2] * 0,

--- a/Source/GradUtil.cpp
+++ b/Source/GradUtil.cpp
@@ -27,10 +27,14 @@ pc_compute_tangential_vel_derivs_eb(
                    , k = sv_ebg[L].iv[2];);
       const amrex::IntVect iv = amrex::IntVect{AMREX_D_DECL(i, j, k)};
       if (bx.contains(iv)) {
-        const int jhip = j + flags(i, j, k).isConnected(0, 1, 0);
-        const int jhim = j - flags(i, j, k).isConnected(0, -1, 0);
-        const int jlop = j + flags(i - 1, j, k).isConnected(0, 1, 0);
-        const int jlom = j - flags(i - 1, j, k).isConnected(0, -1, 0);
+        const int jhip =
+          j + static_cast<int>(flags(i, j, k).isConnected(0, 1, 0));
+        const int jhim =
+          j - static_cast<int>(flags(i, j, k).isConnected(0, -1, 0));
+        const int jlop =
+          j + static_cast<int>(flags(i - 1, j, k).isConnected(0, 1, 0));
+        const int jlom =
+          j - static_cast<int>(flags(i - 1, j, k).isConnected(0, -1, 0));
         const amrex::Real wjhi = weights[jhip - jhim];
         const amrex::Real wjlo = weights[jlop - jlom];
         td(i, j, k, 0) =
@@ -47,10 +51,14 @@ pc_compute_tangential_vel_derivs_eb(
           ((q(i, jhip, k, QW) - q(i, jhim, k, QW)) * wjhi +
            (q(i - 1, jlop, k, QW) - q(i - 1, jlom, k, QW)) * wjlo);
 
-        const int khip = k + flags(i, j, k).isConnected(0, 0, 1);
-        const int khim = k - flags(i, j, k).isConnected(0, 0, -1);
-        const int klop = k + flags(i - 1, j, k).isConnected(0, 0, 1);
-        const int klom = k - flags(i - 1, j, k).isConnected(0, 0, -1);
+        const int khip =
+          k + static_cast<int>(flags(i, j, k).isConnected(0, 0, 1));
+        const int khim =
+          k - static_cast<int>(flags(i, j, k).isConnected(0, 0, -1));
+        const int klop =
+          k + static_cast<int>(flags(i - 1, j, k).isConnected(0, 0, 1));
+        const int klom =
+          k - static_cast<int>(flags(i - 1, j, k).isConnected(0, 0, -1));
         const amrex::Real wkhi = weights[khip - khim];
         const amrex::Real wklo = weights[klop - klom];
         td(i, j, k, 3) =
@@ -77,10 +85,14 @@ pc_compute_tangential_vel_derivs_eb(
                    , k = sv_ebg[L].iv[2];);
       const amrex::IntVect iv = amrex::IntVect{AMREX_D_DECL(i, j, k)};
       if (bx.contains(iv)) {
-        const int ihip = i + flags(i, j, k).isConnected(1, 0, 0);
-        const int ihim = i - flags(i, j, k).isConnected(-1, 0, 0);
-        const int ilop = i + flags(i, j - 1, k).isConnected(1, 0, 0);
-        const int ilom = i - flags(i, j - 1, k).isConnected(-1, 0, 0);
+        const int ihip =
+          i + static_cast<int>(flags(i, j, k).isConnected(1, 0, 0));
+        const int ihim =
+          i - static_cast<int>(flags(i, j, k).isConnected(-1, 0, 0));
+        const int ilop =
+          i + static_cast<int>(flags(i, j - 1, k).isConnected(1, 0, 0));
+        const int ilom =
+          i - static_cast<int>(flags(i, j - 1, k).isConnected(-1, 0, 0));
         const amrex::Real wihi = weights[ihip - ihim];
         const amrex::Real wilo = weights[ilop - ilom];
         td(i, j, k, 0) =
@@ -97,10 +109,14 @@ pc_compute_tangential_vel_derivs_eb(
           ((q(ihip, j, k, QW) - q(ihim, j, k, QW)) * wihi +
            (q(ilop, j - 1, k, QW) - q(ilom, j - 1, k, QW)) * wilo);
 
-        const int khip = k + flags(i, j, k).isConnected(0, 0, 1);
-        const int khim = k - flags(i, j, k).isConnected(0, 0, -1);
-        const int klop = k + flags(i, j - 1, k).isConnected(0, 0, 1);
-        const int klom = k - flags(i, j - 1, k).isConnected(0, 0, -1);
+        const int khip =
+          k + static_cast<int>(flags(i, j, k).isConnected(0, 0, 1));
+        const int khim =
+          k - static_cast<int>(flags(i, j, k).isConnected(0, 0, -1));
+        const int klop =
+          k + static_cast<int>(flags(i, j - 1, k).isConnected(0, 0, 1));
+        const int klom =
+          k - static_cast<int>(flags(i, j - 1, k).isConnected(0, 0, -1));
         const amrex::Real wkhi = weights[khip - khim];
         const amrex::Real wklo = weights[klop - klom];
         td(i, j, k, 3) =
@@ -125,10 +141,14 @@ pc_compute_tangential_vel_derivs_eb(
       const int k = sv_ebg[L].iv[2];
       const amrex::IntVect iv = amrex::IntVect{AMREX_D_DECL(i, j, k)};
       if (bx.contains(iv)) {
-        const int ihip = i + flags(i, j, k).isConnected(1, 0, 0);
-        const int ihim = i - flags(i, j, k).isConnected(-1, 0, 0);
-        const int ilop = i + flags(i, j, k - 1).isConnected(1, 0, 0);
-        const int ilom = i - flags(i, j, k - 1).isConnected(-1, 0, 0);
+        const int ihip =
+          i + static_cast<int>(flags(i, j, k).isConnected(1, 0, 0));
+        const int ihim =
+          i - static_cast<int>(flags(i, j, k).isConnected(-1, 0, 0));
+        const int ilop =
+          i + static_cast<int>(flags(i, j, k - 1).isConnected(1, 0, 0));
+        const int ilom =
+          i - static_cast<int>(flags(i, j, k - 1).isConnected(-1, 0, 0));
         const amrex::Real wihi = weights[ihip - ihim];
         const amrex::Real wilo = weights[ilop - ilom];
         td(i, j, k, 0) =
@@ -144,10 +164,14 @@ pc_compute_tangential_vel_derivs_eb(
           ((q(ihip, j, k, QW) - q(ihim, j, k, QW)) * wihi +
            (q(ilop, j, k - 1, QW) - q(ilom, j, k - 1, QW)) * wilo);
 
-        const int jhip = j + flags(i, j, k).isConnected(0, 1, 0);
-        const int jhim = j - flags(i, j, k).isConnected(0, -1, 0);
-        const int jlop = j + flags(i, j, k - 1).isConnected(0, 1, 0);
-        const int jlom = j - flags(i, j, k - 1).isConnected(0, -1, 0);
+        const int jhip =
+          j + static_cast<int>(flags(i, j, k).isConnected(0, 1, 0));
+        const int jhim =
+          j - static_cast<int>(flags(i, j, k).isConnected(0, -1, 0));
+        const int jlop =
+          j + static_cast<int>(flags(i, j, k - 1).isConnected(0, 1, 0));
+        const int jlom =
+          j - static_cast<int>(flags(i, j, k - 1).isConnected(0, -1, 0));
         const amrex::Real wjhi = weights[jhip - jhim];
         const amrex::Real wjlo = weights[jlop - jlom];
         td(i, j, k, 3) =

--- a/Source/Hydro.cpp
+++ b/Source/Hydro.cpp
@@ -11,14 +11,14 @@ PeleC::construct_hydro_source(
   int sub_iteration,
   int sub_ncycle)
 {
-  if (do_mol) {
-    if (verbose && amrex::ParallelDescriptor::IOProcessor()) {
+  if (do_mol != 0) {
+    if ((verbose != 0) && amrex::ParallelDescriptor::IOProcessor()) {
       amrex::Print() << "... Zeroing Godunov-based hydro advance" << std::endl;
     }
     hydro_source.setVal(0);
   } else {
 
-    if (verbose && amrex::ParallelDescriptor::IOProcessor()) {
+    if ((verbose != 0) && amrex::ParallelDescriptor::IOProcessor()) {
       amrex::Print() << "... Computing hydro advance" << std::endl;
     }
 
@@ -222,7 +222,7 @@ PeleC::construct_hydro_source(
         courno = amrex::max<amrex::Real>(courno, cflLoc);
 
         // Filter hydro source and fluxes here
-        if (use_explicit_filter) {
+        if (use_explicit_filter != 0) {
           for (int dir = 0; dir < AMREX_SPACEDIM; dir++) {
             const amrex::Box& bxtmp = amrex::surroundingNodes(bx, dir);
             amrex::FArrayBox filtered_flux(bxtmp, NVAR);
@@ -245,7 +245,7 @@ PeleC::construct_hydro_source(
             bx, hyd_src.nComp(), filtered_source_out.array(), hyd_src);
         }
 
-        if (do_reflux && sub_iteration == sub_ncycle - 1) {
+        if ((do_reflux != 0) && sub_iteration == sub_ncycle - 1) {
           if (level < finest_level) {
             getFluxReg(level + 1).CrseAdd(
               mfi, {{AMREX_D_DECL(&(flux[0]), &(flux[1]), &(flux[2]))}}, dxDp,
@@ -274,7 +274,7 @@ PeleC::construct_hydro_source(
 
     BL_PROFILE_VAR_STOP(PC_UMDRV);
 
-    if (track_grid_losses) {
+    if (track_grid_losses != 0) {
       material_lost_through_boundary_temp[0] += mass_lost;
       material_lost_through_boundary_temp[1] += xmom_lost;
       material_lost_through_boundary_temp[2] += ymom_lost;
@@ -285,7 +285,7 @@ PeleC::construct_hydro_source(
       material_lost_through_boundary_temp[7] += zang_lost;
     }
 
-    if (print_energy_diagnostics) {
+    if (print_energy_diagnostics != 0) {
       amrex::Real foo[5] = {
         E_added_flux, xmom_added_flux, ymom_added_flux, zmom_added_flux,
         mass_added_flux};

--- a/Source/IO.cpp
+++ b/Source/IO.cpp
@@ -135,12 +135,12 @@ PeleC::restart(amrex::Amr& papa, std::istream& is, bool bReadSpecial)
       grids, dmap, NVAR, newGrow, amrex::MFInfo(), Factory());
   }
 
-  if (do_hydro || do_diffuse) {
+  if ((do_hydro != 0) || do_diffuse) {
     Sborder.define(grids, dmap, NVAR, numGrow(), amrex::MFInfo(), Factory());
   }
 
-  if (!do_mol) {
-    if (do_hydro) {
+  if (do_mol == 0) {
+    if (do_hydro != 0) {
       hydro_source.define(grids, dmap, NVAR, 0, amrex::MFInfo(), Factory());
 
       // This array holds the sum of all source terms that affect the
@@ -169,7 +169,7 @@ PeleC::restart(amrex::Amr& papa, std::istream& is, bool bReadSpecial)
     amrex::Print() << "read CPU time: " << previousCPUTimeUsed << "\n";
   }
 
-  if (track_grid_losses && level == 0) {
+  if ((track_grid_losses != 0) && level == 0) {
 
     // get the current value of the diagnostic quantities
     std::ifstream DiagFile;
@@ -209,7 +209,7 @@ PeleC::restart(amrex::Amr& papa, std::istream& is, bool bReadSpecial)
       }
   */
 
-  if (level > 0 && do_reflux) {
+  if (level > 0 && (do_reflux != 0)) {
     flux_reg.define(
       grids, papa.boxArray(level - 1), dmap, papa.DistributionMap(level - 1),
       geom, papa.Geom(level - 1), papa.refRatio(level - 1), level, NVAR);
@@ -333,7 +333,7 @@ PeleC::checkPoint(
       CPUFile.close();
     }
 
-    if (track_grid_losses) {
+    if (track_grid_losses != 0) {
       // store diagnostic quantities
       std::ofstream DiagFile;
       std::string FullPathDiagFile = dir;

--- a/Source/InitEB.cpp
+++ b/Source/InitEB.cpp
@@ -162,10 +162,10 @@ PeleC::initialize_eb2_structs()
       sv_eb_flux[iLocal].define(sv_eb_bndry_grad_stencil[iLocal], NVAR);
       sv_eb_bcval[iLocal].define(sv_eb_bndry_grad_stencil[iLocal], QVAR);
 
-      if (eb_isothermal && (diffuse_temp != 0 || diffuse_enth != 0)) {
+      if ((eb_isothermal != 0) && (diffuse_temp != 0 || diffuse_enth != 0)) {
         sv_eb_bcval[iLocal].setVal(eb_boundary_T, QTEMP);
       }
-      if (eb_noslip && diffuse_vel == 1) {
+      if ((eb_noslip != 0) && diffuse_vel == 1) {
         sv_eb_bcval[iLocal].setVal(0, QU, AMREX_SPACEDIM);
       }
 

--- a/Source/LES.H
+++ b/Source/LES.H
@@ -211,11 +211,11 @@ pc_smagorinsky_sfs_term(
       alpha, flux_T);
   }
   const amrex::Real sigmadx =
-    Cs2 * alphaij[0] - third * CI * alpha * (dir == 0);
+    Cs2 * alphaij[0] - third * CI * alpha * static_cast<double>(dir == 0);
   const amrex::Real sigmady =
-    Cs2 * alphaij[1] - third * CI * alpha * (dir == 1);
+    Cs2 * alphaij[1] - third * CI * alpha * static_cast<double>(dir == 1);
   const amrex::Real sigmadz =
-    Cs2 * alphaij[2] - third * CI * alpha * (dir == 2);
+    Cs2 * alphaij[2] - third * CI * alpha * static_cast<double>(dir == 2);
   flx(iv, UMX) = -sigmadx;
   flx(iv, UMY) = -sigmady;
   flx(iv, UMZ) = -sigmadz;

--- a/Source/LES.cpp
+++ b/Source/LES.cpp
@@ -54,7 +54,7 @@ PeleC::construct_old_les_source(
   amrex::Real time, amrex::Real dt, int /*sub_iteration*/, int /*sub_ncycle*/)
 {
   // Add grow cells necessary for explicit filtering of source terms
-  if (use_explicit_filter) {
+  if (use_explicit_filter != 0) {
     filtered_les_source.define(
       grids, dmap, NVAR, old_sources[les_src]->nGrow(), amrex::MFInfo(),
       Factory());
@@ -76,7 +76,7 @@ PeleC::construct_new_les_source(
   amrex::Real time, amrex::Real dt, int sub_iteration, int sub_ncycle)
 {
   // Add grow cells necessary for explicit filtering of source terms
-  if (use_explicit_filter) {
+  if (use_explicit_filter != 0) {
     filtered_les_source.define(
       grids, dmap, NVAR, new_sources[les_src]->nGrow(), amrex::MFInfo(),
       Factory());
@@ -108,7 +108,7 @@ PeleC::getLESTerm(
     return;
   }
 
-  if (verbose) {
+  if (verbose != 0) {
     amrex::Print() << "... Computing LES term at time " << time << std::endl;
   }
 
@@ -161,7 +161,7 @@ PeleC::getLESTerm(
   //  }
 
   // Filter the SGS source term
-  if (use_explicit_filter) {
+  if (use_explicit_filter != 0) {
     les_filter.apply_filter(LESTerm, filtered_les_source);
     LESTerm.define(
       grids, dmap, NVAR, filtered_les_source.nGrow(), amrex::MFInfo(),
@@ -335,7 +335,7 @@ PeleC::getSmagorinskyLESTerm(
 #else
       auto device = amrex::RunOn::Cpu;
 #endif
-      if (do_reflux && flux_factor != 0) // no eb in problem
+      if ((do_reflux != 0) && flux_factor != 0) // no eb in problem
       {
         for (int dir = 0; dir < AMREX_SPACEDIM; dir++) {
           amrex::ParallelFor(
@@ -703,7 +703,7 @@ PeleC::getDynamicSmagorinskyLESTerm(
 #else
       auto device = amrex::RunOn::Cpu;
 #endif
-      if (do_reflux && flux_factor != 0) // no eb in problem
+      if ((do_reflux != 0) && flux_factor != 0) // no eb in problem
       {
         for (int dir = 0; dir < AMREX_SPACEDIM; dir++) {
           amrex::ParallelFor(

--- a/Source/MOL.cpp
+++ b/Source/MOL.cpp
@@ -40,7 +40,9 @@ pc_compute_hyp_mol_flux(
     setV(cbox, QVAR, dq, 0.0);
 
     // dimensional indexing
-    const amrex::GpuArray<const int, 3> bdim{{dir == 0, dir == 1, dir == 2}};
+    const amrex::GpuArray<const int, 3> bdim{
+      {static_cast<const int>(dir == 0), static_cast<const int>(dir == 1),
+       static_cast<const int>(dir == 2)}};
     const amrex::GpuArray<const int, 3> q_idx{
       {bdim[0] * QU + bdim[1] * QV + bdim[2] * QW,
        bdim[0] * QV + bdim[1] * QU + bdim[2] * QU,
@@ -125,7 +127,7 @@ pc_compute_hyp_mol_flux(
         amrex::Real flux_tmp[NVAR] = {0.0};
         amrex::Real ustar = 0.0;
 
-        if (!use_laxf_flux) {
+        if (use_laxf_flux == 0) {
           amrex::Real tmp0 = 0.0, tmp1 = 0.0, tmp2 = 0.0, tmp3 = 0.0,
                       tmp4 = 0.0;
           riemann(

--- a/Source/PLM.H
+++ b/Source/PLM.H
@@ -93,7 +93,9 @@ pc_plm_d(
 {
   const amrex::IntVect iv{AMREX_D_DECL(i, j, k)};
   const amrex::IntVect ivp(iv + amrex::IntVect::TheDimensionVector(dir));
-  const amrex::GpuArray<const int, 3> bdim{{dir == 0, dir == 1, dir == 2}};
+  const amrex::GpuArray<const int, 3> bdim{
+    {static_cast<const int>(dir == 0), static_cast<const int>(dir == 1),
+     static_cast<const int>(dir == 2)}};
   const amrex::GpuArray<const int, 3> l_idx{
     {bdim[0] * 0 + bdim[1] * 1 + bdim[2] * 2,
      bdim[0] * 1 + bdim[1] * 0 + bdim[2] * 0,

--- a/Source/PPM.cpp
+++ b/Source/PPM.cpp
@@ -122,7 +122,8 @@ trace_ppm(
     amrex::Real Im[QVAR][3];
 
     for (int n = 0; n < QVAR; n++) {
-      if (use_hybrid_weno && ((weno_scheme == 0) || (weno_scheme == 1))) {
+      if (
+        (use_hybrid_weno != 0) && ((weno_scheme == 0) || (weno_scheme == 1))) {
 
         amrex::Real s_weno5[5];
         s_weno5[0] = q_arr(ivm2, n);
@@ -140,7 +141,7 @@ trace_ppm(
         }
         ppm_int_profile(sm, sp, s_weno5[2], un, cc, dtdx, Ip[n], Im[n]);
 
-      } else if (use_hybrid_weno && weno_scheme == 2) {
+      } else if ((use_hybrid_weno != 0) && weno_scheme == 2) {
 
         amrex::Real s_weno7[7];
         const amrex::IntVect ivm3(
@@ -160,7 +161,7 @@ trace_ppm(
         weno_reconstruct_7z(s_weno7, sm, sp);
         ppm_int_profile(sm, sp, s_weno7[3], un, cc, dtdx, Ip[n], Im[n]);
 
-      } else if (use_hybrid_weno && weno_scheme == 3) {
+      } else if ((use_hybrid_weno != 0) && weno_scheme == 3) {
 
         amrex::Real s_weno3[3];
         if (idir == 0) {

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -263,7 +263,8 @@ PeleC::read_params()
   pp.query("diffuse_vel", diffuse_vel);
   pp.query("diffuse_cutoff_density", diffuse_cutoff_density);
 
-  do_diffuse = diffuse_temp || diffuse_enth || diffuse_spec || diffuse_vel;
+  do_diffuse = (diffuse_temp != 0) || (diffuse_enth != 0) ||
+               (diffuse_spec != 0) || (diffuse_vel != 0);
 
   // sanity checks
   if (cfl <= 0.0 || cfl > 1.0) {
@@ -274,17 +275,17 @@ PeleC::read_params()
                    << std::endl;
   }
 
-  if ((do_les || use_explicit_filter) && (AMREX_SPACEDIM != 3)) {
+  if (((do_les != 0) || (use_explicit_filter != 0)) && (AMREX_SPACEDIM != 3)) {
     amrex::Abort("Using LES/filtering currently requires 3d.");
   }
 
-  if (do_les) {
+  if (do_les != 0) {
     pp.query("les_model", les_model);
     pp.query("les_test_filter_type", les_test_filter_type);
     pp.query("les_test_filter_fgr", les_test_filter_fgr);
   }
 
-  if (use_explicit_filter) {
+  if (use_explicit_filter != 0) {
     pp.query("les_filter_type", les_filter_type);
     pp.query("les_filter_fgr", les_filter_fgr);
   }
@@ -395,7 +396,7 @@ PeleC::PeleC(
       grids, dmap, NVAR, newGrow, amrex::MFInfo(), Factory());
   }
 
-  if (do_hydro || do_diffuse) {
+  if ((do_hydro != 0) || do_diffuse) {
     Sborder.define(grids, dmap, NVAR, numGrow(), amrex::MFInfo(), Factory());
   }
 #ifdef AMREX_PARTICLES
@@ -404,8 +405,8 @@ PeleC::PeleC(
   }
 #endif
 
-  if (!do_mol) {
-    if (do_hydro) {
+  if (do_mol == 0) {
+    if (do_hydro != 0) {
       hydro_source.define(
         grids, dmap, NVAR, numGrow(), amrex::MFInfo(), Factory());
 
@@ -427,7 +428,7 @@ PeleC::PeleC(
     material_lost_through_boundary_temp[i] = 0.0;
   }
 
-  if (do_reflux && level > 0) {
+  if ((do_reflux != 0) && level > 0) {
     flux_reg.define(
       bl, papa.boxArray(level - 1), dm, papa.DistributionMap(level - 1),
       level_geom, papa.Geom(level - 1), papa.refRatio(level - 1), level, NVAR);
@@ -456,13 +457,13 @@ PeleC::PeleC(
   }
 
   // initialize LES variables
-  if (do_les) {
+  if (do_les != 0) {
     init_les();
   }
 
   // initialize filters and variables
   nGrowF = 0;
-  if (use_explicit_filter) {
+  if (use_explicit_filter != 0) {
     init_filters();
   }
 }
@@ -646,7 +647,7 @@ PeleC::initData()
   }
 #endif
 
-  if (verbose) {
+  if (verbose != 0) {
     amrex::Print() << "Initializing the data at level " << level << std::endl;
   }
 
@@ -701,7 +702,7 @@ PeleC::initData()
   }
 #endif
 
-  if (verbose) {
+  if (verbose != 0) {
     amrex::Print() << "Done initializing level " << level << " data "
                    << std::endl;
   }
@@ -726,7 +727,7 @@ PeleC::init(AmrLevel& old)
 
   amrex::MultiFab& React_new = get_new_data(Reactions_Type);
 
-  if (do_react) {
+  if (do_react != 0) {
     FillPatch(
       old, React_new, 0, cur_time, Reactions_Type, 0, React_new.nComp());
   } else {
@@ -812,7 +813,9 @@ amrex::Real PeleC::estTimeStep(amrex::Real /*dt_old*/)
   amrex::Real estdt_vdif = max_dt_over_cfl;
   amrex::Real estdt_tdif = max_dt_over_cfl;
   amrex::Real estdt_edif = max_dt_over_cfl;
-  if (do_hydro || do_mol || diffuse_vel || diffuse_temp || diffuse_enth) {
+  if (
+    (do_hydro != 0) || (do_mol != 0) || (diffuse_vel != 0) ||
+    (diffuse_temp != 0) || (diffuse_enth != 0)) {
 
 #ifdef PELEC_USE_EB
     auto const& fact =
@@ -823,7 +826,7 @@ amrex::Real PeleC::estTimeStep(amrex::Real /*dt_old*/)
     prefetchToDevice(stateMF); // This should accelerate the below operations.
     amrex::Real AMREX_D_DECL(dx1 = dx[0], dx2 = dx[1], dx3 = dx[2]);
 
-    if (do_hydro) {
+    if (do_hydro != 0) {
       amrex::Real dt = amrex::ReduceMin(
         stateMF,
 #ifdef PELEC_USE_EB
@@ -847,7 +850,7 @@ amrex::Real PeleC::estTimeStep(amrex::Real /*dt_old*/)
       estdt_hydro = amrex::min<amrex::Real>(estdt_hydro, dt);
     }
 
-    if (diffuse_vel) {
+    if (diffuse_vel != 0) {
       auto const* ltransparm = trans_parms.device_trans_parm();
       amrex::Real dt = amrex::ReduceMin(
         stateMF,
@@ -872,7 +875,7 @@ amrex::Real PeleC::estTimeStep(amrex::Real /*dt_old*/)
       estdt_vdif = amrex::min<amrex::Real>(estdt_vdif, dt);
     }
 
-    if (diffuse_temp) {
+    if (diffuse_temp != 0) {
       auto const* ltransparm = trans_parms.device_trans_parm();
       amrex::Real dt = amrex::ReduceMin(
         stateMF,
@@ -897,7 +900,7 @@ amrex::Real PeleC::estTimeStep(amrex::Real /*dt_old*/)
       estdt_tdif = amrex::min<amrex::Real>(estdt_tdif, dt);
     }
 
-    if (diffuse_enth) {
+    if (diffuse_enth != 0) {
       auto const* ltransparm = trans_parms.device_trans_parm();
       amrex::Real dt = amrex::ReduceMin(
         stateMF,
@@ -930,7 +933,7 @@ amrex::Real PeleC::estTimeStep(amrex::Real /*dt_old*/)
     amrex::ParallelDescriptor::ReduceRealMin(estdt_hydro);
     estdt_hydro *= cfl;
 
-    if (verbose) {
+    if (verbose != 0) {
       amrex::Print() << "...estimated hydro-limited timestep at level " << level
                      << ": " << estdt_hydro << std::endl;
     }
@@ -953,7 +956,7 @@ amrex::Real PeleC::estTimeStep(amrex::Real /*dt_old*/)
   }
 #endif
 
-  if (verbose) {
+  if (verbose != 0) {
     amrex::Print() << "PeleC::estTimeStep (" << limiter << "-limited) at level "
                    << level << ":  estdt = " << estdt << '\n';
   }
@@ -996,7 +999,7 @@ PeleC::computeNewDt(
     } else {
       // Limit dt's by change_max * old dt
       for (int i = 0; i <= finest_level; i++) {
-        if (verbose && amrex::ParallelDescriptor::IOProcessor()) {
+        if ((verbose != 0) && amrex::ParallelDescriptor::IOProcessor()) {
           if (dt_min[i] > change_max * dt_level[i]) {
             amrex::Print() << "PeleC::compute_new_dt : limiting dt at level "
                            << i << '\n';
@@ -1107,7 +1110,7 @@ PeleC::post_timestep(int
   }
 #endif
 
-  if (do_reflux && level < finest_level) {
+  if ((do_reflux != 0) && level < finest_level) {
     reflux();
 
     // We need to do this before anything else because refluxing changes the
@@ -1151,14 +1154,14 @@ PeleC::post_timestep(int
 
     if (sum_int_test || sum_per_test) {
       sum_integrated_quantities();
-      if (track_extrema) {
+      if (track_extrema != 0) {
         monitor_extrema();
       }
     }
   }
 
   if (
-    do_react && use_typical_vals_chem &&
+    (do_react != 0) && use_typical_vals_chem &&
     parent->levelSteps(0) % reset_typical_vals_int == 0) {
     set_typical_values_chem();
   }
@@ -1199,13 +1202,13 @@ PeleC::post_restart()
   }
 
   // initialize LES variables
-  if (do_les) {
+  if (do_les != 0) {
     init_les();
   }
 
   // initialize filters and variables
   nGrowF = 0;
-  if (use_explicit_filter) {
+  if (use_explicit_filter != 0) {
     init_filters();
   }
 
@@ -1306,7 +1309,7 @@ void PeleC::post_init(amrex::Real /*stop_time*/)
 
   if (sum_int_test || sum_per_test) {
     sum_integrated_quantities();
-    if (track_extrema) {
+    if (track_extrema != 0) {
       monitor_extrema();
     }
   }
@@ -1373,7 +1376,7 @@ PeleC::reflux()
   }
 #endif
 
-  if (verbose) {
+  if (verbose != 0) {
     const int IOProc = amrex::ParallelDescriptor::IOProcessorNumber();
     amrex::Real end = amrex::ParallelDescriptor::second() - strt;
 
@@ -1487,7 +1490,7 @@ PeleC::enforce_min_density(
     //                        &dens_change, &verbose);
   }
 
-  if (print_energy_diagnostics) {
+  if (print_energy_diagnostics != 0) {
     amrex::Real foo[3] = {mass_added, eint_added, eden_added};
 
 #ifdef AMREX_LAZY
@@ -1869,25 +1872,25 @@ std::unique_ptr<amrex::MultiFab>
 PeleC::derive(const std::string& name, amrex::Real time, int ngrow)
 {
 
-  if ((do_les) && (name == "C_s2")) {
+  if (((do_les) != 0) && (name == "C_s2")) {
     std::unique_ptr<amrex::MultiFab> derive_dat(
       new amrex::MultiFab(grids, dmap, 1, 0));
     amrex::MultiFab::Copy(*derive_dat, LES_Coeffs, comp_Cs2, 0, 1, 0);
     return derive_dat;
   }
-  if ((do_les) && (name == "C_I")) {
+  if (((do_les) != 0) && (name == "C_I")) {
     std::unique_ptr<amrex::MultiFab> derive_dat(
       new amrex::MultiFab(grids, dmap, 1, 0));
     amrex::MultiFab::Copy(*derive_dat, LES_Coeffs, comp_CI, 0, 1, 0);
     return derive_dat;
   }
-  if ((do_les) && (les_model != 1) && (name == "Pr_T")) {
+  if (((do_les) != 0) && (les_model != 1) && (name == "Pr_T")) {
     std::unique_ptr<amrex::MultiFab> derive_dat(
       new amrex::MultiFab(grids, dmap, 1, 0));
     amrex::MultiFab::Copy(*derive_dat, LES_Coeffs, comp_PrT, 0, 1, 0);
     return derive_dat;
   }
-  if ((do_les) && (les_model == 1) && (name == "Pr_T")) {
+  if (((do_les) != 0) && (les_model == 1) && (name == "Pr_T")) {
     std::unique_ptr<amrex::MultiFab> derive_dat(
       new amrex::MultiFab(grids, dmap, 1, 0));
     amrex::MultiFab::Copy(*derive_dat, LES_Coeffs, comp_Cs2ovPrT, 0, 1, 0);
@@ -2001,7 +2004,7 @@ PeleC::init_filters()
   nGrowF = les_filter.get_filter_ngrow();
 
   // Add grow cells necessary for explicit filtering of source terms
-  if (do_hydro) {
+  if (do_hydro != 0) {
     Sborder.define(
       grids, dmap, NVAR, Sborder.nGrow() + nGrowF, amrex::MFInfo(), Factory());
     hydro_source.define(
@@ -2071,7 +2074,7 @@ PeleC::reset_internal_energy(amrex::MultiFab& S_new, int ng)
 {
 #ifndef AMREX_USE_GPU
   amrex::Real sum0 = 0.0;
-  if (parent->finestLevel() == 0 && print_energy_diagnostics) {
+  if (parent->finestLevel() == 0 && (print_energy_diagnostics != 0)) {
     // Pass in the multifab and the component
     sum0 = volWgtSumMF(S_new, Eden, true);
   }
@@ -2103,7 +2106,7 @@ PeleC::reset_internal_energy(amrex::MultiFab& S_new, int ng)
   }
 
 #ifndef AMREX_USE_GPU
-  if (parent->finestLevel() == 0 && print_energy_diagnostics) {
+  if (parent->finestLevel() == 0 && (print_energy_diagnostics != 0)) {
     // Pass in the multifab and the component
     amrex::Real sum = volWgtSumMF(S_new, Eden, true);
 #ifdef AMREX_LAZY
@@ -2286,7 +2289,7 @@ PeleC::InitialRedistribution(
     return;
   }
 
-  if (verbose) {
+  if (verbose != 0) {
     amrex::Print() << "Doing initial redistribution... " << std::endl;
   }
 

--- a/Source/React.cpp
+++ b/Source/React.cpp
@@ -44,7 +44,7 @@ PeleC::react_state(
 
   AMREX_ASSERT(do_react == 1);
 
-  if (verbose && amrex::ParallelDescriptor::IOProcessor()) {
+  if ((verbose != 0) && amrex::ParallelDescriptor::IOProcessor()) {
     if (react_init) {
       amrex::Print() << "... Initializing reactions, using interval dt = " << dt
                      << std::endl;
@@ -82,7 +82,7 @@ PeleC::react_state(
           non_react_src_tmp, 0.5, *old_sources[src_list[n]], 0, 0, NVAR, ng);
       }
 
-      if (do_hydro && !do_mol) {
+      if ((do_hydro != 0) && (do_mol == 0)) {
         amrex::MultiFab::Add(non_react_src_tmp, hydro_source, 0, 0, NVAR, ng);
       }
     } else {
@@ -259,7 +259,7 @@ PeleC::react_state(
               rhonew += rhoY(i, j, k, nsp);
             }
 
-            if (do_update) {
+            if (do_update != 0) {
               snew_arr(i, j, k, URHO) = rhonew;
               snew_arr(i, j, k, UMX) = umnew;
               snew_arr(i, j, k, UMY) = vmnew;

--- a/Source/Setup.cpp
+++ b/Source/Setup.cpp
@@ -600,7 +600,7 @@ PeleC::variableSetUp()
   derive_lst.addComponent("diffusivity", desc_lst, State_Type, Density, NVAR);
 
   // LES coefficients
-  if (do_les) {
+  if (do_les != 0) {
     derive_lst.add(
       "C_s2", amrex::IndexType::TheCellType(), 1, pc_dernull,
       amrex::DeriveRec::TheSameBox);
@@ -682,7 +682,7 @@ PeleC::variableCleanUp()
 void
 PeleC::set_active_sources()
 {
-  if (do_diffuse && !do_mol) {
+  if (do_diffuse && (do_mol == 0)) {
     src_list.push_back(diff_src);
   }
 
@@ -703,7 +703,7 @@ PeleC::set_active_sources()
 #endif
 
   // optional LES source
-  if (do_les) {
+  if (do_les != 0) {
     src_list.push_back(les_src);
   }
 

--- a/Source/Sources.cpp
+++ b/Source/Sources.cpp
@@ -81,7 +81,7 @@ PeleC::sum_of_sources(amrex::MultiFab& source)
     amrex::MultiFab::Add(source, *old_sources[src_list[n]], 0, 0, NVAR, ng);
   }
 
-  if (do_hydro) {
+  if (do_hydro != 0) {
     amrex::MultiFab::Add(source, hydro_source, 0, 0, NVAR, ng);
   }
 

--- a/Source/SparseData.H
+++ b/Source/SparseData.H
@@ -129,7 +129,7 @@ SparseData<T, Cell>::merge(
   auto* d_thdlocal_data = thdlocal.m_data.data();
   const auto* d_mask = mask.data();
   amrex::ParallelFor(captured_m_region_size, [=] AMREX_GPU_DEVICE(int i) {
-    if (d_mask[i]) {
+    if (d_mask[i] != 0) {
       for (int n = 0; n < ncomp; ++n) {
 #ifdef _OPENMP
 #pragma omp atomic write

--- a/Source/Utilities.cpp
+++ b/Source/Utilities.cpp
@@ -109,7 +109,7 @@ clean_massfrac(
 
   amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
     const amrex::IntVect iv{AMREX_D_DECL(i, j, k)};
-    if (mask(iv)) {
+    if (mask(iv) != 0) {
       const amrex::Real rhoOld = rho(iv);
       const amrex::Real rhoOld_inv = 1.0 / rhoOld;
 

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -55,7 +55,7 @@ main(int argc, char* argv[])
 #endif
 
   // Save the inputs file name for later.
-  if (!strchr(argv[1], '=')) {
+  if (strchr(argv[1], '=') == nullptr) {
     inputs_name = argv[1];
   }
 
@@ -146,7 +146,7 @@ main(int argc, char* argv[])
 
   amrex::Real dRunTime2 = amrex::ParallelDescriptor::second();
 
-  while (amrptr->okToContinue() &&
+  while ((amrptr->okToContinue() != 0) &&
          (amrptr->levelSteps(0) < max_step || max_step < 0) &&
          (amrptr->cumTime() < stop_time || stop_time < 0.0)) {
     // Do a timestep


### PR DESCRIPTION
I'm in support of this one, because it makes it clear we're treating ints as bools, but I understand skipping this one if it makes the code look undesirable.