### PR TITLE
Simplify spray data

### DIFF
--- a/Exec/RegTests/Spray-Conv/Spray-Conv.inp
+++ b/Exec/RegTests/Spray-Conv/Spray-Conv.inp
@@ -60,7 +60,6 @@ particles.v = 0
 particles.mom_transfer = 1
 particles.mass_transfer = 1
 particles.cfl = 0.5
-particles.init_function = 1 # Use SprayParticlesInitInsert.cpp for initialization
 particles.write_ascii_files = 0 # Do not write ascii output files
 
 particles.fuel_species = NC10H22

--- a/Source/IO.cpp
+++ b/Source/IO.cpp
@@ -259,7 +259,7 @@ PeleC::checkPoint(
 
 #ifdef PELEC_USE_SPRAY
   if (SprayPC != nullptr) {
-    SprayPC->SprayParticleIO(level, true, 0, dir);
+    SprayPC->SprayParticleIO(level, true, dir);
   }
 #endif
 

--- a/Source/Particle.cpp
+++ b/Source/Particle.cpp
@@ -70,7 +70,7 @@ PeleC::defineParticles()
     ext_force[i] = external_forcing[i];
   }
   SprayParticleContainer::spraySetup(ext_force.data());
-  SprayData scomps;
+  SprayComps scomps;
   scomps.rhoIndx = PeleC::Density;
   scomps.momIndx = PeleC::Xmom;
   scomps.engIndx = PeleC::Eden;
@@ -185,7 +185,7 @@ PeleC::initParticles()
 }
 
 void
-PeleC::postRestartParticles(bool is_checkpoint)
+PeleC::postRestartParticles()
 {
   if (level > 0) {
     defineSpraySource(parent->MaxRefRatio(level - 1));
@@ -199,7 +199,7 @@ PeleC::postRestartParticles(bool is_checkpoint)
 
     const ProbParmHost* lprobparm = prob_parm_host;
     const ProbParmDevice* lprobparm_d = h_prob_parm_device;
-    SprayPC->InitSprayParticles(
+    SprayPC->SprayInitialize(
       *lprobparm, *lprobparm_d, parent->theRestartFile());
     amrex::Gpu::Device::streamSynchronize();
   }

--- a/Source/Particle.cpp
+++ b/Source/Particle.cpp
@@ -4,26 +4,19 @@
 namespace {
 bool virtual_particles_set = false;
 
-SprayData sprayData;
 // Indices for spray source MultiFab
 int sprayRhoSrcIndx = 0;
 int sprayMomSrcIndx = 1;
 int sprayEngSrcIndx = 1 + AMREX_SPACEDIM;
 int spraySpecSrcIndx = 2 + AMREX_SPACEDIM;
-SprayComps scomps;
 
-std::string init_file;
-int init_function = 1;
 int particle_verbose = 0;
-amrex::Real particle_cfl = 0.5;
-int plot_spray_src = 0;
 } // namespace
 
 std::unique_ptr<SprayParticleContainer> PeleC::SprayPC = nullptr;
 std::unique_ptr<SprayParticleContainer> PeleC::VirtPC = nullptr;
 std::unique_ptr<SprayParticleContainer> PeleC::GhostPC = nullptr;
 
-int PeleC::write_spray_ascii_files = 0;
 // momentum + density + fuel species + energy
 int PeleC::num_spray_src = AMREX_SPACEDIM + 2 + SPRAY_FUEL_NUM;
 
@@ -34,7 +27,7 @@ PeleC::estTimeStepParticles(amrex::Real& est_dt)
     return;
   }
   BL_PROFILE("PeleC::particleEstTimeStep()");
-  amrex::Real est_dt_particle = SprayPC->estTimestep(level, particle_cfl);
+  amrex::Real est_dt_particle = SprayPC->estTimestep(level);
 
   if (est_dt_particle > 0) {
     est_dt = amrex::min<amrex::Real>(est_dt, est_dt_particle);
@@ -57,9 +50,7 @@ PeleC::readSprayParams()
 
   pp.query("do_spray_particles", do_spray_particles);
   if (do_spray_particles) {
-    SprayParticleContainer::readSprayParams(
-      particle_verbose, particle_cfl, write_spray_ascii_files, plot_spray_src,
-      init_function, init_file, sprayData);
+    SprayParticleContainer::readSprayParams(particle_verbose);
   }
 }
 
@@ -78,7 +69,8 @@ PeleC::defineParticles()
   for (int i = 0; i < static_cast<int>(external_forcing.size()); i++) {
     ext_force[i] = external_forcing[i];
   }
-  SprayParticleContainer::spraySetup(sprayData, ext_force.data());
+  SprayParticleContainer::spraySetup(ext_force.data());
+  SprayData scomps;
   scomps.rhoIndx = PeleC::Density;
   scomps.momIndx = PeleC::Xmom;
   scomps.engIndx = PeleC::Eden;
@@ -88,6 +80,7 @@ PeleC::defineParticles()
   scomps.momSrcIndx = sprayMomSrcIndx;
   scomps.specSrcIndx = spraySpecSrcIndx;
   scomps.engSrcIndx = sprayEngSrcIndx;
+  SprayParticleContainer::AssignSprayComps(scomps);
 }
 
 int
@@ -165,13 +158,10 @@ PeleC::removeGhostParticles(const int level)
 void
 PeleC::createDataParticles()
 {
-  SprayPC = std::make_unique<SprayParticleContainer>(
-    parent, &phys_bc, sprayData, scomps);
+  SprayPC = std::make_unique<SprayParticleContainer>(parent, &phys_bc);
   SprayPC->SetVerbose(particle_verbose);
-  VirtPC = std::make_unique<SprayParticleContainer>(
-    parent, &phys_bc, sprayData, scomps);
-  GhostPC = std::make_unique<SprayParticleContainer>(
-    parent, &phys_bc, sprayData, scomps);
+  VirtPC = std::make_unique<SprayParticleContainer>(parent, &phys_bc);
+  GhostPC = std::make_unique<SprayParticleContainer>(parent, &phys_bc);
 }
 
 // Initialize the particles on the grid at level 0
@@ -190,15 +180,7 @@ PeleC::initParticles()
 
     const ProbParmHost* lprobparm = prob_parm_host;
     const ProbParmDevice* lprobparm_d = h_prob_parm_device;
-    SprayPC->InitSprayParticles(true, *lprobparm, *lprobparm_d);
-    if (!init_file.empty()) {
-      SprayPC->InitFromAsciiFile(init_file, NSR_SPR);
-    } else if (init_function == 0) {
-      amrex::Abort(
-        "Must initialize spray particles with particles.init_function or "
-        "particles.init_file");
-    }
-    SprayPC->PostInitRestart();
+    SprayPC->SprayInitialize(*lprobparm, *lprobparm_d);
   }
 }
 
@@ -217,12 +199,8 @@ PeleC::postRestartParticles(bool is_checkpoint)
 
     const ProbParmHost* lprobparm = prob_parm_host;
     const ProbParmDevice* lprobparm_d = h_prob_parm_device;
-    SprayPC->InitSprayParticles(false, *lprobparm, *lprobparm_d);
-    {
-      SprayPC->Restart(parent->theRestartFile(), "particles", is_checkpoint);
-      SprayPC->PostInitRestart(parent->theRestartFile());
-      amrex::Gpu::Device::streamSynchronize();
-    }
+    SprayPC->InitSprayParticles(*lprobparm, *lprobparm_d, parent->theRestartFile());
+    amrex::Gpu::Device::streamSynchronize();
   }
 }
 

--- a/Source/Particle.cpp
+++ b/Source/Particle.cpp
@@ -199,7 +199,8 @@ PeleC::postRestartParticles(bool is_checkpoint)
 
     const ProbParmHost* lprobparm = prob_parm_host;
     const ProbParmDevice* lprobparm_d = h_prob_parm_device;
-    SprayPC->InitSprayParticles(*lprobparm, *lprobparm_d, parent->theRestartFile());
+    SprayPC->InitSprayParticles(
+      *lprobparm, *lprobparm_d, parent->theRestartFile());
     amrex::Gpu::Device::streamSynchronize();
   }
 }

--- a/Source/PeleC.H
+++ b/Source/PeleC.H
@@ -129,7 +129,7 @@ public:
   void createDataParticles();
 
   // How to initialize at restart
-  void postRestartParticles(bool is_checkpoint = true);
+  void postRestartParticles();
 
   // Post timestep particle functions
   void postTimeStepParticles(int iteration);

--- a/Source/PeleC.H
+++ b/Source/PeleC.H
@@ -182,9 +182,6 @@ public:
   // Number of source terms in temporary spray data
   static int num_spray_src;
 
-  // Should we write particle ascii files?
-  static int write_spray_ascii_files;
-
   static std::unique_ptr<SprayParticleContainer> SprayPC;
   static std::unique_ptr<SprayParticleContainer> VirtPC;
   static std::unique_ptr<SprayParticleContainer> GhostPC;

--- a/Source/PeleCAmr.cpp
+++ b/Source/PeleCAmr.cpp
@@ -296,8 +296,8 @@ PeleCAmr::writePlotFileDoit(
   }
 
 #ifdef PELEC_USE_SPRAY
-  if (do_spray_particles) {
-    if (PeleC::SprayPC != nullptr && regular) {
+  if (PeleC::SprayPC != nullptr) {
+    if (regular) {
       for (int lev = 0; lev < nlevels; ++lev) {
         PeleC::SprayPC->SprayParticleIO(lev, false, pltfile);
       }

--- a/Source/PeleCAmr.cpp
+++ b/Source/PeleCAmr.cpp
@@ -296,12 +296,14 @@ PeleCAmr::writePlotFileDoit(
   }
 
 #ifdef PELEC_USE_SPRAY
-  if (PeleC::SprayPC != nullptr && regular) {
-    for (int lev = 0; lev < nlevels; ++lev) {
-      PeleC::SprayPC->SprayParticleIO(lev, false, pltfile);
+  if (do_spray_particles) {
+    if (PeleC::SprayPC != nullptr && regular) {
+      for (int lev = 0; lev < nlevels; ++lev) {
+        PeleC::SprayPC->SprayParticleIO(lev, false, pltfile);
+      }
+    } else {
+      amrex::Abort("HDF5 particle writing incomplete");
     }
-  } else {
-    amrex::Abort("HDF5 particle writing incomplete");
   }
 #endif
 

--- a/Source/PeleCAmr.cpp
+++ b/Source/PeleCAmr.cpp
@@ -298,8 +298,7 @@ PeleCAmr::writePlotFileDoit(
 #ifdef PELEC_USE_SPRAY
   if (PeleC::SprayPC != nullptr && regular) {
     for (int lev = 0; lev < nlevels; ++lev) {
-      PeleC::SprayPC->SprayParticleIO(
-        lev, false, PeleC::write_spray_ascii_files, pltfile);
+      PeleC::SprayPC->SprayParticleIO(lev, false, pltfile);
     }
   } else {
     amrex::Abort("HDF5 particle writing incomplete");

--- a/Source/Setup.cpp
+++ b/Source/Setup.cpp
@@ -14,6 +14,10 @@ using namespace MASA;
 #include "IndexDefines.H"
 #include "prob.H"
 
+#ifdef PELEC_USE_SPRAY
+#include "SprayParticles.H"
+#endif
+
 #ifdef PELEC_USE_SOOT
 #include "SootModel.H"
 #endif

--- a/Source/Setup.cpp
+++ b/Source/Setup.cpp
@@ -686,6 +686,9 @@ PeleC::variableCleanUp()
   delete h_prob_parm_device;
   amrex::The_Arena()->free(d_prob_parm_device);
   trans_parms.deallocate();
+#ifdef PELEC_USE_SPRAY
+  SprayParticleContainer::SprayCleanUp();
+#endif
 }
 
 void


### PR DESCRIPTION
This is an attempt to better manage data associated with the spray class. Removed almost all spray variables in the empty name space in `Particle.cpp`. Also update the PeleMP submodule.