### PR TITLE
Remove duplicate typical values output

### DIFF
--- a/Source/React.cpp
+++ b/Source/React.cpp
@@ -7,7 +7,6 @@
 void
 PeleC::set_typical_values_chem()
 {
-
   if (use_typical_vals_chem_usr) {
     reactor->set_typ_vals_ode(typical_values_chem_usr);
   } else {
@@ -24,13 +23,6 @@ PeleC::set_typical_values_chem()
     }
     typical_values_chem[NUM_SPECIES] = 0.5 * (minTemp + maxTemp);
     reactor->set_typ_vals_ode(typical_values_chem);
-
-    amrex::Print() << "\nSetting typical values for level \n" << level << "\n";
-    amrex::Print() << "pelec.typical_values_chem =";
-    for (int i = 0; i < (NUM_SPECIES + 1); i++) {
-      amrex::Print() << typical_values_chem[i] << "   ";
-    }
-    amrex::Print() << "\n-------------\n";
   }
 }
 


### PR DESCRIPTION
The output of the typical values is done in PelePhysics, no need to do it in PeleC as well. 

Update with pelephysics once https://github.com/AMReX-Combustion/PelePhysics/pull/269 is merged.