### PR TITLE
Remove amrex::Math (not needed anymore)

### DIFF
--- a/Exec/RegTests/ChannelFlow/prob.H
+++ b/Exec/RegTests/ChannelFlow/prob.H
@@ -58,7 +58,7 @@ pc_initdata(
   const amrex::Real c_f = 0.0062418;
   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> vel = {0.0};
   vel[0] = std::sqrt(prob_parm.dpdx * Ly / (1e-3 * 0.4688 * c_f)) *
-           (1.0 - std::pow(amrex::Math::abs(2.0 * y / Ly), 10.0));
+           (1.0 - std::pow(std::abs(2.0 * y / Ly), 10.0));
 
   AMREX_D_TERM(const amrex::Real u =
                  vel[0] *

--- a/Source/EB.H
+++ b/Source/EB.H
@@ -36,7 +36,7 @@ argmax(const amrex::Real array[AMREX_SPACEDIM])
   const amrex::Real max_num =
     amrex::max<amrex::Real>(AMREX_D_DECL(array[0], array[1], array[2]));
   for (int i = 0; i < AMREX_SPACEDIM; i++) {
-    if (amrex::Math::abs(max_num - array[i]) < constants::very_small_num()) {
+    if (std::abs(max_num - array[i]) < constants::very_small_num()) {
       return i;
     }
   }
@@ -50,7 +50,7 @@ idxsort(const amrex::Real array[AMREX_SPACEDIM], int idx[AMREX_SPACEDIM])
 {
   amrex::Real absarray[AMREX_SPACEDIM] = {0.0};
   for (int dir = 0; dir < AMREX_SPACEDIM; dir++) {
-    absarray[dir] = amrex::Math::abs(array[dir]);
+    absarray[dir] = std::abs(array[dir]);
   }
 
   for (int dir = 0; dir < AMREX_SPACEDIM; dir++) {

--- a/Source/EB.cpp
+++ b/Source/EB.cpp
@@ -83,27 +83,27 @@ pc_fill_bndry_grad_stencil_quadratic(
       const int ivs[AMREX_SPACEDIM] = {
         AMREX_D_DECL(ebg[L].iv[0], ebg[L].iv[1], ebg[L].iv[2])};
       const int s[AMREX_SPACEDIM] = {AMREX_D_DECL(
-        (int)amrex::Math::copysign(1.0, n[c[0]]),
-        (int)amrex::Math::copysign(1.0, n[c[1]]),
-        (int)amrex::Math::copysign(1.0, n[c[2]]))};
+        (int)std::copysign(1.0, n[c[0]]),
+        (int)std::copysign(1.0, n[c[1]]),
+        (int)std::copysign(1.0, n[c[2]]))};
       amrex::Real b[AMREX_SPACEDIM] = {AMREX_D_DECL(
         ebg[L].eb_centroid[c[0]] * s[0], ebg[L].eb_centroid[c[1]] * s[1],
         ebg[L].eb_centroid[c[2]] * s[2])};
 
       // From ivs, move to center of stencil, then move to lower-left of that
       const int baseiv[AMREX_SPACEDIM] = {AMREX_D_DECL(
-        ivs[0] + (int)amrex::Math::copysign(1.0, n[0]) - 1,
-        ivs[1] + (int)amrex::Math::copysign(1.0, n[1]) - 1,
-        ivs[2] + (int)amrex::Math::copysign(1.0, n[2]) - 1)};
+        ivs[0] + (int)std::copysign(1.0, n[0]) - 1,
+        ivs[1] + (int)std::copysign(1.0, n[1]) - 1,
+        ivs[2] + (int)std::copysign(1.0, n[2]) - 1)};
 
       const amrex::Real x[2] = {1.0, 2.0};
       amrex::Real y[2] = {
-        b[1] + (x[0] - b[0]) * amrex::Math::abs(n[c[1]] / n[c[0]]),
-        b[1] + (x[1] - b[0]) * amrex::Math::abs(n[c[1]] / n[c[0]])};
+        b[1] + (x[0] - b[0]) * std::abs(n[c[1]] / n[c[0]]),
+        b[1] + (x[1] - b[0]) * std::abs(n[c[1]] / n[c[0]])};
 #if AMREX_SPACEDIM > 2
       amrex::Real z[2] = {
-        b[2] + (x[0] - b[0]) * amrex::Math::abs(n[c[2]] / n[c[0]]),
-        b[2] + (x[1] - b[0]) * amrex::Math::abs(n[c[2]] / n[c[0]])};
+        b[2] + (x[0] - b[0]) * std::abs(n[c[2]] / n[c[0]]),
+        b[2] + (x[1] - b[0]) * std::abs(n[c[2]] / n[c[0]])};
 #endif
 
       int sh[AMREX_SPACEDIM] = {0};
@@ -111,16 +111,16 @@ pc_fill_bndry_grad_stencil_quadratic(
         sh[c[1]] = -s[1]; // Slide stencil down to avoid extrapolating, push
                           // up eb, shift down base later
         b[1] += 1;
-        y[0] = b[1] + (x[0] - b[0]) * amrex::Math::abs(n[c[1]] / n[c[0]]);
-        y[1] = b[1] + (x[1] - b[0]) * amrex::Math::abs(n[c[1]] / n[c[0]]);
+        y[0] = b[1] + (x[0] - b[0]) * std::abs(n[c[1]] / n[c[0]]);
+        y[1] = b[1] + (x[1] - b[0]) * std::abs(n[c[1]] / n[c[0]]);
       }
 #if AMREX_SPACEDIM > 2
       if (z[0] < 0.0 || z[1] < 0.0) {
         sh[c[2]] = -s[2]; // Slide stencil down to avoid extrapolating, push
                           // up eb, shift down base later
         b[2] += 1;
-        z[0] = b[2] + (x[0] - b[0]) * amrex::Math::abs(n[c[2]] / n[c[0]]);
-        z[1] = b[2] + (x[1] - b[0]) * amrex::Math::abs(n[c[2]] / n[c[0]]);
+        z[0] = b[2] + (x[0] - b[0]) * std::abs(n[c[2]] / n[c[0]]);
+        z[1] = b[2] + (x[1] - b[0]) * std::abs(n[c[2]] / n[c[0]]);
       }
 #endif
       const amrex::Real d[2] = {
@@ -277,9 +277,9 @@ pc_fill_bndry_grad_stencil_ls(
 
       // From ivs, move to center of stencil, then move to lower-left of that
       const int baseiv[AMREX_SPACEDIM] = {AMREX_D_DECL(
-        ivs[0] + (int)amrex::Math::copysign(1.0, n[0]) - 1,
-        ivs[1] + (int)amrex::Math::copysign(1.0, n[1]) - 1,
-        ivs[2] + (int)amrex::Math::copysign(1.0, n[2]) - 1)};
+        ivs[0] + (int)std::copysign(1.0, n[0]) - 1,
+        ivs[1] + (int)std::copysign(1.0, n[1]) - 1,
+        ivs[2] + (int)std::copysign(1.0, n[2]) - 1)};
 
       // set iv and iv_base
       for (int dir = 0; dir < AMREX_SPACEDIM; dir++) {
@@ -407,8 +407,8 @@ pc_fill_flux_interp_stencil(
         jj = 0.0;
       }
       const amrex::Real ct = fc(iv, 0);
-      const int tn = (int)amrex::Math::copysign(1.0, ct);
-      const amrex::Real act = amrex::Math::abs(ct);
+      const int tn = (int)std::copysign(1.0, ct);
+      const amrex::Real act = std::abs(ct);
       sten[L].val[1] = fa(iv) * (1.0 - act);
       sten[L].val[tn + 1] = fa(iv) * act;
 #elif AMREX_SPACEDIM == 3
@@ -419,10 +419,10 @@ pc_fill_flux_interp_stencil(
       }
       const amrex::Real ct0 = fc(iv, 0);
       const amrex::Real ct1 = fc(iv, 1);
-      const int t0n = (int)amrex::Math::copysign(1.0, ct0);
-      const int t1n = (int)amrex::Math::copysign(1.0, ct1);
-      const amrex::Real act0 = amrex::Math::abs(ct0);
-      const amrex::Real act1 = amrex::Math::abs(ct1);
+      const int t0n = (int)std::copysign(1.0, ct0);
+      const int t1n = (int)std::copysign(1.0, ct1);
+      const amrex::Real act0 = std::abs(ct0);
+      const amrex::Real act1 = std::abs(ct1);
       sten[L].val[1][1] = fa(iv) * (1.0 - act0) * (1.0 - act1);
       sten[L].val[t0n + 1][1] = fa(iv) * act0 * (1.0 - act1);
       sten[L].val[1][t1n + 1] = fa(iv) * (1.0 - act0) * act1;

--- a/Source/EB.cpp
+++ b/Source/EB.cpp
@@ -83,8 +83,7 @@ pc_fill_bndry_grad_stencil_quadratic(
       const int ivs[AMREX_SPACEDIM] = {
         AMREX_D_DECL(ebg[L].iv[0], ebg[L].iv[1], ebg[L].iv[2])};
       const int s[AMREX_SPACEDIM] = {AMREX_D_DECL(
-        (int)std::copysign(1.0, n[c[0]]),
-        (int)std::copysign(1.0, n[c[1]]),
+        (int)std::copysign(1.0, n[c[0]]), (int)std::copysign(1.0, n[c[1]]),
         (int)std::copysign(1.0, n[c[2]]))};
       amrex::Real b[AMREX_SPACEDIM] = {AMREX_D_DECL(
         ebg[L].eb_centroid[c[0]] * s[0], ebg[L].eb_centroid[c[1]] * s[1],

--- a/Source/Geometry.cpp
+++ b/Source/Geometry.cpp
@@ -77,7 +77,7 @@ Combustor::build(const amrex::Geometry& geom, const int max_coarsening_level)
     {AMREX_D_DECL(pipehi[0], pipehi[1], 1.)}, false);
 
   // where does plane 1 and plane 2 intersect?
-  amrex::Real k2 = amrex::Math::abs(pl2nm[0] / pl2nm[1]);
+  amrex::Real k2 = std::abs(pl2nm[0] / pl2nm[1]);
   amrex::Real secty = pl2pt[1] + k2 * (pl3pt[0] - pl2pt[0]);
   // How much do we cut?
   amrex::Real dx = geom.CellSize(0);

--- a/Source/Godunov.H
+++ b/Source/Godunov.H
@@ -174,8 +174,8 @@ flatten(
   const int ishft = (dp > 0.0) ? 1 : -1;
 
   amrex::Real denom =
-    amrex::max<amrex::Real>(small_pres, amrex::Math::abs(qpp - qmm));
-  amrex::Real zeta = amrex::Math::abs(dp) / denom;
+    amrex::max<amrex::Real>(small_pres, std::abs(qpp - qmm));
+  amrex::Real zeta = std::abs(dp) / denom;
   const amrex::Real z = amrex::min<amrex::Real>(
     1.0, amrex::max<amrex::Real>(0.0, dzcut * (zeta - zcut1)));
 
@@ -183,7 +183,7 @@ flatten(
 
   amrex::Real tmp = amrex::min<amrex::Real>(qp, qm);
 
-  const amrex::Real chi = (amrex::Math::abs(dp) / tmp) > shktst ? tst : 0.0;
+  const amrex::Real chi = (std::abs(dp) / tmp) > shktst ? tst : 0.0;
 
   const amrex::Real qpshft = q(iv + (1 - ishft) * dvec, n);
   const amrex::Real qmshft = q(iv - (1 + ishft) * dvec, n);
@@ -195,8 +195,8 @@ flatten(
   dp = qpshft - qmshft;
 
   denom =
-    amrex::max<amrex::Real>(small_pres, amrex::Math::abs(qppshft - qmmshft));
-  zeta = amrex::Math::abs(dp) / denom;
+    amrex::max<amrex::Real>(small_pres, std::abs(qppshft - qmmshft));
+  zeta = std::abs(dp) / denom;
   const amrex::Real z2 = amrex::min<amrex::Real>(
     1.0, amrex::max<amrex::Real>(0.0, dzcut * (zeta - zcut1)));
 
@@ -204,7 +204,7 @@ flatten(
 
   tmp = amrex::min<amrex::Real>(qpshft, qmshft);
 
-  const amrex::Real chi2 = (amrex::Math::abs(dp) / tmp) > shktst ? tst : 0.0;
+  const amrex::Real chi2 = (std::abs(dp) / tmp) > shktst ? tst : 0.0;
 
   return 1.0 - amrex::max<amrex::Real>(chi2 * z2, chi * z);
 }

--- a/Source/Godunov.H
+++ b/Source/Godunov.H
@@ -173,8 +173,7 @@ flatten(
 
   const int ishft = (dp > 0.0) ? 1 : -1;
 
-  amrex::Real denom =
-    amrex::max<amrex::Real>(small_pres, std::abs(qpp - qmm));
+  amrex::Real denom = amrex::max<amrex::Real>(small_pres, std::abs(qpp - qmm));
   amrex::Real zeta = std::abs(dp) / denom;
   const amrex::Real z = amrex::min<amrex::Real>(
     1.0, amrex::max<amrex::Real>(0.0, dzcut * (zeta - zcut1)));
@@ -194,8 +193,7 @@ flatten(
 
   dp = qpshft - qmshft;
 
-  denom =
-    amrex::max<amrex::Real>(small_pres, std::abs(qppshft - qmmshft));
+  denom = amrex::max<amrex::Real>(small_pres, std::abs(qppshft - qmmshft));
   zeta = std::abs(dp) / denom;
   const amrex::Real z2 = amrex::min<amrex::Real>(
     1.0, amrex::max<amrex::Real>(0.0, dzcut * (zeta - zcut1)));

--- a/Source/IO.cpp
+++ b/Source/IO.cpp
@@ -815,7 +815,7 @@ PeleC::initLevelDataFromPlt(
       }
 
       // If the sumY isn't too far from 1, renormalize
-      if (amrex::Math::abs(1.0 - sumY) < tol) {
+      if (std::abs(1.0 - sumY) < tol) {
         for (int n = 0; n < NUM_SPECIES; n++) {
           sarr(i, j, k, UFS + n) /= sumY;
         }

--- a/Source/MOL.H
+++ b/Source/MOL.H
@@ -112,11 +112,10 @@ mol_slope(
     const amrex::Real dcen = 0.5 * (dlft[n] + drgt[n]);
     const amrex::Real dlim =
       dlft[n] * drgt[n] >= 0.0
-        ? 2.0 * amrex::min<amrex::Real>(
-                  std::abs(dlft[n]), std::abs(drgt[n]))
+        ? 2.0 * amrex::min<amrex::Real>(std::abs(dlft[n]), std::abs(drgt[n]))
         : 0.0;
-    dq(iv, n) = std::copysign(1.0, dcen) *
-                amrex::min<amrex::Real>(dlim, std::abs(dcen));
+    dq(iv, n) =
+      std::copysign(1.0, dcen) * amrex::min<amrex::Real>(dlim, std::abs(dcen));
   }
 }
 

--- a/Source/MOL.H
+++ b/Source/MOL.H
@@ -113,10 +113,10 @@ mol_slope(
     const amrex::Real dlim =
       dlft[n] * drgt[n] >= 0.0
         ? 2.0 * amrex::min<amrex::Real>(
-                  amrex::Math::abs(dlft[n]), amrex::Math::abs(drgt[n]))
+                  std::abs(dlft[n]), std::abs(drgt[n]))
         : 0.0;
-    dq(iv, n) = amrex::Math::copysign(1.0, dcen) *
-                amrex::min<amrex::Real>(dlim, amrex::Math::abs(dcen));
+    dq(iv, n) = std::copysign(1.0, dcen) *
+                amrex::min<amrex::Real>(dlim, std::abs(dcen));
   }
 }
 

--- a/Source/PLM.H
+++ b/Source/PLM.H
@@ -42,8 +42,7 @@ plm_slope(
   dcen = 0.5 * (dlft + drgt);
   dsgn = std::copysign(1.0, dcen);
   dlim = (dlft * drgt >= 0.0)
-           ? 2.0 * amrex::min<amrex::Real>(
-                     std::abs(dlft), std::abs(drgt))
+           ? 2.0 * amrex::min<amrex::Real>(std::abs(dlft), std::abs(drgt))
            : 0.0;
   dfm = dsgn * amrex::min<amrex::Real>(dlim, std::abs(dcen));
 
@@ -52,8 +51,7 @@ plm_slope(
   dcen = 0.5 * (dlft + drgt);
   dsgn = std::copysign(1.0, dcen);
   dlim = (dlft * drgt >= 0.0)
-           ? 2.0 * amrex::min<amrex::Real>(
-                     std::abs(dlft), std::abs(drgt))
+           ? 2.0 * amrex::min<amrex::Real>(std::abs(dlft), std::abs(drgt))
            : 0.0;
   dfp = dsgn * amrex::min<amrex::Real>(dlim, std::abs(dcen));
 
@@ -62,8 +60,7 @@ plm_slope(
   dcen = 0.5 * (dlft + drgt);
   dsgn = std::copysign(1.0, dcen);
   dlim = (dlft * drgt >= 0.0)
-           ? 2.0 * amrex::min<amrex::Real>(
-                     std::abs(dlft), std::abs(drgt))
+           ? 2.0 * amrex::min<amrex::Real>(std::abs(dlft), std::abs(drgt))
            : 0.0;
 
   dtemp = 4.0 / 3.0 * dcen - 1.0 / 6.0 * (dfp + dfm);
@@ -154,23 +151,19 @@ pc_plm_d(
   amrex::Real rhoe_ref =
     rhoe - 0.5 * (1.0 + dtdx * amrex::min<amrex::Real>(wv[0], 0.0)) * drhoe;
 
-  const amrex::Real apright = 0.25 * dtdx * (wv[0] - wv[2]) *
-                              (1.0 - std::copysign(1.0, wv[2])) *
-                              alphap;
+  const amrex::Real apright =
+    0.25 * dtdx * (wv[0] - wv[2]) * (1.0 - std::copysign(1.0, wv[2])) * alphap;
   const amrex::Real amright = 0.0;
 
-  const amrex::Real azrright = 0.25 * dtdx * (wv[0] - wv[1]) *
-                               (1.0 - std::copysign(1.0, wv[1])) *
-                               alpha0r;
-  const amrex::Real azeright = 0.25 * dtdx * (wv[0] - wv[1]) *
-                               (1.0 - std::copysign(1.0, wv[1])) *
-                               alpha0e;
-  AMREX_D_TERM(, const amrex::Real azv1rght =
-                   0.25 * dtdx * (wv[0] - wv[1]) *
-                   (1.0 - std::copysign(1.0, wv[1])) * alpha0v;
-               , const amrex::Real azw1rght =
-                   0.25 * dtdx * (wv[0] - wv[1]) *
-                   (1.0 - std::copysign(1.0, wv[1])) * alpha0w;)
+  const amrex::Real azrright =
+    0.25 * dtdx * (wv[0] - wv[1]) * (1.0 - std::copysign(1.0, wv[1])) * alpha0r;
+  const amrex::Real azeright =
+    0.25 * dtdx * (wv[0] - wv[1]) * (1.0 - std::copysign(1.0, wv[1])) * alpha0e;
+  AMREX_D_TERM(
+    , const amrex::Real azv1rght = 0.25 * dtdx * (wv[0] - wv[1]) *
+                                   (1.0 - std::copysign(1.0, wv[1])) * alpha0v;
+    , const amrex::Real azw1rght = 0.25 * dtdx * (wv[0] - wv[1]) *
+                                   (1.0 - std::copysign(1.0, wv[1])) * alpha0w;)
 
   qp(iv, QRHO) = rho_ref + apright + amright + azrright;
   qp(iv, QRHO) = amrex::max<amrex::Real>(
@@ -199,21 +192,18 @@ pc_plm_d(
     rhoe + 0.5 * (1.0 - dtdx * amrex::max<amrex::Real>(wv[2], 0.0)) * drhoe;
 
   const amrex::Real apleft = 0.0;
-  const amrex::Real amleft = 0.25 * dtdx * (wv[2] - wv[0]) *
-                             (1.0 + std::copysign(1.0, wv[0])) * alpham;
+  const amrex::Real amleft =
+    0.25 * dtdx * (wv[2] - wv[0]) * (1.0 + std::copysign(1.0, wv[0])) * alpham;
 
-  const amrex::Real azrleft = 0.25 * dtdx * (wv[2] - wv[1]) *
-                              (1.0 + std::copysign(1.0, wv[1])) *
-                              alpha0r;
-  const amrex::Real azeleft = 0.25 * dtdx * (wv[2] - wv[1]) *
-                              (1.0 + std::copysign(1.0, wv[1])) *
-                              alpha0e;
-  AMREX_D_TERM(, const amrex::Real azv1left =
-                   0.25 * dtdx * (wv[2] - wv[1]) *
-                   (1.0 + std::copysign(1.0, wv[1])) * alpha0v;
-               , const amrex::Real azw1left =
-                   0.25 * dtdx * (wv[2] - wv[1]) *
-                   (1.0 + std::copysign(1.0, wv[1])) * alpha0w;)
+  const amrex::Real azrleft =
+    0.25 * dtdx * (wv[2] - wv[1]) * (1.0 + std::copysign(1.0, wv[1])) * alpha0r;
+  const amrex::Real azeleft =
+    0.25 * dtdx * (wv[2] - wv[1]) * (1.0 + std::copysign(1.0, wv[1])) * alpha0e;
+  AMREX_D_TERM(
+    , const amrex::Real azv1left = 0.25 * dtdx * (wv[2] - wv[1]) *
+                                   (1.0 + std::copysign(1.0, wv[1])) * alpha0v;
+    , const amrex::Real azw1left = 0.25 * dtdx * (wv[2] - wv[1]) *
+                                   (1.0 + std::copysign(1.0, wv[1])) * alpha0w;)
   qm(ivp, QRHO) = rho_ref + apleft + amleft + azrleft;
   qm(ivp, QRHO) = amrex::max<amrex::Real>(
     qm(ivp, QRHO), std::numeric_limits<amrex::Real>::min());

--- a/Source/PLM.H
+++ b/Source/PLM.H
@@ -40,36 +40,36 @@ plm_slope(
   dlft = qm - qm2;
   drgt = qc - qm;
   dcen = 0.5 * (dlft + drgt);
-  dsgn = amrex::Math::copysign(1.0, dcen);
+  dsgn = std::copysign(1.0, dcen);
   dlim = (dlft * drgt >= 0.0)
            ? 2.0 * amrex::min<amrex::Real>(
-                     amrex::Math::abs(dlft), amrex::Math::abs(drgt))
+                     std::abs(dlft), std::abs(drgt))
            : 0.0;
-  dfm = dsgn * amrex::min<amrex::Real>(dlim, amrex::Math::abs(dcen));
+  dfm = dsgn * amrex::min<amrex::Real>(dlim, std::abs(dcen));
 
   dlft = qp - qc;
   drgt = qp2 - qp;
   dcen = 0.5 * (dlft + drgt);
-  dsgn = amrex::Math::copysign(1.0, dcen);
+  dsgn = std::copysign(1.0, dcen);
   dlim = (dlft * drgt >= 0.0)
            ? 2.0 * amrex::min<amrex::Real>(
-                     amrex::Math::abs(dlft), amrex::Math::abs(drgt))
+                     std::abs(dlft), std::abs(drgt))
            : 0.0;
-  dfp = dsgn * amrex::min<amrex::Real>(dlim, amrex::Math::abs(dcen));
+  dfp = dsgn * amrex::min<amrex::Real>(dlim, std::abs(dcen));
 
   dlft = qc - qm;
   drgt = qp - qc;
   dcen = 0.5 * (dlft + drgt);
-  dsgn = amrex::Math::copysign(1.0, dcen);
+  dsgn = std::copysign(1.0, dcen);
   dlim = (dlft * drgt >= 0.0)
            ? 2.0 * amrex::min<amrex::Real>(
-                     amrex::Math::abs(dlft), amrex::Math::abs(drgt))
+                     std::abs(dlft), std::abs(drgt))
            : 0.0;
 
   dtemp = 4.0 / 3.0 * dcen - 1.0 / 6.0 * (dfp + dfm);
 
   // Flattening could be done here (see Nyx if we want to do it)
-  return dsgn * amrex::min<amrex::Real>(dlim, amrex::Math::abs(dtemp));
+  return dsgn * amrex::min<amrex::Real>(dlim, std::abs(dtemp));
 }
 
 AMREX_GPU_DEVICE
@@ -155,22 +155,22 @@ pc_plm_d(
     rhoe - 0.5 * (1.0 + dtdx * amrex::min<amrex::Real>(wv[0], 0.0)) * drhoe;
 
   const amrex::Real apright = 0.25 * dtdx * (wv[0] - wv[2]) *
-                              (1.0 - amrex::Math::copysign(1.0, wv[2])) *
+                              (1.0 - std::copysign(1.0, wv[2])) *
                               alphap;
   const amrex::Real amright = 0.0;
 
   const amrex::Real azrright = 0.25 * dtdx * (wv[0] - wv[1]) *
-                               (1.0 - amrex::Math::copysign(1.0, wv[1])) *
+                               (1.0 - std::copysign(1.0, wv[1])) *
                                alpha0r;
   const amrex::Real azeright = 0.25 * dtdx * (wv[0] - wv[1]) *
-                               (1.0 - amrex::Math::copysign(1.0, wv[1])) *
+                               (1.0 - std::copysign(1.0, wv[1])) *
                                alpha0e;
   AMREX_D_TERM(, const amrex::Real azv1rght =
                    0.25 * dtdx * (wv[0] - wv[1]) *
-                   (1.0 - amrex::Math::copysign(1.0, wv[1])) * alpha0v;
+                   (1.0 - std::copysign(1.0, wv[1])) * alpha0v;
                , const amrex::Real azw1rght =
                    0.25 * dtdx * (wv[0] - wv[1]) *
-                   (1.0 - amrex::Math::copysign(1.0, wv[1])) * alpha0w;)
+                   (1.0 - std::copysign(1.0, wv[1])) * alpha0w;)
 
   qp(iv, QRHO) = rho_ref + apright + amright + azrright;
   qp(iv, QRHO) = amrex::max<amrex::Real>(
@@ -200,20 +200,20 @@ pc_plm_d(
 
   const amrex::Real apleft = 0.0;
   const amrex::Real amleft = 0.25 * dtdx * (wv[2] - wv[0]) *
-                             (1.0 + amrex::Math::copysign(1.0, wv[0])) * alpham;
+                             (1.0 + std::copysign(1.0, wv[0])) * alpham;
 
   const amrex::Real azrleft = 0.25 * dtdx * (wv[2] - wv[1]) *
-                              (1.0 + amrex::Math::copysign(1.0, wv[1])) *
+                              (1.0 + std::copysign(1.0, wv[1])) *
                               alpha0r;
   const amrex::Real azeleft = 0.25 * dtdx * (wv[2] - wv[1]) *
-                              (1.0 + amrex::Math::copysign(1.0, wv[1])) *
+                              (1.0 + std::copysign(1.0, wv[1])) *
                               alpha0e;
   AMREX_D_TERM(, const amrex::Real azv1left =
                    0.25 * dtdx * (wv[2] - wv[1]) *
-                   (1.0 + amrex::Math::copysign(1.0, wv[1])) * alpha0v;
+                   (1.0 + std::copysign(1.0, wv[1])) * alpha0v;
                , const amrex::Real azw1left =
                    0.25 * dtdx * (wv[2] - wv[1]) *
-                   (1.0 + amrex::Math::copysign(1.0, wv[1])) * alpha0w;)
+                   (1.0 + std::copysign(1.0, wv[1])) * alpha0w;)
   qm(ivp, QRHO) = rho_ref + apleft + amleft + azrleft;
   qm(ivp, QRHO) = amrex::max<amrex::Real>(
     qm(ivp, QRHO), std::numeric_limits<amrex::Real>::min());

--- a/Source/PPM.H
+++ b/Source/PPM.H
@@ -42,8 +42,7 @@ ppm_reconstruct(
     dsvl_l =
       std::copysign(1.0, dsc) *
       amrex::min<amrex::Real>(
-        std::abs(dsc),
-        amrex::min<amrex::Real>(std::abs(dsl), std::abs(dsr)));
+        std::abs(dsc), amrex::min<amrex::Real>(std::abs(dsl), std::abs(dsr)));
   }
 
   dsl = 2.0 * (s[i0] - s[im1]);
@@ -55,8 +54,7 @@ ppm_reconstruct(
     dsvl_r =
       std::copysign(1.0, dsc) *
       amrex::min<amrex::Real>(
-        std::abs(dsc),
-        amrex::min<amrex::Real>(std::abs(dsl), std::abs(dsr)));
+        std::abs(dsc), amrex::min<amrex::Real>(std::abs(dsl), std::abs(dsr)));
   }
 
   // Interpolate s to edges
@@ -76,8 +74,7 @@ ppm_reconstruct(
     dsvl_l =
       std::copysign(1.0, dsc) *
       amrex::min<amrex::Real>(
-        std::abs(dsc),
-        amrex::min<amrex::Real>(std::abs(dsl), std::abs(dsr)));
+        std::abs(dsc), amrex::min<amrex::Real>(std::abs(dsl), std::abs(dsr)));
   }
 
   dsl = 2.0 * (s[ip1] - s[i0]);
@@ -89,8 +86,7 @@ ppm_reconstruct(
     dsvl_r =
       std::copysign(1.0, dsc) *
       amrex::min<amrex::Real>(
-        std::abs(dsc),
-        amrex::min<amrex::Real>(std::abs(dsl), std::abs(dsr)));
+        std::abs(dsc), amrex::min<amrex::Real>(std::abs(dsl), std::abs(dsr)));
   }
 
   // Interpolate s to edges
@@ -110,12 +106,10 @@ ppm_reconstruct(
     sp = s[i0];
     sm = s[i0];
 
-  } else if (
-    std::abs(sp - s[i0]) >= 2.0 * std::abs(sm - s[i0])) {
+  } else if (std::abs(sp - s[i0]) >= 2.0 * std::abs(sm - s[i0])) {
     sp = 3.0 * s[i0] - 2.0 * sm;
 
-  } else if (
-    std::abs(sm - s[i0]) >= 2.0 * std::abs(sp - s[i0])) {
+  } else if (std::abs(sm - s[i0]) >= 2.0 * std::abs(sp - s[i0])) {
     sm = 3.0 * s[i0] - 2.0 * sp;
   }
 }

--- a/Source/PPM.H
+++ b/Source/PPM.H
@@ -40,10 +40,10 @@ ppm_reconstruct(
   if (dsl * dsr > 0.0) {
     amrex::Real dsc = 0.5 * (s[i0] - s[im2]);
     dsvl_l =
-      amrex::Math::copysign(1.0, dsc) *
+      std::copysign(1.0, dsc) *
       amrex::min<amrex::Real>(
-        amrex::Math::abs(dsc),
-        amrex::min<amrex::Real>(amrex::Math::abs(dsl), amrex::Math::abs(dsr)));
+        std::abs(dsc),
+        amrex::min<amrex::Real>(std::abs(dsl), std::abs(dsr)));
   }
 
   dsl = 2.0 * (s[i0] - s[im1]);
@@ -53,10 +53,10 @@ ppm_reconstruct(
   if (dsl * dsr > 0.0) {
     amrex::Real dsc = 0.5 * (s[ip1] - s[im1]);
     dsvl_r =
-      amrex::Math::copysign(1.0, dsc) *
+      std::copysign(1.0, dsc) *
       amrex::min<amrex::Real>(
-        amrex::Math::abs(dsc),
-        amrex::min<amrex::Real>(amrex::Math::abs(dsl), amrex::Math::abs(dsr)));
+        std::abs(dsc),
+        amrex::min<amrex::Real>(std::abs(dsl), std::abs(dsr)));
   }
 
   // Interpolate s to edges
@@ -74,10 +74,10 @@ ppm_reconstruct(
   if (dsl * dsr > 0.0) {
     amrex::Real dsc = 0.5 * (s[ip1] - s[im1]);
     dsvl_l =
-      amrex::Math::copysign(1.0, dsc) *
+      std::copysign(1.0, dsc) *
       amrex::min<amrex::Real>(
-        amrex::Math::abs(dsc),
-        amrex::min<amrex::Real>(amrex::Math::abs(dsl), amrex::Math::abs(dsr)));
+        std::abs(dsc),
+        amrex::min<amrex::Real>(std::abs(dsl), std::abs(dsr)));
   }
 
   dsl = 2.0 * (s[ip1] - s[i0]);
@@ -87,10 +87,10 @@ ppm_reconstruct(
   if (dsl * dsr > 0.0) {
     amrex::Real dsc = 0.5 * (s[ip2] - s[i0]);
     dsvl_r =
-      amrex::Math::copysign(1.0, dsc) *
+      std::copysign(1.0, dsc) *
       amrex::min<amrex::Real>(
-        amrex::Math::abs(dsc),
-        amrex::min<amrex::Real>(amrex::Math::abs(dsl), amrex::Math::abs(dsr)));
+        std::abs(dsc),
+        amrex::min<amrex::Real>(std::abs(dsl), std::abs(dsr)));
   }
 
   // Interpolate s to edges
@@ -111,11 +111,11 @@ ppm_reconstruct(
     sm = s[i0];
 
   } else if (
-    amrex::Math::abs(sp - s[i0]) >= 2.0 * amrex::Math::abs(sm - s[i0])) {
+    std::abs(sp - s[i0]) >= 2.0 * std::abs(sm - s[i0])) {
     sp = 3.0 * s[i0] - 2.0 * sm;
 
   } else if (
-    amrex::Math::abs(sm - s[i0]) >= 2.0 * amrex::Math::abs(sp - s[i0])) {
+    std::abs(sm - s[i0]) >= 2.0 * std::abs(sp - s[i0])) {
     sm = 3.0 * s[i0] - 2.0 * sp;
   }
 }
@@ -158,7 +158,7 @@ ppm_int_profile(
 
   // u-c wave
   amrex::Real speed = u - c;
-  amrex::Real sigma = amrex::Math::abs(speed) * dtdx;
+  amrex::Real sigma = std::abs(speed) * dtdx;
 
   // if speed == ZERO, then either branch is the same
   if (speed <= 0.0) {
@@ -171,7 +171,7 @@ ppm_int_profile(
 
   // u wave
   speed = u;
-  sigma = amrex::Math::abs(speed) * dtdx;
+  sigma = std::abs(speed) * dtdx;
 
   if (speed <= 0.0) {
     Ip[1] = sp;
@@ -183,7 +183,7 @@ ppm_int_profile(
 
   // u+c wave
   speed = u + c;
-  sigma = amrex::Math::abs(speed) * dtdx;
+  sigma = std::abs(speed) * dtdx;
 
   if (speed <= 0.0) {
     Ip[2] = sp;
@@ -227,7 +227,7 @@ ppm_int_profile_single(
   // Ip integrates to the right edge of a cell
   // Im integrates to the left edge of a cell
 
-  amrex::Real sigma = amrex::Math::abs(lam) * dtdx;
+  amrex::Real sigma = std::abs(lam) * dtdx;
 
   if (lam <= 0.0) {
     Ip = sp;

--- a/Source/PeleC.H
+++ b/Source/PeleC.H
@@ -844,9 +844,7 @@ pc_check_initial_species(
   for (int n = 0; n < NUM_SPECIES; n++) {
     spec_sum = spec_sum + Sfab(i, j, k, UFS + n);
   }
-  if (
-    std::abs(Sfab(i, j, k, URHO) - spec_sum) >
-    1.e-8 * Sfab(i, j, k, URHO)) {
+  if (std::abs(Sfab(i, j, k, URHO) - spec_sum) > 1.e-8 * Sfab(i, j, k, URHO)) {
     // print *,'Sum of (rho X)_i vs rho at (i,j,k):
     // ',i,j,k,spec_sum,state(i,j,k,URHO)
     amrex::Abort("Error:: Failed check of initial species summing to 1");

--- a/Source/PeleC.H
+++ b/Source/PeleC.H
@@ -845,7 +845,7 @@ pc_check_initial_species(
     spec_sum = spec_sum + Sfab(i, j, k, UFS + n);
   }
   if (
-    amrex::Math::abs(Sfab(i, j, k, URHO) - spec_sum) >
+    std::abs(Sfab(i, j, k, URHO) - spec_sum) >
     1.e-8 * Sfab(i, j, k, URHO)) {
     // print *,'Sum of (rho X)_i vs rho at (i,j,k):
     // ',i,j,k,spec_sum,state(i,j,k,URHO)

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -648,8 +648,8 @@ PeleC::initData()
   if (
     amrex::max<amrex::Real>(AMREX_D_DECL(
       static_cast<amrex::Real>(0.0),
-      static_cast<amrex::Real>(amrex::Math::abs(dx[0] - dx[1])),
-      static_cast<amrex::Real>(amrex::Math::abs(dx[0] - dx[2])))) >
+      static_cast<amrex::Real>(std::abs(dx[0] - dx[1])),
+      static_cast<amrex::Real>(std::abs(dx[0] - dx[2])))) >
     small * dx[0]) {
     amrex::Abort("dx != dy != dz not supported");
   }
@@ -1077,9 +1077,9 @@ PeleC::post_timestep(int iteration)
 
     if (sum_per > 0.0) {
       const int num_per_old =
-        static_cast<int>(amrex::Math::floor((cumtime - dtlev) / sum_per));
+        static_cast<int>(std::floor((cumtime - dtlev) / sum_per));
       const int num_per_new =
-        static_cast<int>(amrex::Math::floor((cumtime) / sum_per));
+        static_cast<int>(std::floor((cumtime) / sum_per));
 
       if (num_per_old != num_per_new) {
         sum_per_test = true;
@@ -1218,9 +1218,9 @@ PeleC::post_init(amrex::Real /*stop_time*/)
 
   if (sum_per > 0.0) {
     const int num_per_old =
-      static_cast<int>(amrex::Math::floor((cumtime - dtlev) / sum_per));
+      static_cast<int>(std::floor((cumtime - dtlev) / sum_per));
     const int num_per_new =
-      static_cast<int>(amrex::Math::floor((cumtime) / sum_per));
+      static_cast<int>(std::floor((cumtime) / sum_per));
 
     if (num_per_old != num_per_new) {
       sum_per_test = true;
@@ -1932,7 +1932,7 @@ PeleC::reset_internal_energy(amrex::MultiFab& S_new, int ng)
     amrex::ParallelDescriptor::ReduceRealSum(sum);
     if (
       amrex::ParallelDescriptor::IOProcessor() &&
-      amrex::Math::abs(sum - sum0) > 0) {
+      std::abs(sum - sum0) > 0) {
       amrex::Print() << "(rho E) added from reset terms                 : "
                      << sum - sum0 << " out of " << sum0 << std::endl;
     }

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -649,8 +649,7 @@ PeleC::initData()
     amrex::max<amrex::Real>(AMREX_D_DECL(
       static_cast<amrex::Real>(0.0),
       static_cast<amrex::Real>(std::abs(dx[0] - dx[1])),
-      static_cast<amrex::Real>(std::abs(dx[0] - dx[2])))) >
-    small * dx[0]) {
+      static_cast<amrex::Real>(std::abs(dx[0] - dx[2])))) > small * dx[0]) {
     amrex::Abort("dx != dy != dz not supported");
   }
 #endif
@@ -1078,8 +1077,7 @@ PeleC::post_timestep(int iteration)
     if (sum_per > 0.0) {
       const int num_per_old =
         static_cast<int>(std::floor((cumtime - dtlev) / sum_per));
-      const int num_per_new =
-        static_cast<int>(std::floor((cumtime) / sum_per));
+      const int num_per_new = static_cast<int>(std::floor((cumtime) / sum_per));
 
       if (num_per_old != num_per_new) {
         sum_per_test = true;
@@ -1219,8 +1217,7 @@ PeleC::post_init(amrex::Real /*stop_time*/)
   if (sum_per > 0.0) {
     const int num_per_old =
       static_cast<int>(std::floor((cumtime - dtlev) / sum_per));
-    const int num_per_new =
-      static_cast<int>(std::floor((cumtime) / sum_per));
+    const int num_per_new = static_cast<int>(std::floor((cumtime) / sum_per));
 
     if (num_per_old != num_per_new) {
       sum_per_test = true;
@@ -1930,9 +1927,7 @@ PeleC::reset_internal_energy(amrex::MultiFab& S_new, int ng)
     amrex::Real sum = volWgtSumMF(S_new, Eden, true);
     amrex::ParallelDescriptor::ReduceRealSum(sum0);
     amrex::ParallelDescriptor::ReduceRealSum(sum);
-    if (
-      amrex::ParallelDescriptor::IOProcessor() &&
-      std::abs(sum - sum0) > 0) {
+    if (amrex::ParallelDescriptor::IOProcessor() && std::abs(sum - sum0) > 0) {
       amrex::Print() << "(rho E) added from reset terms                 : "
                      << sum - sum0 << " out of " << sum0 << std::endl;
     }

--- a/Source/Riemann.H
+++ b/Source/Riemann.H
@@ -70,8 +70,8 @@ riemann(
   amrex::Real po = mask ? pl : pr;
 
   mask =
-    amrex::Math::abs(ustar) < constants::smallu() * 0.5 *
-                                (amrex::Math::abs(ul) + amrex::Math::abs(ur)) ||
+    std::abs(ustar) < constants::smallu() * 0.5 *
+                                (std::abs(ul) + std::abs(ur)) ||
     ustar == 0.0;
   ustar = mask ? 0.0 : ustar;
   ro = 0.0;
@@ -109,7 +109,7 @@ riemann(
   amrex::Real cstar;
   eos.RPY2Cs(gdnv_state_rho, gdnv_state_p, gdnv_state_massfrac, cstar);
 
-  const amrex::Real sgnm = amrex::Math::copysign(1.0, ustar);
+  const amrex::Real sgnm = std::copysign(1.0, ustar);
 
   amrex::Real spout = co - sgnm * uo;
   amrex::Real spin = cstar - sgnm * ustar;
@@ -120,7 +120,7 @@ riemann(
   spin = mask ? spin : ushock;
 
   const amrex::Real scr =
-    (amrex::Math::abs(spout - spin) < constants::very_small_num())
+    (std::abs(spout - spin) < constants::very_small_num())
       ? constants::small_num() * cav
       : spout - spin;
   const amrex::Real frac = amrex::max<amrex::Real>(
@@ -250,13 +250,13 @@ laxfriedrich_flux(
   ustar = ((wl * ul + wr * ur) + (pl - pr)) / (wl + wr);
 
   bool mask =
-    amrex::Math::abs(ustar) < constants::smallu() * 0.5 *
-                                (amrex::Math::abs(ul) + amrex::Math::abs(ur)) ||
+    std::abs(ustar) < constants::smallu() * 0.5 *
+                                (std::abs(ul) + std::abs(ur)) ||
     ustar == 0.0;
   ustar = mask ? 0.0 : ustar;
 
   amrex::Real chalf = 0.5 * (cr + cl);
-  amrex::Real max_wavespd = amrex::Math::abs(ustar) + chalf;
+  amrex::Real max_wavespd = std::abs(ustar) + chalf;
 
   maxeigval = max_wavespd;
 

--- a/Source/Riemann.H
+++ b/Source/Riemann.H
@@ -69,10 +69,9 @@ riemann(
   amrex::Real uo = mask ? ul : ur;
   amrex::Real po = mask ? pl : pr;
 
-  mask =
-    std::abs(ustar) < constants::smallu() * 0.5 *
-                                (std::abs(ul) + std::abs(ur)) ||
-    ustar == 0.0;
+  mask = std::abs(ustar) <
+           constants::smallu() * 0.5 * (std::abs(ul) + std::abs(ur)) ||
+         ustar == 0.0;
   ustar = mask ? 0.0 : ustar;
   ro = 0.0;
   for (int n = 0; n < NUM_SPECIES; n++) {
@@ -119,10 +118,9 @@ riemann(
   spout = mask ? spout : ushock;
   spin = mask ? spin : ushock;
 
-  const amrex::Real scr =
-    (std::abs(spout - spin) < constants::very_small_num())
-      ? constants::small_num() * cav
-      : spout - spin;
+  const amrex::Real scr = (std::abs(spout - spin) < constants::very_small_num())
+                            ? constants::small_num() * cav
+                            : spout - spin;
   const amrex::Real frac = amrex::max<amrex::Real>(
     0.0, amrex::min<amrex::Real>(1.0, (1.0 + (spout + spin) / scr) * 0.5));
 
@@ -249,10 +247,9 @@ laxfriedrich_flux(
   const amrex::Real wr = amrex::max<amrex::Real>(wsmall, cr * rr);
   ustar = ((wl * ul + wr * ur) + (pl - pr)) / (wl + wr);
 
-  bool mask =
-    std::abs(ustar) < constants::smallu() * 0.5 *
-                                (std::abs(ul) + std::abs(ur)) ||
-    ustar == 0.0;
+  bool mask = std::abs(ustar) <
+                constants::smallu() * 0.5 * (std::abs(ul) + std::abs(ur)) ||
+              ustar == 0.0;
   ustar = mask ? 0.0 : ustar;
 
   amrex::Real chalf = 0.5 * (cr + cl);

--- a/Source/Tagging.H
+++ b/Source/Tagging.H
@@ -97,15 +97,15 @@ tag_graderror(
 {
   // Tag on regions of high field gradient
   AMREX_D_TERM(
-    amrex::Real ax = amrex::Math::abs(field(i + 1, j, k) - field(i, j, k));
+    amrex::Real ax = std::abs(field(i + 1, j, k) - field(i, j, k));
     ax = amrex::max<amrex::Real>(
-      ax, amrex::Math::abs(field(i, j, k) - field(i - 1, j, k)));
-    , amrex::Real ay = amrex::Math::abs(field(i, j + 1, k) - field(i, j, k));
+      ax, std::abs(field(i, j, k) - field(i - 1, j, k)));
+    , amrex::Real ay = std::abs(field(i, j + 1, k) - field(i, j, k));
     ay = amrex::max<amrex::Real>(
-      ay, amrex::Math::abs(field(i, j, k) - field(i, j - 1, k)));
-    , amrex::Real az = amrex::Math::abs(field(i, j, k + 1) - field(i, j, k));
+      ay, std::abs(field(i, j, k) - field(i, j - 1, k)));
+    , amrex::Real az = std::abs(field(i, j, k + 1) - field(i, j, k));
     az = amrex::max<amrex::Real>(
-      az, amrex::Math::abs(field(i, j, k) - field(i, j, k - 1)));)
+      az, std::abs(field(i, j, k) - field(i, j, k - 1)));)
 #if AMREX_SPACEDIM > 1
   if (amrex::max<amrex::Real>(AMREX_D_DECL(ax, ay, az)) >= fieldgrad)
 #elif AMREX_SPACEDIM == 1
@@ -130,19 +130,19 @@ tag_ratioerror(
 {
   // Tag on regions of high ratio of adacent cell values in field
   AMREX_D_TERM(
-    amrex::Real axp1 = amrex::Math::abs(field(i + 1, j, k) / field(i, j, k));
+    amrex::Real axp1 = std::abs(field(i + 1, j, k) / field(i, j, k));
     axp1 = amrex::max<amrex::Real>(axp1, 1.0 / axp1);
-    amrex::Real axm1 = amrex::Math::abs(field(i - 1, j, k) / field(i, j, k));
+    amrex::Real axm1 = std::abs(field(i - 1, j, k) / field(i, j, k));
     axm1 = amrex::max<amrex::Real>(axm1, 1.0 / axm1);
     amrex::Real ax = amrex::max<amrex::Real>(axm1, axp1);
-    , amrex::Real ayp1 = amrex::Math::abs(field(i, j + 1, k) / field(i, j, k));
+    , amrex::Real ayp1 = std::abs(field(i, j + 1, k) / field(i, j, k));
     ayp1 = amrex::max<amrex::Real>(ayp1, 1.0 / ayp1);
-    amrex::Real aym1 = amrex::Math::abs(field(i, j - 1, k) / field(i, j, k));
+    amrex::Real aym1 = std::abs(field(i, j - 1, k) / field(i, j, k));
     aym1 = amrex::max<amrex::Real>(aym1, 1.0 / aym1);
     amrex::Real ay = amrex::max<amrex::Real>(aym1, ayp1);
-    , amrex::Real azp1 = amrex::Math::abs(field(i, j, k + 1) / field(i, j, k));
+    , amrex::Real azp1 = std::abs(field(i, j, k + 1) / field(i, j, k));
     azp1 = amrex::max<amrex::Real>(azp1, 1.0 / azp1);
-    amrex::Real azm1 = amrex::Math::abs(field(i, j, k - 1) / field(i, j, k));
+    amrex::Real azm1 = std::abs(field(i, j, k - 1) / field(i, j, k));
     azm1 = amrex::max<amrex::Real>(azm1, 1.0 / azm1);
     amrex::Real az = amrex::max<amrex::Real>(azm1, azp1);)
 #if AMREX_SPACEDIM > 1
@@ -168,7 +168,7 @@ tag_abserror(
   char tagval) noexcept
 {
   // Tag on regions of high field values
-  if (amrex::Math::abs(field(i, j, k)) >= fielderr) {
+  if (std::abs(field(i, j, k)) >= fielderr) {
     tag(i, j, k) = tagval;
   }
 }

--- a/Source/Tagging.H
+++ b/Source/Tagging.H
@@ -96,16 +96,15 @@ tag_graderror(
   char tagval) noexcept
 {
   // Tag on regions of high field gradient
-  AMREX_D_TERM(
-    amrex::Real ax = std::abs(field(i + 1, j, k) - field(i, j, k));
-    ax = amrex::max<amrex::Real>(
-      ax, std::abs(field(i, j, k) - field(i - 1, j, k)));
-    , amrex::Real ay = std::abs(field(i, j + 1, k) - field(i, j, k));
-    ay = amrex::max<amrex::Real>(
-      ay, std::abs(field(i, j, k) - field(i, j - 1, k)));
-    , amrex::Real az = std::abs(field(i, j, k + 1) - field(i, j, k));
-    az = amrex::max<amrex::Real>(
-      az, std::abs(field(i, j, k) - field(i, j, k - 1)));)
+  AMREX_D_TERM(amrex::Real ax = std::abs(field(i + 1, j, k) - field(i, j, k));
+               ax = amrex::max<amrex::Real>(
+                 ax, std::abs(field(i, j, k) - field(i - 1, j, k)));
+               , amrex::Real ay = std::abs(field(i, j + 1, k) - field(i, j, k));
+               ay = amrex::max<amrex::Real>(
+                 ay, std::abs(field(i, j, k) - field(i, j - 1, k)));
+               , amrex::Real az = std::abs(field(i, j, k + 1) - field(i, j, k));
+               az = amrex::max<amrex::Real>(
+                 az, std::abs(field(i, j, k) - field(i, j, k - 1)));)
 #if AMREX_SPACEDIM > 1
   if (amrex::max<amrex::Real>(AMREX_D_DECL(ax, ay, az)) >= fieldgrad)
 #elif AMREX_SPACEDIM == 1

--- a/Source/Timestep.H
+++ b/Source/Timestep.H
@@ -70,13 +70,13 @@ pc_estdt_hydro(
       auto eos = pele::physics::PhysicsType::eos();
       eos.RTY2Cs(rho, T, massfrac, c);
       AMREX_D_TERM(const amrex::Real ux = u(i, j, k, UMX) * rhoInv;
-                   const amrex::Real dt1 = dx / (c + amrex::Math::abs(ux));
+                   const amrex::Real dt1 = dx / (c + std::abs(ux));
                    dt = amrex::min<amrex::Real>(dt, dt1);
                    , const amrex::Real uy = u(i, j, k, UMY) * rhoInv;
-                   const amrex::Real dt2 = dy / (c + amrex::Math::abs(uy));
+                   const amrex::Real dt2 = dy / (c + std::abs(uy));
                    dt = amrex::min<amrex::Real>(dt, dt2);
                    , const amrex::Real uz = u(i, j, k, UMZ) * rhoInv;
-                   const amrex::Real dt3 = dz / (c + amrex::Math::abs(uz));
+                   const amrex::Real dt3 = dz / (c + std::abs(uz));
                    dt = amrex::min<amrex::Real>(dt, dt3););
     }
   });

--- a/Source/WENO.H
+++ b/Source/WENO.H
@@ -96,7 +96,7 @@ weno_reconstruct_5z(const amrex::Real* s, amrex::Real& sm, amrex::Real& sp)
   beta[0] = (13.0 / 12.0) * pow(s[2] - 2.0 * s[3] + s[4], 2) +
             0.25 * pow(3.0 * s[2] - 4.0 * s[3] + s[4], 2);
 
-  amrex::Real tau = amrex::Math::abs(beta[2] - beta[0]);
+  amrex::Real tau = std::abs(beta[2] - beta[0]);
 
   beta[2] = 1.0 + (tau / (eps + beta[2])) * (tau / (eps + beta[2]));
   beta[1] = 1.0 + (tau / (eps + beta[1])) * (tau / (eps + beta[1]));
@@ -121,7 +121,7 @@ weno_reconstruct_5z(const amrex::Real* s, amrex::Real& sm, amrex::Real& sp)
   beta[0] = (13.0 / 12.0) * pow(s[2] - 2.0 * s[1] + s[0], 2) +
             0.25 * pow(3.0 * s[2] - 4.0 * s[1] + s[0], 2);
 
-  tau = amrex::Math::abs(beta[2] - beta[0]);
+  tau = std::abs(beta[2] - beta[0]);
 
   beta[2] = 1.0 + (tau / (eps + beta[2])) * (tau / (eps + beta[2]));
   beta[1] = 1.0 + (tau / (eps + beta[1])) * (tau / (eps + beta[1]));
@@ -181,7 +181,7 @@ weno_reconstruct_7z(const amrex::Real* s, amrex::Real& sm, amrex::Real& sp)
     s[4] * (11003.0 * s[4] - 17246.0 * s[5] + 4642.0 * s[6]) +
     s[5] * (7043.0 * s[5] - 3882.0 * s[6]) + 547.0 * (s[6] * s[6]);
 
-  amrex::Real tau = amrex::Math::abs(beta[3] - beta[0]);
+  amrex::Real tau = std::abs(beta[3] - beta[0]);
 
   beta[3] = 1.0 + (tau / (eps + beta[3])) * (tau / (eps + beta[3]));
   beta[2] = 1.0 + (tau / (eps + beta[2])) * (tau / (eps + beta[2]));
@@ -223,7 +223,7 @@ weno_reconstruct_7z(const amrex::Real* s, amrex::Real& sm, amrex::Real& sp)
     s[2] * (11003.0 * s[2] - 17246.0 * s[1] + 4642.0 * s[0]) +
     s[1] * (7043.0 * s[1] - 3882.0 * s[0]) + 547.0 * (s[0] * s[0]);
 
-  tau = amrex::Math::abs(beta[3] - beta[0]);
+  tau = std::abs(beta[3] - beta[0]);
 
   beta[3] = 1.0 + (tau / (eps + beta[3])) * (tau / (eps + beta[3]));
   beta[2] = 1.0 + (tau / (eps + beta[2])) * (tau / (eps + beta[2]));
@@ -265,7 +265,7 @@ weno_reconstruct_3z(const amrex::Real* s, amrex::Real& sm, amrex::Real& sp)
   beta[1] = (s[0] - s[1]) * (s[0] - s[1]);
   beta[0] = (s[1] - s[2]) * (s[1] - s[2]);
 
-  amrex::Real tau = amrex::Math::abs(beta[1] - beta[0]);
+  amrex::Real tau = std::abs(beta[1] - beta[0]);
 
   beta[1] = 1.0 + (tau / (eps + beta[1])) * (tau / (eps + beta[1]));
   beta[0] = 1.0 + (tau / (eps + beta[0])) * (tau / (eps + beta[0]));
@@ -282,7 +282,7 @@ weno_reconstruct_3z(const amrex::Real* s, amrex::Real& sm, amrex::Real& sp)
   beta[1] = (s[2] - s[1]) * (s[2] - s[1]);
   beta[0] = (s[1] - s[0]) * (s[1] - s[0]);
 
-  tau = amrex::Math::abs(beta[1] - beta[0]);
+  tau = std::abs(beta[1] - beta[0]);
 
   beta[1] = 1.0 + (tau / (eps + beta[1])) * (tau / (eps + beta[1]));
   beta[0] = 1.0 + (tau / (eps + beta[0])) * (tau / (eps + beta[0]));


### PR DESCRIPTION
Per https://github.com/AMReX-Codes/amrex/pull/3164 we don't need `amrex::Math` anymore

merge https://github.com/AMReX-Combustion/PelePhysics/pull/362 first