### PR TITLE
Rename header guards

### DIFF
--- a/Exec/Production/ChallengeProblem/prob.H
+++ b/Exec/Production/ChallengeProblem/prob.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_H_
-#define _PROB_H_
+#ifndef PROB_H
+#define PROB_H
 
 #include <AMReX_EB2.H>
 #include <AMReX_EB2_GeometryShop.H>

--- a/Exec/Production/ChallengeProblem/prob_parm.H
+++ b/Exec/Production/ChallengeProblem/prob_parm.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_PARM_H_
-#define _PROB_PARM_H_
+#ifndef PROB_PARM_H
+#define PROB_PARM_H
 
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_REAL.H>

--- a/Exec/Production/JetFlame/prob.H
+++ b/Exec/Production/JetFlame/prob.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_H_
-#define _PROB_H_
+#ifndef PROB_H
+#define PROB_H
 
 #include <AMReX_Print.H>
 #include <AMReX_ParmParse.H>

--- a/Exec/Production/JetFlame/prob_parm.H
+++ b/Exec/Production/JetFlame/prob_parm.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_PARM_H_
-#define _PROB_PARM_H_
+#ifndef PROB_PARM_H
+#define PROB_PARM_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuMemory.H>

--- a/Exec/Production/PistonBowl/prob.H
+++ b/Exec/Production/PistonBowl/prob.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_H_
-#define _PROB_H_
+#ifndef PROB_H
+#define PROB_H
 
 #include <AMReX_EB2.H>
 #include <AMReX_EB2_GeometryShop.H>

--- a/Exec/Production/PistonBowl/prob_parm.H
+++ b/Exec/Production/PistonBowl/prob_parm.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_PARM_H_
-#define _PROB_PARM_H_
+#ifndef PROB_PARM_H
+#define PROB_PARM_H
 
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_REAL.H>

--- a/Exec/RegTests/EB-BluffBody/prob.H
+++ b/Exec/RegTests/EB-BluffBody/prob.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_H_
-#define _PROB_H_
+#ifndef PROB_H
+#define PROB_H
 
 #include <AMReX_Geometry.H>
 #include <AMReX_FArrayBox.H>

--- a/Exec/RegTests/EB-BluffBody/prob_parm.H
+++ b/Exec/RegTests/EB-BluffBody/prob_parm.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_PARM_H_
-#define _PROB_PARM_H_
+#ifndef PROB_PARM_H
+#define PROB_PARM_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>

--- a/Exec/RegTests/EB-C1/prob.H
+++ b/Exec/RegTests/EB-C1/prob.H
@@ -1,5 +1,5 @@
-#ifndef PROB_H_
-#define PROB_H_
+#ifndef PROB_H
+#define PROB_H
 
 #include <AMReX_Print.H>
 #include <AMReX_Geometry.H>

--- a/Exec/RegTests/EB-C1/prob_parm.H
+++ b/Exec/RegTests/EB-C1/prob_parm.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_PARM_H_
-#define _PROB_PARM_H_
+#ifndef PROB_PARM_H
+#define PROB_PARM_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>

--- a/Exec/RegTests/EB-C10/prob.H
+++ b/Exec/RegTests/EB-C10/prob.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_H_
-#define _PROB_H_
+#ifndef PROB_H
+#define PROB_H
 
 #include <AMReX_Geometry.H>
 #include <AMReX_FArrayBox.H>

--- a/Exec/RegTests/EB-C10/prob_parm.H
+++ b/Exec/RegTests/EB-C10/prob_parm.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_PARM_H_
-#define _PROB_PARM_H_
+#ifndef PROB_PARM_H
+#define PROB_PARM_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>

--- a/Exec/RegTests/EB-C11/prob.H
+++ b/Exec/RegTests/EB-C11/prob.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_H_
-#define _PROB_H_
+#ifndef PROB_H
+#define PROB_H
 
 #include <AMReX_Print.H>
 #include <AMReX_ParmParse.H>

--- a/Exec/RegTests/EB-C11/prob_parm.H
+++ b/Exec/RegTests/EB-C11/prob_parm.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_PARM_H_
-#define _PROB_PARM_H_
+#ifndef PROB_PARM_H
+#define PROB_PARM_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>

--- a/Exec/RegTests/EB-C12/prob.H
+++ b/Exec/RegTests/EB-C12/prob.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_H_
-#define _PROB_H_
+#ifndef PROB_H
+#define PROB_H
 
 #include <AMReX_Geometry.H>
 #include <AMReX_FArrayBox.H>

--- a/Exec/RegTests/EB-C12/prob_parm.H
+++ b/Exec/RegTests/EB-C12/prob_parm.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_PARM_H_
-#define _PROB_PARM_H_
+#ifndef PROB_PARM_H
+#define PROB_PARM_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>

--- a/Exec/RegTests/EB-C13/prob.H
+++ b/Exec/RegTests/EB-C13/prob.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_H_
-#define _PROB_H_
+#ifndef PROB_H
+#define PROB_H
 
 #include <AMReX_Geometry.H>
 #include <AMReX_FArrayBox.H>

--- a/Exec/RegTests/EB-C13/prob_parm.H
+++ b/Exec/RegTests/EB-C13/prob_parm.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_PARM_H_
-#define _PROB_PARM_H_
+#ifndef PROB_PARM_H
+#define PROB_PARM_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>

--- a/Exec/RegTests/EB-C14/prob.H
+++ b/Exec/RegTests/EB-C14/prob.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_H_
-#define _PROB_H_
+#ifndef PROB_H
+#define PROB_H
 
 #include <AMReX_Geometry.H>
 #include <AMReX_FArrayBox.H>

--- a/Exec/RegTests/EB-C14/prob_parm.H
+++ b/Exec/RegTests/EB-C14/prob_parm.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_PARM_H_
-#define _PROB_PARM_H_
+#ifndef PROB_PARM_H
+#define PROB_PARM_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>

--- a/Exec/RegTests/EB-C3/prob.H
+++ b/Exec/RegTests/EB-C3/prob.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_H_
-#define _PROB_H_
+#ifndef PROB_H
+#define PROB_H
 
 #include <AMReX_Print.H>
 #include <AMReX_ParmParse.H>

--- a/Exec/RegTests/EB-C3/prob_parm.H
+++ b/Exec/RegTests/EB-C3/prob_parm.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_PARM_H_
-#define _PROB_PARM_H_
+#ifndef PROB_PARM_H
+#define PROB_PARM_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>

--- a/Exec/RegTests/EB-C4-5/prob.H
+++ b/Exec/RegTests/EB-C4-5/prob.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_H_
-#define _PROB_H_
+#ifndef PROB_H
+#define PROB_H
 
 #include <AMReX_Print.H>
 #include <AMReX_ParmParse.H>

--- a/Exec/RegTests/EB-C4-5/prob_parm.H
+++ b/Exec/RegTests/EB-C4-5/prob_parm.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_PARM_H_
-#define _PROB_PARM_H_
+#ifndef PROB_PARM_H
+#define PROB_PARM_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>

--- a/Exec/RegTests/EB-C7/prob.H
+++ b/Exec/RegTests/EB-C7/prob.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_H_
-#define _PROB_H_
+#ifndef PROB_H
+#define PROB_H
 
 #include <AMReX_Geometry.H>
 #include <AMReX_FArrayBox.H>

--- a/Exec/RegTests/EB-C7/prob_parm.H
+++ b/Exec/RegTests/EB-C7/prob_parm.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_PARM_H_
-#define _PROB_PARM_H_
+#ifndef PROB_PARM_H
+#define PROB_PARM_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>

--- a/Exec/RegTests/EB-C8/prob.H
+++ b/Exec/RegTests/EB-C8/prob.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_H_
-#define _PROB_H_
+#ifndef PROB_H
+#define PROB_H
 
 #include <AMReX_Print.H>
 #include <AMReX_ParmParse.H>

--- a/Exec/RegTests/EB-C8/prob_parm.H
+++ b/Exec/RegTests/EB-C8/prob_parm.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_PARM_H_
-#define _PROB_PARM_H_
+#ifndef PROB_PARM_H
+#define PROB_PARM_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>

--- a/Exec/RegTests/EB-C9/prob.H
+++ b/Exec/RegTests/EB-C9/prob.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_H_
-#define _PROB_H_
+#ifndef PROB_H
+#define PROB_H
 
 #include <AMReX_Print.H>
 #include <AMReX_ParmParse.H>

--- a/Exec/RegTests/EB-C9/prob_parm.H
+++ b/Exec/RegTests/EB-C9/prob_parm.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_PARM_H_
-#define _PROB_PARM_H_
+#ifndef PROB_PARM_H
+#define PROB_PARM_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>

--- a/Exec/RegTests/EB-ConvergingNozzle/prob.H
+++ b/Exec/RegTests/EB-ConvergingNozzle/prob.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_H_
-#define _PROB_H_
+#ifndef PROB_H
+#define PROB_H
 
 #include <AMReX_Print.H>
 #include <AMReX_ParmParse.H>

--- a/Exec/RegTests/EB-ConvergingNozzle/prob_parm.H
+++ b/Exec/RegTests/EB-ConvergingNozzle/prob_parm.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_PARM_H_
-#define _PROB_PARM_H_
+#ifndef PROB_PARM_H
+#define PROB_PARM_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>

--- a/Exec/RegTests/EB-EnclosedVortex/prob.H
+++ b/Exec/RegTests/EB-EnclosedVortex/prob.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_H_
-#define _PROB_H_
+#ifndef PROB_H
+#define PROB_H
 
 #include <AMReX_Print.H>
 #include <AMReX_ParmParse.H>

--- a/Exec/RegTests/EB-EnclosedVortex/prob_parm.H
+++ b/Exec/RegTests/EB-EnclosedVortex/prob_parm.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_PARM_H_
-#define _PROB_PARM_H_
+#ifndef PROB_PARM_H
+#define PROB_PARM_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>

--- a/Exec/RegTests/EB-Plane/prob.H
+++ b/Exec/RegTests/EB-Plane/prob.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_H_
-#define _PROB_H_
+#ifndef PROB_H
+#define PROB_H
 
 #include <AMReX_Geometry.H>
 #include <AMReX_FArrayBox.H>

--- a/Exec/RegTests/EB-Plane/prob_parm.H
+++ b/Exec/RegTests/EB-Plane/prob_parm.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_PARM_H_
-#define _PROB_PARM_H_
+#ifndef PROB_PARM_H
+#define PROB_PARM_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>

--- a/Exec/RegTests/HIT/prob.H
+++ b/Exec/RegTests/HIT/prob.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_H_
-#define _PROB_H_
+#ifndef PROB_H
+#define PROB_H
 
 #include <AMReX_Print.H>
 #include <AMReX_Geometry.H>

--- a/Exec/RegTests/HIT/prob_parm.H
+++ b/Exec/RegTests/HIT/prob_parm.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_PARM_H_
-#define _PROB_PARM_H_
+#ifndef PROB_PARM_H
+#define PROB_PARM_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>

--- a/Exec/RegTests/MMS/prob.H
+++ b/Exec/RegTests/MMS/prob.H
@@ -1,5 +1,5 @@
-#ifndef PROB_H_
-#define PROB_H_
+#ifndef PROB_H
+#define PROB_H
 
 #include <AMReX_Print.H>
 #include <AMReX_ParmParse.H>

--- a/Exec/RegTests/MMS/prob_parm.H
+++ b/Exec/RegTests/MMS/prob_parm.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_PARM_H_
-#define _PROB_PARM_H_
+#ifndef PROB_PARM_H
+#define PROB_PARM_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>

--- a/Exec/RegTests/MultiSpecSod/prob.H
+++ b/Exec/RegTests/MultiSpecSod/prob.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_H_
-#define _PROB_H_
+#ifndef PROB_H
+#define PROB_H
 
 #include <AMReX_Print.H>
 #include <AMReX_ParmParse.H>

--- a/Exec/RegTests/MultiSpecSod/prob_parm.H
+++ b/Exec/RegTests/MultiSpecSod/prob_parm.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_PARM_H_
-#define _PROB_PARM_H_
+#ifndef PROB_PARM_H
+#define PROB_PARM_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>

--- a/Exec/RegTests/PMF-SRK/prob.H
+++ b/Exec/RegTests/PMF-SRK/prob.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_H_
-#define _PROB_H_
+#ifndef PROB_H
+#define PROB_H
 
 #include <AMReX_ParmParse.H>
 #include <AMReX_Geometry.H>

--- a/Exec/RegTests/PMF-SRK/prob_parm.H
+++ b/Exec/RegTests/PMF-SRK/prob_parm.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_PARM_H_
-#define _PROB_PARM_H_
+#ifndef PROB_PARM_H
+#define PROB_PARM_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>

--- a/Exec/RegTests/PMF/prob.H
+++ b/Exec/RegTests/PMF/prob.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_H_
-#define _PROB_H_
+#ifndef PROB_H
+#define PROB_H
 
 #include <AMReX_ParmParse.H>
 #include <AMReX_Geometry.H>

--- a/Exec/RegTests/PMF/prob_parm.H
+++ b/Exec/RegTests/PMF/prob_parm.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_PARM_H_
-#define _PROB_PARM_H_
+#ifndef PROB_PARM_H
+#define PROB_PARM_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>

--- a/Exec/RegTests/Sedov/prob.H
+++ b/Exec/RegTests/Sedov/prob.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_H_
-#define _PROB_H_
+#ifndef PROB_H
+#define PROB_H
 
 #include <AMReX_Print.H>
 #include <AMReX_ParmParse.H>

--- a/Exec/RegTests/Sedov/prob_parm.H
+++ b/Exec/RegTests/Sedov/prob_parm.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_PARM_H_
-#define _PROB_PARM_H_
+#ifndef PROB_PARM_H
+#define PROB_PARM_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>

--- a/Exec/RegTests/Shu-Osher/prob.H
+++ b/Exec/RegTests/Shu-Osher/prob.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_H_
-#define _PROB_H_
+#ifndef PROB_H
+#define PROB_H
 
 #include <AMReX_Print.H>
 #include <AMReX_ParmParse.H>

--- a/Exec/RegTests/Shu-Osher/prob_parm.H
+++ b/Exec/RegTests/Shu-Osher/prob_parm.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_PARM_H_
-#define _PROB_PARM_H_
+#ifndef PROB_PARM_H
+#define PROB_PARM_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>

--- a/Exec/RegTests/Sod/prob.H
+++ b/Exec/RegTests/Sod/prob.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_H_
-#define _PROB_H_
+#ifndef PROB_H
+#define PROB_H
 
 #include <AMReX_Print.H>
 #include <AMReX_ParmParse.H>

--- a/Exec/RegTests/Sod/prob_parm.H
+++ b/Exec/RegTests/Sod/prob_parm.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_PARM_H_
-#define _PROB_PARM_H_
+#ifndef PROB_PARM_H
+#define PROB_PARM_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>

--- a/Exec/RegTests/TG/prob.H
+++ b/Exec/RegTests/TG/prob.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_H_
-#define _PROB_H_
+#ifndef PROB_H
+#define PROB_H
 
 #include <AMReX_Print.H>
 #include <AMReX_ParmParse.H>

--- a/Exec/RegTests/TG/prob_parm.H
+++ b/Exec/RegTests/TG/prob_parm.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_PARM_H_
-#define _PROB_PARM_H_
+#ifndef PROB_PARM_H
+#define PROB_PARM_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuMemory.H>

--- a/Exec/RegTests/zeroD/prob.H
+++ b/Exec/RegTests/zeroD/prob.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_H_
-#define _PROB_H_
+#ifndef PROB_H
+#define PROB_H
 
 #include <AMReX_Print.H>
 #include <AMReX_ParmParse.H>

--- a/Exec/RegTests/zeroD/prob_parm.H
+++ b/Exec/RegTests/zeroD/prob_parm.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_PARM_H_
-#define _PROB_PARM_H_
+#ifndef PROB_PARM_H
+#define PROB_PARM_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuMemory.H>

--- a/Exec/UnitTests/prob.H
+++ b/Exec/UnitTests/prob.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_H_
-#define _PROB_H_
+#ifndef PROB_H
+#define PROB_H
 
 #include "ProblemDerive.H"
 

--- a/Exec/UnitTests/prob_parm.H
+++ b/Exec/UnitTests/prob_parm.H
@@ -1,5 +1,5 @@
-#ifndef _PROB_PARM_H_
-#define _PROB_PARM_H_
+#ifndef PROB_PARM_H
+#define PROB_PARM_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>

--- a/Source/Constants.H
+++ b/Source/Constants.H
@@ -1,5 +1,5 @@
-#ifndef _CONSTANTS_H_
-#define _CONSTANTS_H_
+#ifndef CONSTANTS_H
+#define CONSTANTS_H
 
 namespace constants {
 AMREX_GPU_HOST_DEVICE constexpr amrex::Real

--- a/Source/Derive.H
+++ b/Source/Derive.H
@@ -1,5 +1,5 @@
-#ifndef _Derive_H_
-#define _Derive_H_
+#ifndef Derive_H
+#define Derive_H
 
 #include <AMReX_FArrayBox.H>
 #include <AMReX_Geometry.H>

--- a/Source/Diffterm.H
+++ b/Source/Diffterm.H
@@ -1,5 +1,5 @@
-#ifndef _DIFFTERM_H_
-#define _DIFFTERM_H_
+#ifndef DIFFTERM_H
+#define DIFFTERM_H
 
 #include <AMReX_FArrayBox.H>
 #include <AMReX_EBCellFlag.H>

--- a/Source/Diffusion.H
+++ b/Source/Diffusion.H
@@ -1,5 +1,5 @@
-#ifndef _DIFFUSION_H_
-#define _DIFFUSION_H_
+#ifndef DIFFUSION_H
+#define DIFFUSION_H
 
 #ifdef _OPENMP
 #include <omp.h>

--- a/Source/EB.H
+++ b/Source/EB.H
@@ -1,5 +1,5 @@
-#ifndef _EB_H_
-#define _EB_H_
+#ifndef EB_H
+#define EB_H
 
 #include <AMReX_ParmParse.H>
 #include <AMReX_Geometry.H>

--- a/Source/EBStencilTypes.H
+++ b/Source/EBStencilTypes.H
@@ -1,5 +1,5 @@
-#ifndef _EBStencilTypes_H_
-#define _EBStencilTypes_H_
+#ifndef EBStencilTypes_H
+#define EBStencilTypes_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_IntVect.H>

--- a/Source/Filter.H
+++ b/Source/Filter.H
@@ -1,5 +1,5 @@
-#ifndef _FILTER_H_
-#define _FILTER_H_
+#ifndef FILTER_H
+#define FILTER_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_Array.H>
@@ -168,4 +168,4 @@ private:
   void set_gaussian_5pt_optimized_approx_weights();
 };
 
-#endif /*_FILTER_H_*/
+#endif /*_FILTER_H*/

--- a/Source/Geometry.H
+++ b/Source/Geometry.H
@@ -1,5 +1,5 @@
-#ifndef _GEOMETRY_H_
-#define _GEOMETRY_H_
+#ifndef GEOMETRY_H
+#define GEOMETRY_H
 #include "Factory.H"
 #include "EB.H"
 #include "Utilities.H"

--- a/Source/Godunov.H
+++ b/Source/Godunov.H
@@ -1,5 +1,5 @@
-#ifndef _GODUNOV_H_
-#define _GODUNOV_H_
+#ifndef GODUNOV_H
+#define GODUNOV_H
 
 #include <AMReX_FArrayBox.H>
 #include <AMReX_IArrayBox.H>

--- a/Source/GradUtil.H
+++ b/Source/GradUtil.H
@@ -1,5 +1,5 @@
-#ifndef _GRADUTIL_H_
-#define _GRADUTIL_H_
+#ifndef GRADUTIL_H
+#define GRADUTIL_H
 
 #include <AMReX_FArrayBox.H>
 #include "IndexDefines.H"

--- a/Source/Hydro.H
+++ b/Source/Hydro.H
@@ -1,5 +1,5 @@
-#ifndef _HYDRO_H_
-#define _HYDRO_H_
+#ifndef HYDRO_H
+#define HYDRO_H
 
 #include "PeleC.H"
 #include "IndexDefines.H"

--- a/Source/IO.H
+++ b/Source/IO.H
@@ -1,4 +1,4 @@
-#ifndef _IO_H_
-#define _IO_H_
+#ifndef IO_H
+#define IO_H
 extern std::string inputs_name;
 #endif

--- a/Source/IndexDefines.H
+++ b/Source/IndexDefines.H
@@ -1,5 +1,5 @@
-#ifndef _INDEX_DEFINES_H_
-#define _INDEX_DEFINES_H_
+#ifndef INDEX_DEFINES_H
+#define INDEX_DEFINES_H
 
 #include "mechanism.H"
 

--- a/Source/LES.H
+++ b/Source/LES.H
@@ -1,5 +1,5 @@
-#ifndef _LES_H_
-#define _LES_H_
+#ifndef LES_H
+#define LES_H
 
 #include "PeleC.H"
 #include "Utilities.H"

--- a/Source/MOL.H
+++ b/Source/MOL.H
@@ -1,5 +1,5 @@
-#ifndef _MOL_H_
-#define _MOL_H_
+#ifndef MOL_H
+#define MOL_H
 
 #include <AMReX_EBCellFlag.H>
 

--- a/Source/PLM.H
+++ b/Source/PLM.H
@@ -1,5 +1,5 @@
-#ifndef _PLM_H_
-#define _PLM_H_
+#ifndef PLM_H
+#define PLM_H
 
 #include <cmath>
 

--- a/Source/PPM.H
+++ b/Source/PPM.H
@@ -1,5 +1,5 @@
-#ifndef _PPM_H_
-#define _PPM_H_
+#ifndef PPM_H
+#define PPM_H
 
 #include <AMReX_FArrayBox.H>
 #include <AMReX_IArrayBox.H>

--- a/Source/PeleC.H
+++ b/Source/PeleC.H
@@ -1,5 +1,5 @@
-#ifndef _PELEC_H_
-#define _PELEC_H_
+#ifndef PELEC_H
+#define PELEC_H
 
 #include <AMReX_BC_TYPES.H>
 #include <AMReX_AmrLevel.H>

--- a/Source/Problem.H
+++ b/Source/Problem.H
@@ -1,5 +1,5 @@
-//#ifndef _PROBLEM_H_
-//#define _PROBLEM_H_
+//#ifndef PROBLEM_H
+//#define PROBLEM_H
 
 // problem-specific PeleC:: declarations go here
 

--- a/Source/ProblemDerive.H
+++ b/Source/ProblemDerive.H
@@ -1,6 +1,6 @@
 // Problem-specific derives
-#ifndef _PROBLEMDERIVE_H_
-#define _PROBLEMDERIVE_H_
+#ifndef PROBLEMDERIVE_H
+#define PROBLEMDERIVE_H
 
 #include <AMReX_Derive.H>
 #include <AMReX_FArrayBox.H>

--- a/Source/Riemann.H
+++ b/Source/Riemann.H
@@ -1,5 +1,5 @@
-#ifndef _RIEMANN_H_
-#define _RIEMANN_H_
+#ifndef RIEMANN_H
+#define RIEMANN_H
 #include "PeleC.H"
 #include "PelePhysics.H"
 

--- a/Source/SparseData.H
+++ b/Source/SparseData.H
@@ -1,5 +1,5 @@
-#ifndef _SparseData_H_
-#define _SparseData_H_
+#ifndef SparseData_H
+#define SparseData_H
 
 #include <AMReX_Vector.H>
 

--- a/Source/Tagging.H
+++ b/Source/Tagging.H
@@ -1,5 +1,5 @@
-#ifndef _TAGGING_H_
-#define _TAGGING_H_
+#ifndef TAGGING_H
+#define TAGGING_H
 
 #include <AMReX_FArrayBox.H>
 #include <AMReX_TagBox.H>

--- a/Source/Timestep.H
+++ b/Source/Timestep.H
@@ -1,5 +1,5 @@
-#ifndef _TIMESTEP_H_
-#define _TIMESTEP_H_
+#ifndef TIMESTEP_H
+#define TIMESTEP_H
 
 #include <AMReX_FArrayBox.H>
 #include <AMReX_EBFArrayBox.H>

--- a/Source/Utilities.H
+++ b/Source/Utilities.H
@@ -1,5 +1,5 @@
-#ifndef _UTILITIES_H_
-#define _UTILITIES_H_
+#ifndef UTILITIES_H
+#define UTILITIES_H
 
 #include <AMReX_IArrayBox.H>
 #include <AMReX_FArrayBox.H>

--- a/Source/WENO.H
+++ b/Source/WENO.H
@@ -1,5 +1,5 @@
-#ifndef _WENO_H_
-#define _WENO_H_
+#ifndef WENO_H
+#define WENO_H
 
 #include <AMReX_FArrayBox.H>
 #include <AMReX_IArrayBox.H>


### PR DESCRIPTION
To avoid [this](https://wiki.sei.cmu.edu/confluence/display/c/DCL37-C.+Do+not+declare+or+define+a+reserved+identifier)