### PR TITLE
Fix workestimate restart and IO

### DIFF
--- a/Source/IO.cpp
+++ b/Source/IO.cpp
@@ -375,7 +375,14 @@ PeleC::setPlotVariables()
   bool plot_cost = do_react_load_balance || do_mol_load_balance;
   pp.query("plot_cost", plot_cost);
   if (plot_cost) {
-    amrex::Amr::addDerivePlotVar("WorkEstimate");
+    for (int i = 0; i < desc_lst[Work_Estimate_Type].nComp(); i++) {
+      amrex::Amr::addStatePlotVar(desc_lst[Work_Estimate_Type].name(i));
+    }
+  }
+  else{
+    for (int i = 0; i < desc_lst[Work_Estimate_Type].nComp(); i++) {
+      amrex::Amr::deleteStatePlotVar(desc_lst[Work_Estimate_Type].name(i));
+    }
   }
 
   if (!do_react) {

--- a/Source/IO.cpp
+++ b/Source/IO.cpp
@@ -372,7 +372,7 @@ PeleC::setPlotVariables()
   } else if (amrex::Amr::isDerivePlotVar("vfrac")) {
     amrex::Amr::deleteDerivePlotVar("vfrac");
   }
-  bool plot_cost = true;
+  bool plot_cost = do_react_load_balance || do_mol_load_balance;
   pp.query("plot_cost", plot_cost);
   if (plot_cost) {
     amrex::Amr::addDerivePlotVar("WorkEstimate");

--- a/Source/IO.cpp
+++ b/Source/IO.cpp
@@ -378,8 +378,7 @@ PeleC::setPlotVariables()
     for (int i = 0; i < desc_lst[Work_Estimate_Type].nComp(); i++) {
       amrex::Amr::addStatePlotVar(desc_lst[Work_Estimate_Type].name(i));
     }
-  }
-  else{
+  } else {
     for (int i = 0; i < desc_lst[Work_Estimate_Type].nComp(); i++) {
       amrex::Amr::deleteStatePlotVar(desc_lst[Work_Estimate_Type].name(i));
     }

--- a/Source/PeleC.H
+++ b/Source/PeleC.H
@@ -182,8 +182,6 @@ public:
   // other levels for the Amr class to do timed load balances.
   int WorkEstType() override { return Work_Estimate_Type; }
 
-  static bool DoMOLLoadBalance() { return do_mol_load_balance; }
-
   const amrex::MultiFab& volFrac() const { return vfrac; }
 
   void init_eb();

--- a/Source/Setup.cpp
+++ b/Source/Setup.cpp
@@ -381,17 +381,16 @@ PeleC::variableSetUp()
 
   desc_lst.setComponent(Reactions_Type, 0, react_name, react_bcs, bndryfunc2);
 
-  if (do_react_load_balance || do_mol_load_balance) {
-    desc_lst.addDescriptor(
+  store_in_checkpoint = false;
+  desc_lst.addDescriptor(
       Work_Estimate_Type, amrex::IndexType::TheCellType(),
-      amrex::StateDescriptor::Point, 0, 1, &amrex::pc_interp);
+      amrex::StateDescriptor::Point, 0, 1, &amrex::pc_interp, state_data_extrap, store_in_checkpoint);
     // Because we use piecewise constant interpolation, we do not use bc and
     // BndryFunc.
-    desc_lst.setComponent(
+  desc_lst.setComponent(
       Work_Estimate_Type, 0, "WorkEstimate", bc,
       amrex::StateDescriptor::BndryFunc(pc_nullfill));
-  }
-
+  
   num_state_type = desc_lst.size();
 
   // DEFINE DERIVED QUANTITIES

--- a/Source/Setup.cpp
+++ b/Source/Setup.cpp
@@ -381,11 +381,12 @@ PeleC::variableSetUp()
 
   desc_lst.setComponent(Reactions_Type, 0, react_name, react_bcs, bndryfunc2);
 
-  store_in_checkpoint = false;
+  const bool workest_store_in_checkpoint = false;
+  const bool workest_data_extrap = false;
   desc_lst.addDescriptor(
     Work_Estimate_Type, amrex::IndexType::TheCellType(),
-    amrex::StateDescriptor::Point, 0, 1, &amrex::pc_interp, state_data_extrap,
-    store_in_checkpoint);
+    amrex::StateDescriptor::Point, 0, 1, &amrex::pc_interp, workest_data_extrap,
+    workest_store_in_checkpoint);
   // Because we use piecewise constant interpolation, we do not use bc and
   // BndryFunc.
   desc_lst.setComponent(

--- a/Source/Setup.cpp
+++ b/Source/Setup.cpp
@@ -383,14 +383,15 @@ PeleC::variableSetUp()
 
   store_in_checkpoint = false;
   desc_lst.addDescriptor(
-      Work_Estimate_Type, amrex::IndexType::TheCellType(),
-      amrex::StateDescriptor::Point, 0, 1, &amrex::pc_interp, state_data_extrap, store_in_checkpoint);
-    // Because we use piecewise constant interpolation, we do not use bc and
-    // BndryFunc.
+    Work_Estimate_Type, amrex::IndexType::TheCellType(),
+    amrex::StateDescriptor::Point, 0, 1, &amrex::pc_interp, state_data_extrap,
+    store_in_checkpoint);
+  // Because we use piecewise constant interpolation, we do not use bc and
+  // BndryFunc.
   desc_lst.setComponent(
-      Work_Estimate_Type, 0, "WorkEstimate", bc,
-      amrex::StateDescriptor::BndryFunc(pc_nullfill));
-  
+    Work_Estimate_Type, 0, "WorkEstimate", bc,
+    amrex::StateDescriptor::BndryFunc(pc_nullfill));
+
   num_state_type = desc_lst.size();
 
   // DEFINE DERIVED QUANTITIES


### PR DESCRIPTION
This PR ensures for
```
restarting loadbalance_with_workestimates = 0 from loadbalance_with_workestimates = 1  -> this one didn't work in current code
restarting loadbalance_with_workestimates = 0 from loadbalance_with_workestimates = 0 
restarting loadbalance_with_workestimates = 1 from loadbalance_with_workestimates = 1 
restarting loadbalance_with_workestimates = 1 from loadbalance_with_workestimates = 0 
```