### PR TITLE
Add scripts for building and running the challenge problem on OLCF machines

### DIFF
--- a/Exec/Production/ChallengeProblem/build-olcf.sh
+++ b/Exec/Production/ChallengeProblem/build-olcf.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -l
+
+cmd() {
+  echo "+ $@"
+  eval "$@"
+}
+
+if [ "${LMOD_SYSTEM_NAME}" == 'summit' ]; then
+  cmd "module unload xl"
+  cmd "module load gcc/9.3.0"
+  cmd "module load python/3.7.7"
+  cmd "module load cuda/11.4.2"
+  cmd "module load hdf5/1.10.7"
+  cmd "module load cmake"
+  BASE_DIR="${PROJWORK}/cfd116/jrood/spack-manager-summit/spack/opt/spack/linux-rhel8-ppc64le/gcc-9.3.0"
+  H5Z_HOME="${BASE_DIR}/h5z-zfp-develop-czinnk7mbsrkmf7o74mxzpzv7hqp34sl"
+  ZFP_HOME="${BASE_DIR}/zfp-0.5.5-dsefgrt3iinobwohmbuspnpar3yasm4l"
+elif [ "${LMOD_SYSTEM_NAME}" == 'crusher' ]; then
+  cmd "module unload PrgEnv-cray"
+  cmd "module load PrgEnv-amd"
+  cmd "module load rocm/5.1.0"
+  cmd "module load hdf5/1.12.1"
+  cmd "module load cmake"
+  BASE_DIR="${PROJWORK}/cfd116/jrood/spack-manager-crusher/spack/opt/spack/cray-sles15-zen3/clang-14.0.0"
+  H5Z_HOME="${BASE_DIR}/h5z-zfp-develop-y7qstijn2lvrhdvhswgxfnzcyh2nctfg"
+  ZFP_HOME="${BASE_DIR}/zfp-0.5.5-dxggbklt74oeev6xtnici2mjq4zh2oqx"
+  ARGS="USE_HIP=TRUE USE_HDF5=TRUE USE_HDF5_ZFP=TRUE HDF5_HOME=${OLCF_HDF5_ROOT} H5Z_HOME=${H5Z_HOME} ZFP_HOME=${ZFP_HOME}"
+fi
+
+ARGS="USE_HDF5=TRUE USE_HDF5_ZFP=TRUE HDF5_HOME=${OLCF_HDF5_ROOT} H5Z_HOME=${H5Z_HOME} ZFP_HOME=${ZFP_HOME}"
+
+cmd "make ${ARGS} TPLrealclean"
+cmd "make ${ARGS} realclean"
+cmd "make ${ARGS} TPL"
+cmd "make ${ARGS} -j16"

--- a/Exec/Production/ChallengeProblem/build-olcf.sh
+++ b/Exec/Production/ChallengeProblem/build-olcf.sh
@@ -24,7 +24,6 @@ elif [ "${LMOD_SYSTEM_NAME}" == 'crusher' ]; then
   BASE_DIR="${PROJWORK}/cfd116/jrood/spack-manager-crusher/spack/opt/spack/cray-sles15-zen3/clang-14.0.0"
   H5Z_HOME="${BASE_DIR}/h5z-zfp-develop-y7qstijn2lvrhdvhswgxfnzcyh2nctfg"
   ZFP_HOME="${BASE_DIR}/zfp-0.5.5-dxggbklt74oeev6xtnici2mjq4zh2oqx"
-  ARGS="USE_HIP=TRUE USE_HDF5=TRUE USE_HDF5_ZFP=TRUE HDF5_HOME=${OLCF_HDF5_ROOT} H5Z_HOME=${H5Z_HOME} ZFP_HOME=${ZFP_HOME}"
 fi
 
 ARGS="USE_HDF5=TRUE USE_HDF5_ZFP=TRUE HDF5_HOME=${OLCF_HDF5_ROOT} H5Z_HOME=${H5Z_HOME} ZFP_HOME=${ZFP_HOME}"

--- a/Exec/Production/ChallengeProblem/challenge.inp
+++ b/Exec/Production/ChallengeProblem/challenge.inp
@@ -73,6 +73,8 @@ amr.derive_plot_vars = density x_velocity y_velocity z_velocity magvel Y(CH4) Y(
 pelec.plot_rhoy = 0
 pelec.plot_massfrac = 1
 pelec.extrema_spec_name = ALL
+pelec.write_hdf5_plots=true
+pelec.hdf5_compression="ZFP_REVERSIBLE@reversible"
 
 # PROBLEM PARAMETERS
 prob.P_mean = 6.0795e7

--- a/Exec/Production/ChallengeProblem/run-crusher.sh
+++ b/Exec/Production/ChallengeProblem/run-crusher.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -l
+
+#SBATCH -J pelec-challenge-crusher
+#SBATCH -o %x.o%j
+#SBATCH -A CMB138_crusher
+#SBATCH -t 2:00:00
+#SBATCH -N 32
+
+set -e
+
+cmd() {
+  echo "+ $@"
+  eval "$@"
+}
+
+cmd "module load rocm/5.1.0"
+cmd "module load hdf5/1.12.1"
+cmd "module load cmake"
+cmd "export SPACK_MANAGER=${PROJWORK}/cfd116/jrood/spack-manager-${LMOD_SYSTEM_NAME}"
+cmd "source ${SPACK_MANAGER}/start.sh && spack-start"
+cmd "spack env activate -d ${SPACK_MANAGER}/environments/exawind-${LMOD_SYSTEM_NAME}"
+cmd "spack load exawind+amr_wind_gpu~nalu_wind_gpu"
+cmd "srun -N32 -n256 -c1 --gpus-per-node=8 --gpu-bind=closest ./PeleC3d.hip.x86-trento.TPROF.MPI.HIP.ex challenge.inp"

--- a/Exec/Production/ChallengeProblem/run-summit.sh
+++ b/Exec/Production/ChallengeProblem/run-summit.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -l
+
+#BSUB -J pelec-challenge-summit
+#BSUB -o pelec-challenge-summit.o%J
+#BSUB -P CMB138
+#BSUB -W 60
+#BSUB -nnodes 128
+#BSUB -N
+
+cmd() {
+  echo "+ $@"
+  eval "$@"
+}
+
+cmd "module unload xl"
+cmd "module load gcc/9.3.0"
+cmd "module load cuda/11.4.2"
+cmd "module load hdf5/1.10.7"
+cmd "export SPACK_MANAGER=${PROJWORK}/cfd116/jrood/spack-manager-${LMOD_SYSTEM_NAME}"
+cmd "source ${SPACK_MANAGER}/start.sh && spack-start"
+cmd "spack env activate -d ${SPACK_MANAGER}/environments/exawind-${LMOD_SYSTEM_NAME}"
+cmd "spack load exawind+amr_wind_gpu~nalu_wind_gpu"
+
+cmd "jsrun -n 768 -r 6 -a 1 -c 1 -g 1 ./PeleC3d.gnu.TPROF.MPI.CUDA.ex challenge.inp max_step=500"


### PR DESCRIPTION
At the moment these reference an HDF5 installation that most people don't have access to. I will create a world-readable installation for these an update these scripts in the future. However, these serve as an example of how to enable plot compression on the OLCF machines.