### PR TITLE
Make geom_type default to all_regular

### DIFF
--- a/Exec/Production/JetFlame/inputs.inp
+++ b/Exec/Production/JetFlame/inputs.inp
@@ -106,4 +106,3 @@ tagging.max_temprad_lev = 3
 amrex.signal_handling=0
 #amrex.throw_handling=0
 #fabarray.mfiter_tile_size = 1024000 8 8
-eb2.geom_type = all_regular

--- a/Exec/RegTests/HIT/example.inp
+++ b/Exec/RegTests/HIT/example.inp
@@ -65,4 +65,3 @@ prob.reynolds_lambda0 = 100.0
 prob.mach_t0 = 0.1
 prob.prandtl = 0.71
 prob.inres = 32
-eb2.geom_type = all_regular

--- a/Exec/RegTests/HIT/hit-1.inp
+++ b/Exec/RegTests/HIT/hit-1.inp
@@ -64,5 +64,4 @@ prob.prandtl = 0.71
 prob.inres = 32
 
 # EB
-eb2.geom_type = "all_regular"
 ebd.boundary_grad_stencil_type = 0

--- a/Exec/RegTests/HIT/hit-2.inp
+++ b/Exec/RegTests/HIT/hit-2.inp
@@ -65,5 +65,4 @@ prob.inres = 32
 prob.uin_norm = 1.4142135623730950
 
 # EB
-eb2.geom_type = "all_regular"
 ebd.boundary_grad_stencil_type = 0

--- a/Exec/RegTests/HIT/hit-3.inp
+++ b/Exec/RegTests/HIT/hit-3.inp
@@ -67,5 +67,4 @@ prob.uin_norm = 1.4142135623730950
 prob.forcing = 240945.78770686506
 
 # EB
-eb2.geom_type = "all_regular"
 ebd.boundary_grad_stencil_type = 0

--- a/Exec/RegTests/MMS/cns-les-no-amr.inp
+++ b/Exec/RegTests/MMS/cns-les-no-amr.inp
@@ -64,5 +64,4 @@ amr.derive_plot_vars = x_velocity y_velocity z_velocity magvel magvort pressure 
 # PROBLEM PARAMETERS
 
 # EB
-eb2.geom_type = "all_regular"
 ebd.boundary_grad_stencil_type = 0

--- a/Exec/RegTests/MMS/cns-no-amr-mol.inp
+++ b/Exec/RegTests/MMS/cns-no-amr-mol.inp
@@ -59,5 +59,4 @@ amr.derive_plot_vars = x_velocity y_velocity z_velocity magvel magvort pressure 
 # PROBLEM PARAMETERS
 
 # EB
-eb2.geom_type = "all_regular"
 ebd.boundary_grad_stencil_type = 0

--- a/Exec/RegTests/MMS/cns-no-amr.inp
+++ b/Exec/RegTests/MMS/cns-no-amr.inp
@@ -58,5 +58,4 @@ amr.derive_plot_vars = x_velocity y_velocity z_velocity magvel magvort pressure 
 # PROBLEM PARAMETERS
 
 # EB
-eb2.geom_type = "all_regular"
 ebd.boundary_grad_stencil_type = 0

--- a/Exec/RegTests/MMS/example.inp
+++ b/Exec/RegTests/MMS/example.inp
@@ -65,4 +65,3 @@ amr.plot_vars  =  density Temp
 amr.derive_plot_vars = x_velocity y_velocity z_velocity magvel magvort pressure rhommserror ummserror vmmserror wmmserror pmmserror
 
 # PROBLEM PARAMETERS
-eb2.geom_type = all_regular

--- a/Exec/RegTests/MMS/example_symmetry.inp
+++ b/Exec/RegTests/MMS/example_symmetry.inp
@@ -80,4 +80,3 @@ prob.a_wx = 0.0
 prob.a_wy = 0.0
 prob.a_wz = 2.0
 #fabarray.mfiter_tile_size = 1024 1024 1024
-eb2.geom_type = all_regular

--- a/Exec/RegTests/MMS/mms-1.inp
+++ b/Exec/RegTests/MMS/mms-1.inp
@@ -60,5 +60,4 @@ amr.derive_plot_vars = x_velocity y_velocity z_velocity magvel magvort pressure 
 # PROBLEM PARAMETERS
 
 # EB
-eb2.geom_type = "all_regular"
 ebd.boundary_grad_stencil_type = 0

--- a/Exec/RegTests/MMS/mms-2.inp
+++ b/Exec/RegTests/MMS/mms-2.inp
@@ -70,5 +70,4 @@ tagging.max_pressgrad_lev = 5
 # PROBLEM PARAMETERS
 
 # EB
-eb2.geom_type = "all_regular"
 ebd.boundary_grad_stencil_type = 0

--- a/Exec/RegTests/MMS/mms-3.inp
+++ b/Exec/RegTests/MMS/mms-3.inp
@@ -61,5 +61,4 @@ amr.derive_plot_vars = x_velocity y_velocity z_velocity magvel magvort pressure 
 # PROBLEM PARAMETERS
 
 # EB
-eb2.geom_type = "all_regular"
 ebd.boundary_grad_stencil_type = 0

--- a/Exec/RegTests/MMS/mms-4.inp
+++ b/Exec/RegTests/MMS/mms-4.inp
@@ -74,5 +74,4 @@ prob.a_wy = 1.0
 prob.p_x_fact = 0.0
 
 # EB
-eb2.geom_type = "all_regular"
 ebd.boundary_grad_stencil_type = 0

--- a/Exec/RegTests/MMS/mms-5.inp
+++ b/Exec/RegTests/MMS/mms-5.inp
@@ -66,5 +66,4 @@ amr.derive_plot_vars = x_velocity y_velocity z_velocity magvel magvort pressure 
 # PROBLEM PARAMETERS
 
 # EB
-eb2.geom_type = "all_regular"
 ebd.boundary_grad_stencil_type = 0

--- a/Exec/RegTests/MMS/symmetry.inp
+++ b/Exec/RegTests/MMS/symmetry.inp
@@ -75,7 +75,6 @@ prob.a_wy = 0.0
 prob.a_wz = 2.0
 
 # EB
-eb2.geom_type = "all_regular"
 ebd.boundary_grad_stencil_type = 0
 
 # Tiling

--- a/Exec/RegTests/MultiSpecSod/example.inp
+++ b/Exec/RegTests/MultiSpecSod/example.inp
@@ -66,4 +66,3 @@ prob.frac = 0.5
 prob.left_gas = N2
 prob.right_gas = HE
 
-eb2.geom_type = "all_regular"

--- a/Exec/RegTests/MultiSpecSod/multispecsod-1.inp
+++ b/Exec/RegTests/MultiSpecSod/multispecsod-1.inp
@@ -66,4 +66,3 @@ prob.frac = 0.5
 prob.left_gas = N2
 prob.right_gas = HE
 
-eb2.geom_type = "all_regular"

--- a/Exec/RegTests/PMF-SRK/example.inp
+++ b/Exec/RegTests/PMF-SRK/example.inp
@@ -67,4 +67,3 @@ pelec.sdc_iters = 2
 pelec.flame_trac_name = HO2
 amrex.signal_handling=0
 #amrex.throw_handling=0
-eb2.geom_type = all_regular

--- a/Exec/RegTests/PMF-SRK/pmf-srk-1.inp
+++ b/Exec/RegTests/PMF-SRK/pmf-srk-1.inp
@@ -71,5 +71,4 @@ pelec.sdc_iters = 2
 pelec.flame_trac_name = HO2
 pelec.do_mol=0
 
-eb2.geom_type = "all_regular"
 ebd.boundary_grad_stencil_type = 0

--- a/Exec/RegTests/PMF/example.inp
+++ b/Exec/RegTests/PMF/example.inp
@@ -71,4 +71,3 @@ pelec.extrema_spec_name = H2O
 pelec.plot_massfrac = 1
 amrex.signal_handling=0
 #amrex.throw_handling=0
-eb2.geom_type = all_regular

--- a/Exec/RegTests/PMF/pmf-dodecane.inp
+++ b/Exec/RegTests/PMF/pmf-dodecane.inp
@@ -69,4 +69,3 @@ pelec.sdc_iters = 2
 pelec.flame_trac_name = HO2
 amrex.signal_handling=0
 #amrex.throw_handling=0
-eb2.geom_type = all_regular

--- a/Exec/RegTests/PMF/pmf-lidryer-arkode.inp
+++ b/Exec/RegTests/PMF/pmf-lidryer-arkode.inp
@@ -71,5 +71,4 @@ pelec.sdc_iters = 2
 pelec.flame_trac_name = HO2
 pelec.do_mol=0
 
-eb2.geom_type = "all_regular"
 ebd.boundary_grad_stencil_type = 0

--- a/Exec/RegTests/PMF/pmf-lidryer-cvode.inp
+++ b/Exec/RegTests/PMF/pmf-lidryer-cvode.inp
@@ -72,5 +72,4 @@ pelec.sdc_iters = 2
 pelec.flame_trac_name = HO2
 pelec.do_mol=0
 
-eb2.geom_type = "all_regular"
 ebd.boundary_grad_stencil_type = 0

--- a/Exec/RegTests/PMF/pmf-lidryer-rk64.inp
+++ b/Exec/RegTests/PMF/pmf-lidryer-rk64.inp
@@ -71,5 +71,4 @@ pelec.sdc_iters = 2
 pelec.flame_trac_name = HO2
 pelec.do_mol=0
 
-eb2.geom_type = "all_regular"
 ebd.boundary_grad_stencil_type = 0

--- a/Exec/RegTests/Sedov/example.inp
+++ b/Exec/RegTests/Sedov/example.inp
@@ -62,4 +62,3 @@ prob.p_ambient = 1.e-5
 prob.dens_ambient = 1.0
 prob.exp_energy = 1.0
 prob.nsub = 10
-eb2.geom_type = all_regular

--- a/Exec/RegTests/Sedov/sedov-1.inp
+++ b/Exec/RegTests/Sedov/sedov-1.inp
@@ -63,5 +63,4 @@ prob.dens_ambient = 1.0
 prob.exp_energy = 1.0
 prob.nsub = 10
 
-eb2.geom_type = "all_regular"
 ebd.boundary_grad_stencil_type = 0

--- a/Exec/RegTests/Shu-Osher/example.inp
+++ b/Exec/RegTests/Shu-Osher/example.inp
@@ -70,5 +70,4 @@ prob.rho_r_osc  = 5.0
 prob.idir = 1
 prob.frac=0.1
 
-eb2.geom_type = "all_regular"
 ebd.boundary_grad_stencil_type = 0

--- a/Exec/RegTests/Shu-Osher/shu-osher-1.inp
+++ b/Exec/RegTests/Shu-Osher/shu-osher-1.inp
@@ -70,5 +70,4 @@ prob.rho_r_osc  = 5.0
 prob.idir = 1
 prob.frac=0.1
 
-eb2.geom_type = "all_regular"
 ebd.boundary_grad_stencil_type = 0

--- a/Exec/RegTests/Sod/example.inp
+++ b/Exec/RegTests/Sod/example.inp
@@ -75,5 +75,4 @@ tagging.max_presserr_lev = 3
 tagging.max_pressgrad_lev = 3
 
 # EB
-eb2.geom_type = "all_regular"
 ebd.boundary_grad_stencil_type = 0

--- a/Exec/RegTests/Sod/sod-1.inp
+++ b/Exec/RegTests/Sod/sod-1.inp
@@ -75,5 +75,4 @@ tagging.max_presserr_lev = 3
 tagging.max_pressgrad_lev = 3
 
 # EB
-eb2.geom_type = "all_regular"
 ebd.boundary_grad_stencil_type = 0

--- a/Exec/RegTests/Sod/sod-2.inp
+++ b/Exec/RegTests/Sod/sod-2.inp
@@ -76,5 +76,4 @@ tagging.max_presserr_lev = 3
 tagging.max_pressgrad_lev = 3
 
 # EB
-eb2.geom_type = "all_regular"
 ebd.boundary_grad_stencil_type = 0

--- a/Exec/RegTests/TG/example.inp
+++ b/Exec/RegTests/TG/example.inp
@@ -73,4 +73,3 @@ prob.prandtl = 0.71
 amrex.signal_handling=0
 #amrex.throw_handling=0
 #fabarray.mfiter_tile_size = 1024000 8 8
-eb2.geom_type = all_regular

--- a/Exec/RegTests/TG/tg-1.inp
+++ b/Exec/RegTests/TG/tg-1.inp
@@ -63,5 +63,4 @@ prob.mach = 0.1
 prob.prandtl = 0.71
 
 # EB
-eb2.geom_type = "all_regular"
 ebd.boundary_grad_stencil_type = 0

--- a/Exec/RegTests/TG/tg-2.inp
+++ b/Exec/RegTests/TG/tg-2.inp
@@ -64,5 +64,4 @@ tagging.vorterr = 2e4
 tagging.max_vorterr_lev = 5
 
 # EB
-eb2.geom_type = "all_regular"
 ebd.boundary_grad_stencil_type = 0

--- a/Exec/RegTests/TG/tg-3.inp
+++ b/Exec/RegTests/TG/tg-3.inp
@@ -66,5 +66,4 @@ prob.mach = 0.1
 prob.prandtl = 0.71
 
 # EB
-eb2.geom_type = "all_regular"
 ebd.boundary_grad_stencil_type = 0

--- a/Exec/RegTests/TG/tg-4.inp
+++ b/Exec/RegTests/TG/tg-4.inp
@@ -67,5 +67,4 @@ prob.mach = 0.1
 prob.prandtl = 0.71
 
 # EB
-eb2.geom_type = "all_regular"
 ebd.boundary_grad_stencil_type = 0

--- a/Exec/RegTests/zeroD/example.inp
+++ b/Exec/RegTests/zeroD/example.inp
@@ -74,4 +74,3 @@ tagging.ftracerr = 150e-6
 amrex.signal_handling=0
 #amrex.throw_handling=0
 
-eb2.geom_type = all_regular

--- a/Exec/RegTests/zeroD/zerod-1.inp
+++ b/Exec/RegTests/zeroD/zerod-1.inp
@@ -73,5 +73,4 @@ tagging.ftracerr = 150e-6
 amrex.signal_handling=0
 #amrex.throw_handling=0
 
-eb2.geom_type = "all_regular"
 ebd.boundary_grad_stencil_type = 0

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -21,6 +21,16 @@ initialize_EB2(const amrex::Geometry& geom, int required_level, int max_level);
 
 amrex::LevelBld* getLevelBld();
 
+void
+override_default_parameters()
+{
+  amrex::ParmParse pp("eb2");
+  if (not pp.contains("geom_type")) {
+    std::string geom_type("all_regular");
+    pp.add("geom_type", geom_type);
+  }
+}
+
 int
 main(int argc, char* argv[])
 {
@@ -42,7 +52,8 @@ main(int argc, char* argv[])
   }
 
   // Make sure to catch new failures.
-  amrex::Initialize(argc, argv);
+  amrex::Initialize(
+    argc, argv, true, MPI_COMM_WORLD, override_default_parameters);
 // Defined and initialized when in gnumake, but not defined in cmake and
 // initialization done manually
 #ifndef AMREX_USE_SUNDIALS


### PR DESCRIPTION
This makes it so we don't need to add `all_regular` to all the input files when there is no EB.