### PR TITLE
Use gamma constant instead of EOS class member

### DIFF
--- a/Exec/RegTests/EB-C10/prob.H
+++ b/Exec/RegTests/EB-C10/prob.H
@@ -12,6 +12,7 @@
 #include "IndexDefines.H"
 #include "Constants.H"
 #include "PelePhysics.H"
+#include "PhysicsConstants.H"
 #include "Tagging.H"
 #include "ProblemDerive.H"
 #include "prob_parm.H"

--- a/Exec/RegTests/EB-C10/prob.cpp
+++ b/Exec/RegTests/EB-C10/prob.cpp
@@ -73,8 +73,9 @@ amrex_probinit(
   amrex::Print(ofs).SetPrecision(17)
     << L << "," << PeleC::h_prob_parm_device->rho << ","
     << PeleC::h_prob_parm_device->umax << "," << PeleC::h_prob_parm_device->p
-    << "," << PeleC::h_prob_parm_device->T << "," << eos.gamma << ","
-    << trans_parm.const_viscosity << "," << trans_parm.const_conductivity << ","
+    << "," << PeleC::h_prob_parm_device->T << ","
+    << pele::physics::Constants::gamma << "," << trans_parm.const_viscosity
+    << "," << trans_parm.const_conductivity << ","
     << PeleC::h_prob_parm_device->Re << "," << PeleC::h_prob_parm_device->Ma
     << "," << PeleC::h_prob_parm_device->Pr << ","
     << PeleC::h_prob_parm_device->dpdx << "," << PeleC::h_prob_parm_device->G

--- a/Exec/RegTests/EB-C7/prob.H
+++ b/Exec/RegTests/EB-C7/prob.H
@@ -11,6 +11,7 @@
 #include "PeleC.H"
 #include "IndexDefines.H"
 #include "Constants.H"
+#include "PhysicsConstants.H"
 #include "PelePhysics.H"
 #include "Tagging.H"
 #include "ProblemDerive.H"

--- a/Exec/RegTests/EB-C7/prob.cpp
+++ b/Exec/RegTests/EB-C7/prob.cpp
@@ -54,8 +54,8 @@ amrex_probinit(
     << "," << PeleC::h_prob_parm_device->pl << ","
     << PeleC::h_prob_parm_device->Tl << "," << PeleC::h_prob_parm_device->rhor
     << "," << PeleC::h_prob_parm_device->pr << ","
-    << PeleC::h_prob_parm_device->Tr << "," << eos.gamma << ","
-    << PeleC::h_prob_parm_device->angle << std::endl;
+    << PeleC::h_prob_parm_device->Tr << "," << pele::physics::Constants::gamma
+    << "," << PeleC::h_prob_parm_device->angle << std::endl;
   ofs.close();
 }
 }

--- a/Exec/RegTests/EB-C9/prob.H
+++ b/Exec/RegTests/EB-C9/prob.H
@@ -14,6 +14,7 @@
 #include "IndexDefines.H"
 #include "Constants.H"
 #include "PelePhysics.H"
+#include "PhysicsConstants.H"
 
 #include "Tagging.H"
 #include "ProblemDerive.H"

--- a/Exec/RegTests/EB-C9/prob.cpp
+++ b/Exec/RegTests/EB-C9/prob.cpp
@@ -43,9 +43,10 @@ amrex_probinit(
   amrex::Print(ofs).SetPrecision(17)
     << PeleC::h_prob_parm_device->L << "," << PeleC::h_prob_parm_device->rho
     << "," << PeleC::h_prob_parm_device->p << ","
-    << PeleC::h_prob_parm_device->T << "," << eos.gamma << ","
-    << PeleC::h_prob_parm_device->cs << "," << PeleC::h_prob_parm_device->radius
-    << "," << PeleC::h_prob_parm_device->alpha << ","
+    << PeleC::h_prob_parm_device->T << "," << pele::physics::Constants::gamma
+    << "," << PeleC::h_prob_parm_device->cs << ","
+    << PeleC::h_prob_parm_device->radius << ","
+    << PeleC::h_prob_parm_device->alpha << ","
     << PeleC::h_prob_parm_device->sigma << std::endl;
   ofs.close();
 }

--- a/Exec/RegTests/HIT/prob.H
+++ b/Exec/RegTests/HIT/prob.H
@@ -15,6 +15,7 @@
 #include "PelePhysics.H"
 #include "Tagging.H"
 #include "ProblemDerive.H"
+#include "PhysicsConstants.H"
 #include "prob_parm.H"
 #include "Utilities.H"
 

--- a/Exec/RegTests/HIT/prob.cpp
+++ b/Exec/RegTests/HIT/prob.cpp
@@ -83,9 +83,10 @@ amrex_probinit(
     << PeleC::h_prob_parm_device->k0 << "," << PeleC::h_prob_parm_device->rho0
     << "," << PeleC::h_prob_parm_device->urms0 << ","
     << PeleC::h_prob_parm_device->tau << "," << PeleC::h_prob_parm_device->p0
-    << "," << PeleC::h_prob_parm_device->T0 << "," << eos.gamma << ","
-    << trans_parm.const_viscosity << "," << trans_parm.const_conductivity << ","
-    << cs << "," << PeleC::h_prob_parm_device->reynolds_lambda0 << ","
+    << "," << PeleC::h_prob_parm_device->T0 << ","
+    << pele::physics::Constants::gamma << "," << trans_parm.const_viscosity
+    << "," << trans_parm.const_conductivity << "," << cs << ","
+    << PeleC::h_prob_parm_device->reynolds_lambda0 << ","
     << PeleC::h_prob_parm_device->mach_t0 << ","
     << PeleC::h_prob_parm_device->prandtl << ","
     << PeleC::h_prob_parm_device->forcing_u0 << ","

--- a/Exec/RegTests/Sedov/prob.H
+++ b/Exec/RegTests/Sedov/prob.H
@@ -14,6 +14,7 @@
 #include "IndexDefines.H"
 #include "Constants.H"
 #include "PelePhysics.H"
+#include "PhysicsConstants.H"
 #include "Tagging.H"
 
 #include "ProblemDerive.H"
@@ -35,7 +36,8 @@ pc_initdata(
   auto eos = pele::physics::PhysicsType::eos();
   amrex::Real vctr =
     4.0 / 3.0 * M_PI * (prob_parm.r_init * prob_parm.r_init * prob_parm.r_init);
-  amrex::Real p_exp = (eos.gamma - 1.0) * prob_parm.exp_energy / vctr;
+  amrex::Real p_exp =
+    (pele::physics::Constants::gamma - 1.0) * prob_parm.exp_energy / vctr;
 
   // Geometry
   const amrex::Real* prob_lo = geomdata.ProbLo();
@@ -88,7 +90,7 @@ pc_initdata(
      static_cast<amrex::Real>(n_amb) * prob_parm.p_ambient) /
     static_cast<amrex::Real>(prob_parm.nsub * prob_parm.nsub * prob_parm.nsub);
 
-  amrex::Real eint = p_zone / (eos.gamma - 1.0);
+  amrex::Real eint = p_zone / (pele::physics::Constants::gamma - 1.0);
 
   state(i, j, k, URHO) = prob_parm.dens_ambient;
   state(i, j, k, UMX) = 0.0;

--- a/Exec/RegTests/TG/prob.cpp
+++ b/Exec/RegTests/TG/prob.cpp
@@ -66,9 +66,9 @@ amrex_probinit(
     << PeleC::h_prob_parm_device->L << "," << PeleC::h_prob_parm_device->rho0
     << "," << PeleC::h_prob_parm_device->v0 << ","
     << PeleC::h_prob_parm_device->p0 << "," << PeleC::h_prob_parm_device->T0
-    << "," << eos.gamma << "," << trans_parm.const_viscosity << ","
-    << trans_parm.const_conductivity << "," << cs << ","
-    << PeleC::h_prob_parm_device->reynolds << ","
+    << "," << pele::physics::Constants::gamma << ","
+    << trans_parm.const_viscosity << "," << trans_parm.const_conductivity << ","
+    << cs << "," << PeleC::h_prob_parm_device->reynolds << ","
     << PeleC::h_prob_parm_device->mach << ","
     << PeleC::h_prob_parm_device->prandtl << ","
     << PeleC::h_prob_parm_device->omega_x << ","


### PR DESCRIPTION
This should hopefully finish my cleaning of PelePhysics. We can make this a runtime parameter later if it's necessary. I expect all the PelePhysics checks to be clean in this PR.