### PR TITLE
Rogue omp pragma near new ParallelFor

### DIFF
--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -1899,9 +1899,6 @@ PeleC::reset_internal_energy(amrex::MultiFab& S_new, int ng)
 #endif
 
   // Ensure (rho e) isn't too small or negative
-#ifdef AMREX_USE_OMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
   {
     const auto captured_allow_small_energy = allow_small_energy;
     const auto captured_allow_negative_energy = allow_negative_energy;


### PR DESCRIPTION
I'm pretty sure this is extraneous and just got left behind when the ParallelFors were switched over to multifab ParallelFors. With the OMP pragma, I get a nested/multiple MultiFab error when running with multiple OMP threads, but things work without it.