### PR TITLE
Only compile Soot.cpp in CMake if soot is enabled

### DIFF
--- a/CMake/BuildPeleCExe.cmake
+++ b/CMake/BuildPeleCExe.cmake
@@ -57,6 +57,7 @@ function(build_pelec_exe pelec_exe_name pelec_lib_name)
       message(FATAL_ERROR "NUM_SOOT_MOMENTS must be either 3 or 6")
     endif()
     target_sources(${pelec_exe_name} PRIVATE
+                   ${SRC_DIR}/Soot.cpp
                    ${PELEMP_SRC_DIR}/Soot_Models/SootModel.cpp
                    ${PELEMP_SRC_DIR}/Soot_Models/SootModel_react.cpp
                    ${PELEMP_SRC_DIR}/Soot_Models/SootModel_derive.cpp
@@ -115,7 +116,6 @@ function(build_pelec_exe pelec_exe_name pelec_lib_name)
        ${SRC_DIR}/React.cpp
        ${SRC_DIR}/Riemann.H
        ${SRC_DIR}/Setup.cpp
-       ${SRC_DIR}/Soot.cpp
        ${SRC_DIR}/Sources.cpp
        ${SRC_DIR}/SparseData.H
        ${SRC_DIR}/SumIQ.cpp

--- a/Exec/RegTests/Soot-Flame/soot-flame.inp
+++ b/Exec/RegTests/Soot-Flame/soot-flame.inp
@@ -56,7 +56,7 @@ amr.check_int       = 1000
 # PLOTFILES
 amr.plot_file       = plt # root name of plotfile
 #amr.plot_int = 1
-amr.plot_per        = 8.E-5
+#amr.plot_per        = 8.E-5
 
 # SOOT MODELING
 soot.incept_pah = A2 # Soot inception species

--- a/Source/Soot.cpp
+++ b/Source/Soot.cpp
@@ -1,6 +1,3 @@
-
-
-#ifdef PELEC_USE_SOOT
 #include "PeleC.H"
 #include "SootModel.H"
 #include "SootModel_derive.H"
@@ -176,4 +173,3 @@ PeleC::clipSootMoments(amrex::MultiFab& S_new, const int ng)
     });
   amrex::Gpu::synchronize();
 }
-#endif


### PR DESCRIPTION
Also fix plot number length in soot-flame.inp. The tests need a specific plot name.