### PR TITLE
Remove rhoe_dot and heatRelease from PMF plots

### DIFF
--- a/Exec/RegTests/PMF/pmf-lidryer-arkode.inp
+++ b/Exec/RegTests/PMF/pmf-lidryer-arkode.inp
@@ -57,7 +57,7 @@ tagging.ftracerr = 150.e-6
 
 extern.new_Jacobian_each_cell = 0
 
-amr.derive_plot_vars = density xmom ymom zmom eden Temp pressure x_velocity y_velocity z_velocity
+amr.plot_vars = density xmom ymom zmom rho_E rho_e Temp rho_omega_H2 rho_omega_O2 rho_omega_H2O rho_omega_H rho_omega_O rho_omega_OH rho_omega_HO2 rho_omega_H2O2 rho_omega_N2 pressure Y(H2) Y(O2) Y(H2O) Y(H) Y(O) Y(OH) Y(HO2) Y(H2O2) Y(N2) x_velocity y_velocity z_velocity
 pelec.plot_rhoy = 0
 pelec.plot_massfrac = 1
 pelec.do_hydro = 1

--- a/Exec/RegTests/PMF/pmf-lidryer-cvode.inp
+++ b/Exec/RegTests/PMF/pmf-lidryer-cvode.inp
@@ -57,7 +57,7 @@ tagging.ftracerr = 150.e-6
 
 extern.new_Jacobian_each_cell = 0
 
-amr.derive_plot_vars = density xmom ymom zmom eden Temp pressure x_velocity y_velocity z_velocity
+amr.plot_vars = density xmom ymom zmom rho_E rho_e Temp rho_omega_H2 rho_omega_O2 rho_omega_H2O rho_omega_H rho_omega_O rho_omega_OH rho_omega_HO2 rho_omega_H2O2 rho_omega_N2 pressure Y(H2) Y(O2) Y(H2O) Y(H) Y(O) Y(OH) Y(HO2) Y(H2O2) Y(N2) x_velocity y_velocity z_velocity
 pelec.plot_rhoy = 0
 pelec.plot_massfrac = 1
 pelec.do_hydro = 1

--- a/Exec/RegTests/PMF/pmf-lidryer-rk64.inp
+++ b/Exec/RegTests/PMF/pmf-lidryer-rk64.inp
@@ -57,7 +57,7 @@ tagging.ftracerr = 150.e-6
 
 extern.new_Jacobian_each_cell = 0
 
-amr.derive_plot_vars = density xmom ymom zmom eden Temp pressure x_velocity y_velocity z_velocity
+amr.plot_vars = density xmom ymom zmom rho_E rho_e Temp rho_omega_H2 rho_omega_O2 rho_omega_H2O rho_omega_H rho_omega_O rho_omega_OH rho_omega_HO2 rho_omega_H2O2 rho_omega_N2 pressure Y(H2) Y(O2) Y(H2O) Y(H) Y(O) Y(OH) Y(HO2) Y(H2O2) Y(N2) x_velocity y_velocity z_velocity
 pelec.plot_rhoy = 0
 pelec.plot_massfrac = 1
 pelec.do_hydro = 1


### PR DESCRIPTION
To help solve tolerance issues in GPU tests.