### PR TITLE
Remove unused ifdef

### DIFF
--- a/Source/IO.cpp
+++ b/Source/IO.cpp
@@ -724,12 +724,9 @@ PeleC::writeBuildInfo(std::ostream& os)
      << "UNDEFINED" << std::endl;
 #endif
 
-#ifdef NUM_ADV
   os << std::setw(35) << std::left << "NUM_ADV=" << NUM_ADV << std::endl;
-#else
-  os << std::setw(35) << std::left << "NUM_ADV"
-     << "is undefined (0)" << std::endl;
-#endif
+
+  os << std::setw(35) << std::left << "NUM_AUX=" << NUM_AUX << std::endl;
 
 #ifdef PELEC_USE_MASA
   os << std::setw(35) << std::left << "PELEC_USE_MASA " << std::setw(6) << "ON"

--- a/Source/IndexDefines.H
+++ b/Source/IndexDefines.H
@@ -1,9 +1,6 @@
 #ifndef _INDEX_DEFINES_H_
 #define _INDEX_DEFINES_H_
 
-#include <AMReX_REAL.H>
-#include <AMReX_Arena.H>
-#include <AMReX_GpuMemory.H>
 #include "mechanism.H"
 
 #define URHO 0

--- a/Source/IndexDefines.H
+++ b/Source/IndexDefines.H
@@ -56,10 +56,8 @@
 #define NTHERM 7
 #define QTHERM 8
 
-#ifndef PELEC_USE_AUX
 #define NUM_ADV 0
 #define NUM_AUX 0
-#endif
 
 #define UFS (UFA + NUM_ADV)
 #define UFX (UFS + NUM_SPECIES)

--- a/Source/Setup.cpp
+++ b/Source/Setup.cpp
@@ -163,11 +163,7 @@ PeleC::variableSetUp()
   Eint = cnt++;
   Temp = cnt++;
 
-#ifdef NUM_ADV
   NumAdv = NUM_ADV;
-#else
-  NumAdv = 0;
-#endif
 
   if (NumAdv > 0) {
     FirstAdv = cnt;


### PR DESCRIPTION
I don't see `PELEC_USE_AUX` used anywhere... Also I updated the logging and removed some "useless" includes.