### PR TITLE
EB generation max level

### DIFF
--- a/Source/IO.cpp
+++ b/Source/IO.cpp
@@ -301,6 +301,16 @@ PeleC::checkPoint(
       CPUFile.close();
     }
 
+    {
+      // Store the level at which EB was generated
+      std::ofstream EBLevelFile;
+      std::string FullPathEBLevelFile = dir;
+      FullPathEBLevelFile += "/EBMaxLevel";
+      EBLevelFile.open(FullPathEBLevelFile.c_str(), std::ios::out);
+      EBLevelFile << eb_max_lvl_gen;
+      EBLevelFile.close();
+    }
+
     if (track_grid_losses) {
       // store diagnostic quantities
       std::ofstream DiagFile;

--- a/Source/PeleC.H
+++ b/Source/PeleC.H
@@ -525,6 +525,7 @@ public:
   amrex::EBFluxRegister& getFluxReg(int lev);
 
   static bool ebInitialized();
+  static int getEBMaxLevel();
 
   void InitialRedistribution(
     const amrex::Real time,
@@ -689,6 +690,7 @@ protected:
   static amrex::GpuArray<amrex::Real, NVAR> body_state;
   static bool body_state_set;
   static bool eb_initialized;
+  static int eb_max_lvl_gen;
 
   amrex::MultiFab vfrac;
 

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -125,11 +125,11 @@ PeleC::getEBMaxLevel()
 
   // Get the level in the restart file if present
   std::string restart_file{""};
-  ppa.query("restart" , restart_file);
+  ppa.query("restart", restart_file);
   if (!restart_file.empty()) {
     std::string FullPathEBLevelFile = restart_file;
     FullPathEBLevelFile += "/EBMaxLevel";
-    std::ifstream EBLevelFile(FullPathEBLevelFile);;
+    std::ifstream EBLevelFile(FullPathEBLevelFile);
     if (!EBLevelFile.fail()) {
       EBLevelFile >> max_eb_level;
       EBLevelFile.close();
@@ -138,7 +138,7 @@ PeleC::getEBMaxLevel()
 
   // Allow manual overwrite
   amrex::ParmParse ppeb("eb2");
-  ppeb.query("max_level_generation",max_eb_level);
+  ppeb.query("max_level_generation", max_eb_level);
 
   return max_eb_level;
 }

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -71,6 +71,7 @@ int PeleC::les_test_filter_fgr = 2;
 
 bool PeleC::eb_in_domain = false;
 bool PeleC::eb_initialized = false;
+int PeleC::eb_max_lvl_gen = -1;
 bool PeleC::body_state_set = false;
 amrex::GpuArray<amrex::Real, NVAR> PeleC::body_state;
 
@@ -110,6 +111,36 @@ void
 ebInitialized(bool eb_init_val)
 {
   eb_initialized = eb_init_val;
+}
+
+int
+PeleC::getEBMaxLevel()
+{
+  // Look into amr PP
+  amrex::ParmParse ppa("amr");
+  int max_eb_level = -1;
+
+  // Default to amr.max_level
+  ppa.query("max_level", max_eb_level);
+
+  // Get the level in the restart file if present
+  std::string restart_file{""};
+  ppa.query("restart" , restart_file);
+  if (!restart_file.empty()) {
+    std::string FullPathEBLevelFile = restart_file;
+    FullPathEBLevelFile += "/EBMaxLevel";
+    std::ifstream EBLevelFile(FullPathEBLevelFile);;
+    if (!EBLevelFile.fail()) {
+      EBLevelFile >> max_eb_level;
+      EBLevelFile.close();
+    }
+  }
+
+  // Allow manual overwrite
+  amrex::ParmParse ppeb("eb2");
+  ppeb.query("max_level_generation",max_eb_level);
+
+  return max_eb_level;
 }
 
 void

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -124,7 +124,7 @@ PeleC::getEBMaxLevel()
   ppa.query("max_level", max_eb_level);
 
   // Get the level in the restart file if present
-  std::string restart_file{""};
+  std::string restart_file;
   ppa.query("restart", restart_file);
   if (!restart_file.empty()) {
     std::string FullPathEBLevelFile = restart_file;

--- a/Source/Setup.cpp
+++ b/Source/Setup.cpp
@@ -389,6 +389,9 @@ PeleC::variableSetUp()
 
   num_state_type = desc_lst.size();
 
+  // Get the level at which EB is generated
+  eb_max_lvl_gen = getEBMaxLevel();
+
   // DEFINE DERIVED QUANTITIES
 
   // Pressure

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -126,8 +126,12 @@ main(int argc, char* argv[])
   amrex::AmrLevel::SetEBMaxGrowCells(
     5, 5,
     5); // 5 focdr ebcellflags, 4 for vfrac, 2 is not used for EBSupport::volume
+
   initialize_EB2(
-    amrptr->Geom(amrptr->maxLevel()), amrptr->maxLevel(), amrptr->maxLevel());
+    amrptr->Geom(PeleC::getEBMaxLevel()), PeleC::getEBMaxLevel(), amrptr->maxLevel());
+
+  // Add finer level, might be inconsistent with the coarser level created above.
+  amrex::EB2::addFineLevels(amrptr->maxLevel() - PeleC::getEBMaxLevel());
 
   amrptr->init(strt_time, stop_time);
 

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -128,9 +128,11 @@ main(int argc, char* argv[])
     5); // 5 focdr ebcellflags, 4 for vfrac, 2 is not used for EBSupport::volume
 
   initialize_EB2(
-    amrptr->Geom(PeleC::getEBMaxLevel()), PeleC::getEBMaxLevel(), amrptr->maxLevel());
+    amrptr->Geom(PeleC::getEBMaxLevel()), PeleC::getEBMaxLevel(),
+    amrptr->maxLevel());
 
-  // Add finer level, might be inconsistent with the coarser level created above.
+  // Add finer level, might be inconsistent with the coarser level created
+  // above.
   amrex::EB2::addFineLevels(amrptr->maxLevel() - PeleC::getEBMaxLevel());
 
   amrptr->init(strt_time, stop_time);


### PR DESCRIPTION
Track level at which EB is generated and coarsened from. Allow this level to be smaller than the amr.max_level.
This level is stored in the chk file and used upon restart but can be overwritten using `eb2.max_level_generation`.

Opening the PR for discussion, but let's wait until [this AMReX PR](https://github.com/AMReX-Codes/amrex/pull/2881) is merged.

 
