### PR TITLE
Landon/add spray post func

### DIFF
--- a/CMake/BuildPeleCExe.cmake
+++ b/CMake/BuildPeleCExe.cmake
@@ -40,6 +40,7 @@ function(build_pelec_exe pelec_exe_name pelec_lib_name)
                    ${PELEMP_SRC_DIR}/PP_Spray/SprayDerive.cpp
                    ${PELEMP_SRC_DIR}/PP_Spray/SprayJet.H
                    ${PELEMP_SRC_DIR}/PP_Spray/SprayJet.cpp
+                   ${PELEMP_SRC_DIR}/PP_Spray/SprayIO.cpp
                    ${PELEMP_SRC_DIR}/PP_Spray/WallFunctions.H
                    ${PELEMP_SRC_DIR}/PP_Spray/Distribution/DistBase.H
                    ${PELEMP_SRC_DIR}/PP_Spray/Distribution/Distributions.H

--- a/Exec/RegTests/Spray-Conv/Spray-Conv.inp
+++ b/Exec/RegTests/Spray-Conv/Spray-Conv.inp
@@ -64,13 +64,14 @@ particles.init_function = 1 # Use SprayParticlesInitInsert.cpp for initializatio
 particles.write_ascii_files = 0 # Do not write ascii output files
 
 particles.fuel_species = NC10H22
-# properties for decane
-particles.fuel_crit_temp = 617.8 # K
-particles.fuel_boil_temp = 447.27 # K
 particles.fuel_ref_temp = 298.15
-particles.fuel_latent = 3.5899E9
-particles.fuel_cp = 2.1921E7 # Cp at 298 K
-particles.fuel_rho = 0.640
+
+# properties for decane
+particles.NC10H22_crit_temp = 617.8 # K
+particles.NC10H22_boil_temp = 447.27 # K
+particles.NC10H22_latent = 3.5899E9
+particles.NC10H22_cp = 2.1921E7 # Cp at 298 K
+particles.NC10H22_rho = 0.640
 # Coefficients for saturation pressure using Antoine equation
 # These are from the NIST website
 # Last coefficient converts units, in this case bar, to dyne/cm^2

--- a/Exec/RegTests/Spray-Conv/Spray-Conv.inp
+++ b/Exec/RegTests/Spray-Conv/Spray-Conv.inp
@@ -43,14 +43,14 @@ amr.max_level       = 2       # maximum level number allowed
 amr.ref_ratio       = 2 2 2 2 # refinement ratio
 amr.max_grid_size     = 32
 amr.blocking_factor   = 32
-amr.initial_grid_file = two_d_gridfiles/gridfile_32_1
-amr.regrid_file = two_d_gridfiles/gridfile_32_2
+amr.initial_grid_file = gridfile_32_1.dat
+amr.regrid_file = gridfile_32_2.dat
 # amr.max_grid_size     = 64
 # amr.blocking_factor   = 64
-# amr.initial_grid_file = two_d_gridfiles/gridfile_64_1
-# amr.regrid_file = two_d_gridfiles/gridfile_64_2
+# amr.initial_grid_file = gridfile_64_1.dat
+# amr.regrid_file = gridfile_64_2.dat
 
-amr.regrid_int        = 2 2 2 2
+amr.regrid_int      = 2 2 2 2
 amr.n_error_buf     = 2 2 2 2 # number of buffer cells in error est
 
 # PARTICLES / SPRAY
@@ -60,9 +60,8 @@ particles.v = 0
 particles.mom_transfer = 1
 particles.mass_transfer = 1
 particles.cfl = 0.5
-#particles.init_file = "initspraydata"
 particles.init_function = 1 # Use SprayParticlesInitInsert.cpp for initialization
-particles.write_spray_ascii_files = 0 # Do not write ascii output files
+particles.write_ascii_files = 0 # Do not write ascii output files
 
 particles.fuel_species = NC10H22
 # properties for decane

--- a/Source/Particle.cpp
+++ b/Source/Particle.cpp
@@ -74,7 +74,11 @@ PeleC::defineParticles()
   if (SPRAY_FUEL_NUM > NUM_SPECIES) {
     amrex::Abort("Cannot have more spray fuel species than fluid species");
   }
-  SprayParticleContainer::spraySetup(sprayData);
+  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> ext_force = {0.0};
+  for (int i = 0; i < static_cast<int>(external_forcing.size()); i++) {
+    ext_force[i] = external_forcing[i];
+  }
+  SprayParticleContainer::spraySetup(sprayData, ext_force.data());
   scomps.rhoIndx = PeleC::Density;
   scomps.momIndx = PeleC::Xmom;
   scomps.engIndx = PeleC::Eden;

--- a/Source/Particle.cpp
+++ b/Source/Particle.cpp
@@ -194,6 +194,7 @@ PeleC::initParticles()
         "Must initialize spray particles with particles.init_function or "
         "particles.init_file");
     }
+    SprayPC->PostInitRestart();
   }
 }
 
@@ -215,6 +216,7 @@ PeleC::postRestartParticles(bool is_checkpoint)
     SprayPC->InitSprayParticles(false, *lprobparm, *lprobparm_d);
     {
       SprayPC->Restart(parent->theRestartFile(), "particles", is_checkpoint);
+      SprayPC->PostInitRestart(parent->theRestartFile());
       amrex::Gpu::Device::streamSynchronize();
     }
   }

--- a/Source/PeleCAmr.cpp
+++ b/Source/PeleCAmr.cpp
@@ -110,9 +110,8 @@ PeleCAmr::constructPlotMF(
     }
 #ifdef PELEC_USE_SPRAY
     // Add spray derive variables
-    if (!SprayParticleContainer::spray_derive_vars.empty()) {
-      num_derive +=
-        static_cast<int>(SprayParticleContainer::spray_derive_vars.size());
+    if (SprayParticleContainer::NumDeriveVars() > 0) {
+      num_derive += SprayParticleContainer::NumDeriveVars();
     }
 #endif
   }
@@ -160,9 +159,8 @@ PeleCAmr::constructPlotMF(
     }
 
 #ifdef PELEC_USE_SPRAY
-    if (!SprayParticleContainer::spray_derive_vars.empty() && regular) {
-      const int num_spray_derive =
-        static_cast<int>(SprayParticleContainer::spray_derive_vars.size());
+    if (SprayParticleContainer::NumDeriveVars() > 0 && regular) {
+      const int num_spray_derive = SprayParticleContainer::NumDeriveVars();
       PeleC::setupVirtualParticles(lev, finestLevel());
       plotMFs[lev]->setVal(0., cnt, num_spray_derive);
       // Compute derived spray variables for active particles
@@ -205,9 +203,9 @@ PeleCAmr::constructPlotMF(
   }
 
 #ifdef PELEC_USE_SPRAY
-  if (!SprayParticleContainer::spray_derive_vars.empty() && regular) {
+  if (SprayParticleContainer::NumDeriveVars() > 0 && regular) {
     for (const auto& spray_derive_name :
-         SprayParticleContainer::spray_derive_vars) {
+         SprayParticleContainer::DeriveVarNames()) {
       plt_var_names.push_back(spray_derive_name);
     }
   }


### PR DESCRIPTION
This updates the spray inputs to match the changes in PeleMP. Adds the body force input to the spray data and the post initialize or restart call for spray routines. Also updates the MP submodule.