### PR TITLE
Remove sort in init EB and increase parallelism

### DIFF
--- a/Source/EB.H
+++ b/Source/EB.H
@@ -231,7 +231,6 @@ void pc_fill_bndry_grad_stencil_quadratic(
 
 void pc_fill_flux_interp_stencil(
   const amrex::Box& /*bx*/,
-  const amrex::Box /*unused*/,
   const int /*Nsten*/,
   const amrex::Array4<const amrex::Real>& /*fc*/,
   const amrex::Array4<const amrex::Real>& /*fa*/,

--- a/Source/EB.cpp
+++ b/Source/EB.cpp
@@ -392,7 +392,6 @@ pc_fill_bndry_grad_stencil_ls(
 void
 pc_fill_flux_interp_stencil(
   const amrex::Box& bx,
-  const amrex::Box /*fbx*/,
   const int Nsten,
   const amrex::Array4<const amrex::Real>& fc,
   const amrex::Array4<const amrex::Real>& fa,

--- a/Source/EBStencilTypes.H
+++ b/Source/EBStencilTypes.H
@@ -40,16 +40,4 @@ struct EBBndryGeom
   bool operator<(const EBBndryGeom& rhs) const { return iv < rhs.iv; }
 };
 
-#ifdef AMREX_USE_GPU
-// Comparison operator for device sort
-struct EBBndryGeomCmp
-{
-  AMREX_GPU_DEVICE
-  bool operator()(const EBBndryGeom& a, const EBBndryGeom& b)
-  {
-    return a.iv < b.iv;
-  }
-};
-#endif
-
 #endif

--- a/Source/InitEB.cpp
+++ b/Source/InitEB.cpp
@@ -209,8 +209,8 @@ PeleC::initialize_eb2_structs()
               const bool covered_cells =
                 flag_arr(iv).isCovered() &&
                 flag_arr(iv - amrex::IntVect::TheDimensionVector(dir))
-                .isCovered();
-              if ((afrac_arr(iv) < 1.0) && (!covered_cells)){
+                  .isCovered();
+              if ((afrac_arr(iv) < 1.0) && (!covered_cells)) {
                 const auto iface = fbox.index(iv);
                 const auto idx = d_cutface_offset[iface];
                 d_flux_interp_stencil[idx].iv = iv;

--- a/Source/InitEB.cpp
+++ b/Source/InitEB.cpp
@@ -89,7 +89,7 @@ PeleC::initialize_eb2_structs()
       auto const& flag_arr = flags.const_array(mfi);
 
       const auto nallcells = static_cast<int>(tbox.numPts());
-      amrex::Gpu::DeviceVector<int> cutcell_offset(nallcells);
+      amrex::Gpu::DeviceVector<int> cutcell_offset(nallcells, 0);
       auto* d_cutcell_offset = cutcell_offset.data();
       const auto ncutcells = amrex::Scan::PrefixSum<int>(
         nallcells,
@@ -182,7 +182,7 @@ PeleC::initialize_eb2_structs()
         const auto facecent_arr = (*facecent[dir])[mfi].const_array();
         const auto fbox = amrex::surroundingNodes(tbox, dir);
         const auto nallfaces = static_cast<int>(fbox.numPts());
-        amrex::Gpu::DeviceVector<int> cutfaces_offset(nallfaces);
+        amrex::Gpu::DeviceVector<int> cutfaces_offset(nallfaces, 0);
         auto* d_cutface_offset = cutfaces_offset.data();
         const auto ncutfaces = amrex::Scan::PrefixSum<int>(
           nallfaces,

--- a/Source/InitEB.cpp
+++ b/Source/InitEB.cpp
@@ -185,11 +185,6 @@ PeleC::initialize_eb2_structs()
       if (typ == amrex::FabType::singlevalued) {
         const auto afrac_arr = (*areafrac[dir])[mfi].array();
         const auto facecent_arr = (*facecent[dir])[mfi].array();
-
-        // This used to be an std::set for cut_faces (it ensured
-        // sorting and uniqueness)
-        EBBndryGeom* d_sv_eb_bndry_geom = sv_eb_bndry_geom[iLocal].data();
-
         const auto fbox = amrex::surroundingNodes(tbox, dir);
         const auto nallfaces = static_cast<int>(fbox.numPts());
         amrex::Gpu::DeviceVector<int> cutfaces_offset(nallfaces);

--- a/Source/InitEB.cpp
+++ b/Source/InitEB.cpp
@@ -201,7 +201,7 @@ PeleC::initialize_eb2_structs()
           amrex::ParallelFor(
             fbox, [=] AMREX_GPU_DEVICE(
                     int i, int j, int AMREX_D_PICK(, , k)) noexcept {
-              amrex::IntVect iv(amrex::IntVect(AMREX_D_DECL(i, j, k)));
+              const amrex::IntVect iv(amrex::IntVect(AMREX_D_DECL(i, j, k)));
               if (afrac_arr(iv) < 1.0) {
                 const auto iface = fbox.index(iv);
                 const auto idx = d_cutface_offset[iface];

--- a/Source/InitEB.cpp
+++ b/Source/InitEB.cpp
@@ -206,7 +206,11 @@ PeleC::initialize_eb2_structs()
             fbox, [=] AMREX_GPU_DEVICE(
                     int i, int j, int AMREX_D_PICK(, , k)) noexcept {
               const amrex::IntVect iv(amrex::IntVect(AMREX_D_DECL(i, j, k)));
-              if (afrac_arr(iv) < 1.0) {
+              const bool covered_cells =
+                flag_arr(iv).isCovered() &&
+                flag_arr(iv - amrex::IntVect::TheDimensionVector(dir))
+                .isCovered();
+              if ((afrac_arr(iv) < 1.0) && (!covered_cells)){
                 const auto iface = fbox.index(iv);
                 const auto idx = d_cutface_offset[iface];
                 d_flux_interp_stencil[idx].iv = iv;

--- a/Source/InitEB.cpp
+++ b/Source/InitEB.cpp
@@ -107,7 +107,8 @@ PeleC::initialize_eb2_structs()
         amrex::Scan::Type::exclusive);
       if (Ncut > 0) {
         amrex::ParallelFor(
-          tbox, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+          tbox,
+          [=] AMREX_GPU_DEVICE(int i, int j, int AMREX_D_PICK(, , k)) noexcept {
             amrex::IntVect iv(amrex::IntVect(AMREX_D_DECL(i, j, k)));
             if (flag_arr(iv).isSingleValued()) {
               const auto icell = tbox.index(iv);
@@ -198,7 +199,8 @@ PeleC::initialize_eb2_structs()
           flux_interp_stencil[dir][iLocal].resize(ncutfaces);
           auto* d_flux_interp_stencil = flux_interp_stencil[dir][iLocal].data();
           amrex::ParallelFor(
-            fbox, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+            fbox, [=] AMREX_GPU_DEVICE(
+                    int i, int j, int AMREX_D_PICK(, , k)) noexcept {
               amrex::IntVect iv(amrex::IntVect(AMREX_D_DECL(i, j, k)));
               if (afrac_arr(iv) < 1.0) {
                 const auto iface = fbox.index(iv);

--- a/Source/InitEB.cpp
+++ b/Source/InitEB.cpp
@@ -46,7 +46,7 @@ PeleC::initialize_eb2_structs()
 
   // These are the data sources
   amrex::MultiFab::Copy(vfrac, ebfactory.getVolFrac(), 0, 0, 1, numGrow());
-  const amrex::MultiCutFab* bndrycent = &(ebfactory.getBndryCent());
+  const auto* bndrycent = &(ebfactory.getBndryCent());
   areafrac = ebfactory.getAreaFrac();
   facecent = ebfactory.getFaceCent();
 
@@ -106,11 +106,11 @@ PeleC::initialize_eb2_structs()
 
       sv_eb_bndry_geom[iLocal].resize(ncutcells);
       if (ncutcells > 0) {
-        EBBndryGeom* d_sv_eb_bndry_geom = sv_eb_bndry_geom[iLocal].data();
+        auto* d_sv_eb_bndry_geom = sv_eb_bndry_geom[iLocal].data();
         amrex::ParallelFor(
           tbox,
           [=] AMREX_GPU_DEVICE(int i, int j, int AMREX_D_PICK(, , k)) noexcept {
-            amrex::IntVect iv(amrex::IntVect(AMREX_D_DECL(i, j, k)));
+            const amrex::IntVect iv(amrex::IntVect(AMREX_D_DECL(i, j, k)));
             if (flag_arr(iv).isSingleValued()) {
               const auto icell = tbox.index(iv);
               const auto idx = d_cutcell_offset[icell];
@@ -120,11 +120,12 @@ PeleC::initialize_eb2_structs()
       }
 
       // Now fill the sv_eb_bndry_geom
-      auto const& vfrac_arr = vfrac.array(mfi);
-      auto const& bndrycent_arr = bndrycent->array(mfi);
-      AMREX_D_TERM(auto const& areafrac_arr_0 = areafrac[0]->array(mfi);
-                   , auto const& areafrac_arr_1 = areafrac[1]->array(mfi);
-                   , auto const& areafrac_arr_2 = areafrac[2]->array(mfi);)
+      auto const& vfrac_arr = vfrac.const_array(mfi);
+      auto const& bndrycent_arr = bndrycent->const_array(mfi);
+      AMREX_D_TERM(auto const& areafrac_arr_0 = areafrac[0]->const_array(mfi);
+                   , auto const& areafrac_arr_1 = areafrac[1]->const_array(mfi);
+                   ,
+                   auto const& areafrac_arr_2 = areafrac[2]->const_array(mfi);)
       pc_fill_sv_ebg(
         tbox, ncutcells, vfrac_arr, bndrycent_arr,
         AMREX_D_DECL(areafrac_arr_0, areafrac_arr_1, areafrac_arr_2),
@@ -179,8 +180,8 @@ PeleC::initialize_eb2_structs()
 
       if (typ == amrex::FabType::singlevalued) {
         auto const& flag_arr = flagfab.const_array();
-        const auto afrac_arr = (*areafrac[dir])[mfi].array();
-        const auto facecent_arr = (*facecent[dir])[mfi].array();
+        const auto afrac_arr = (*areafrac[dir])[mfi].const_array();
+        const auto facecent_arr = (*facecent[dir])[mfi].const_array();
         const auto fbox = amrex::surroundingNodes(tbox, dir);
         const auto nallfaces = static_cast<int>(fbox.numPts());
         amrex::Gpu::DeviceVector<int> cutfaces_offset(nallfaces);

--- a/Source/InitEB.cpp
+++ b/Source/InitEB.cpp
@@ -177,7 +177,8 @@ PeleC::initialize_eb2_structs()
       const amrex::FabType typ = flagfab.getType(tbox);
       const int iLocal = mfi.LocalIndex();
 
-      if (typ == amrex::FabType::singlevalued) {
+     if (typ == amrex::FabType::singlevalued) {
+        auto const& flag_arr = flagfab.const_array();
         const auto afrac_arr = (*areafrac[dir])[mfi].array();
         const auto facecent_arr = (*facecent[dir])[mfi].array();
         const auto fbox = amrex::surroundingNodes(tbox, dir);
@@ -188,7 +189,8 @@ PeleC::initialize_eb2_structs()
           nallfaces,
           [=] AMREX_GPU_DEVICE(int iface) -> int {
             const auto iv = fbox.atOffset(iface);
-            return static_cast<int>(afrac_arr(iv) < 1.0);
+            const bool covered_cells = flag_arr(iv).isCovered() && flag_arr(iv-amrex::IntVect::TheDimensionVector(dir)).isCovered();
+            return static_cast<int>((afrac_arr(iv) < 1.0) && (!covered_cells));
           },
           [=] AMREX_GPU_DEVICE(int iface, int const& x) {
             d_cutface_offset[iface] = x;

--- a/Source/InitEB.cpp
+++ b/Source/InitEB.cpp
@@ -122,13 +122,11 @@ PeleC::initialize_eb2_structs()
       // Now fill the sv_eb_bndry_geom
       auto const& vfrac_arr = vfrac.const_array(mfi);
       auto const& bndrycent_arr = bndrycent->const_array(mfi);
-      AMREX_D_TERM(auto const& areafrac_arr_0 = areafrac[0]->const_array(mfi);
-                   , auto const& areafrac_arr_1 = areafrac[1]->const_array(mfi);
-                   ,
-                   auto const& areafrac_arr_2 = areafrac[2]->const_array(mfi);)
+      AMREX_D_TERM(auto const& apx = areafrac[0]->const_array(mfi);
+                   , auto const& apy = areafrac[1]->const_array(mfi);
+                   , auto const& apz = areafrac[2]->const_array(mfi);)
       pc_fill_sv_ebg(
-        tbox, ncutcells, vfrac_arr, bndrycent_arr,
-        AMREX_D_DECL(areafrac_arr_0, areafrac_arr_1, areafrac_arr_2),
+        tbox, ncutcells, vfrac_arr, bndrycent_arr, AMREX_D_DECL(apx, apy, apz),
         sv_eb_bndry_geom[iLocal].data());
 
       // Fill in boundary gradient for cut cells in this grown tile

--- a/Source/InitEB.cpp
+++ b/Source/InitEB.cpp
@@ -177,7 +177,7 @@ PeleC::initialize_eb2_structs()
       const amrex::FabType typ = flagfab.getType(tbox);
       const int iLocal = mfi.LocalIndex();
 
-     if (typ == amrex::FabType::singlevalued) {
+      if (typ == amrex::FabType::singlevalued) {
         auto const& flag_arr = flagfab.const_array();
         const auto afrac_arr = (*areafrac[dir])[mfi].array();
         const auto facecent_arr = (*facecent[dir])[mfi].array();
@@ -189,7 +189,10 @@ PeleC::initialize_eb2_structs()
           nallfaces,
           [=] AMREX_GPU_DEVICE(int iface) -> int {
             const auto iv = fbox.atOffset(iface);
-            const bool covered_cells = flag_arr(iv).isCovered() && flag_arr(iv-amrex::IntVect::TheDimensionVector(dir)).isCovered();
+            const bool covered_cells =
+              flag_arr(iv).isCovered() &&
+              flag_arr(iv - amrex::IntVect::TheDimensionVector(dir))
+                .isCovered();
             return static_cast<int>((afrac_arr(iv) < 1.0) && (!covered_cells));
           },
           [=] AMREX_GPU_DEVICE(int iface, int const& x) {

--- a/Source/InitEB.cpp
+++ b/Source/InitEB.cpp
@@ -1,9 +1,3 @@
-// Need to include these before any other headers
-#ifdef AMREX_USE_SYCL
-#include <oneapi/dpl/algorithm>
-#include <oneapi/dpl/execution>
-#endif
-
 #include <memory>
 
 #include "AMReX_EB_Redistribution.H"

--- a/Source/Utilities.H
+++ b/Source/Utilities.H
@@ -406,69 +406,6 @@ locate(const amrex::Real* xtable, const int n, const amrex::Real& x, int& idxlo)
   }
 }
 
-template <typename T>
-void
-sort(T& vec)
-{
-  typename T::value_type* d_vec = vec.data();
-  const int vec_size = vec.size();
-  // Serial loop on the GPU
-  amrex::ParallelFor(1, [=] AMREX_GPU_DEVICE(int /*dummy*/) {
-    for (int i = 0; i < vec_size - 1; i++) {
-      for (int j = 0; j < vec_size - i - 1; j++) {
-        if (d_vec[j + 1] < d_vec[j]) {
-          typename T::value_type temp = d_vec[j];
-          d_vec[j] = d_vec[j + 1];
-          d_vec[j + 1] = temp;
-        }
-      }
-    }
-  });
-}
-
-// Return vector of unique elements in input. Assume input is sorted. This is
-// device safe code
-template <typename T>
-T
-unique(T input)
-{
-  typename T::value_type* d_input = input.data();
-  const int input_size = input.size();
-  if (input_size == 0) {
-    T output(input_size);
-    return output;
-  }
-
-  // count the number of uniques
-  const int Nunique = amrex::Reduce::Sum<int>(
-    input.size() - 1,
-    [=] AMREX_GPU_DEVICE(int i) noexcept -> int {
-      return (d_input[i] != d_input[i + 1]);
-    },
-    1);
-
-  // allocate the memory
-  T output(Nunique);
-  if (output.empty()) {
-    return output;
-  }
-  typename T::value_type* d_output = output.data();
-
-  // get the uniques
-  amrex::ParallelFor(1, [=] AMREX_GPU_DEVICE(int /*dummy*/) {
-    int cnt = 1;
-    d_output[0] = d_input[0];
-    for (int i = 0; i < input_size - 1; i++) {
-      if (d_input[i] != d_input[i + 1]) {
-        d_output[cnt] = d_input[i + 1];
-        cnt++;
-      }
-    }
-  });
-
-  return output;
-}
-
 // Find position of element in vector
 template <typename T>
 int

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -125,9 +125,7 @@ main(int argc, char* argv[])
 
   amrex::AmrLevel::SetEBSupportLevel(
     amrex::EBSupport::full); // need both area and volume fractions
-  amrex::AmrLevel::SetEBMaxGrowCells(
-    5, 5,
-    5); // 5 focdr ebcellflags, 4 for vfrac, 2 is not used for EBSupport::volume
+  amrex::AmrLevel::SetEBMaxGrowCells(6, 6, 6);
 
   initialize_EB2(
     amrptr->Geom(PeleC::getEBMaxLevel()), PeleC::getEBMaxLevel(),


### PR DESCRIPTION
This PR increases the parallelism in our definition of the EB structs, also it removes all the sort calls. 

EB-C1 on 1 CPU rank and no openmp shows no diffs.

Things left to do:
- [x] try CPU + MPI on a bigger problem
- [x] try GPU
- [x] profile the challenge problem
- [x] more clean up