### PR TITLE
Introduce mol_iorder flag

### DIFF
--- a/Docs/sphinx/Algorithms.rst
+++ b/Docs/sphinx/Algorithms.rst
@@ -459,7 +459,10 @@ where:
 .. math::
   \Delta^{lim} = \left\{ \begin{aligned} {} 2 \min\left\{ |\Delta^-|,|\Delta^+|\right\} \quad& \mathrm{if} \Delta^- \cdot \Delta^+ \ge 0 \\ 0 & \quad \mathrm{otherwise}\end{aligned}\right.
 
-The formulation of the y- and z-directions is analogous to the x-direction.
+The formulation of the y- and z-directions is analogous to the x-direction. One can control the order of the construction of the slopes with the ``mol_iorder`` flag:
+
+* ``mol_iorder = 1`` sets the slopes to zero;
+* ``mol_iorder = 2`` uses the procedure described above.
 
 
 Comparison of PPM and MOL for the decay of homogeneous isotropic turbulence

--- a/Exec/RegTests/MassCons/masscons-mol-1.inp
+++ b/Exec/RegTests/MassCons/masscons-mol-1.inp
@@ -18,7 +18,7 @@ pelec.hi_bc       = "Hard"       "Hard"       "Hard"
 prob.wall_type    = 1            0            1
 
 # WHICH PHYSICS
-pelec.plm_iorder = 1
+pelec.mol_iorder = 1
 pelec.do_hydro = 1
 pelec.do_mol = 1
 pelec.diffuse_vel = 1

--- a/Exec/RegTests/MassCons/masscons-mol-2.inp
+++ b/Exec/RegTests/MassCons/masscons-mol-2.inp
@@ -18,7 +18,7 @@ pelec.hi_bc       = "Hard"       "Hard"       "Hard"
 prob.wall_type    = 1            0            1
 
 # WHICH PHYSICS
-pelec.plm_iorder = 2
+pelec.mol_iorder = 2
 pelec.do_hydro = 1
 pelec.do_mol = 1
 pelec.diffuse_vel = 1

--- a/Source/Godunov.H
+++ b/Source/Godunov.H
@@ -100,8 +100,8 @@ AMREX_FORCE_INLINE
 void
 pc_transd_passive(
   const amrex::IntVect iv,
-  const amrex::IntVect ivp0,
-  const amrex::IntVect ivp1,
+  const amrex::IntVect ivpt,
+  const amrex::IntVect ivpn,
   const int n,
   const int u_offset,
   const int q_offset,
@@ -120,14 +120,14 @@ pc_transd_passive(
   const int uc = u_offset + n;
   const int qc = q_offset + n;
   const amrex::Real srcpass = srcQ(iv, qc);
-  const amrex::Real compn = cdtdx * (flxx(ivp0, uc) - flxx(iv, uc));
+  const amrex::Real compn = cdtdx * (flxx(ivpt, uc) - flxx(iv, uc));
   amrex::Real rrnew = rrr - flxrho;
   amrex::Real compo = rrr * qyp(iv, qc) - compn;
   qp(iv, qc) = compo / rrnew + hdt * srcpass;
 
   rrnew = rrl - flxrho;
-  compo = rrl * qym(ivp1, qc) - compn;
-  qm(ivp1, qc) = compo / rrnew + hdt * srcpass;
+  compo = rrl * qym(ivpn, qc) - compn;
+  qm(ivpn, qc) = compo / rrnew + hdt * srcpass;
 }
 
 AMREX_GPU_DEVICE
@@ -663,52 +663,56 @@ pc_transd(
   const amrex::Real cdtdx)
 {
   const amrex::IntVect iv{AMREX_D_DECL(i, j, k)};
-  const amrex::IntVect ivp0(
+  // ivpt is an offset by 1 in the transverse direction
+  // ivpn is an offset by 1 in the     normal direction
+  // If (dir == 0),  ivpt = (i,j+1) and ivpn = (i+1,j) and qvidx = GDV
+  // If (dir == 1),  ivpt = (i+1,j) and ivpn = (i,j+1) and qvidx = GDU
+  const amrex::IntVect ivpt(
     iv + amrex::IntVect::TheDimensionVector(dir == 0 ? 1 : 0));
-  const amrex::IntVect ivp1(
+  const amrex::IntVect ivpn(
     iv + amrex::IntVect::TheDimensionVector(dir == 0 ? 0 : 1));
   const int qvidx = (dir == 0) ? GDV : GDU;
 
-  const amrex::Real flxrho = cdtdx * (flxx(ivp0, URHO) - flxx(iv, URHO));
-  const amrex::Real flxu = cdtdx * (flxx(ivp0, UMX) - flxx(iv, UMX));
-  const amrex::Real flxv = cdtdx * (flxx(ivp0, UMY) - flxx(iv, UMY));
-  const amrex::Real flxe = cdtdx * (flxx(ivp0, UEDEN) - flxx(iv, UEDEN));
+  const amrex::Real flxrho = cdtdx * (flxx(ivpt, URHO) - flxx(iv, URHO));
+  const amrex::Real flxu = cdtdx * (flxx(ivpt, UMX) - flxx(iv, UMX));
+  const amrex::Real flxv = cdtdx * (flxx(ivpt, UMY) - flxx(iv, UMY));
+  const amrex::Real flxe = cdtdx * (flxx(ivpt, UEDEN) - flxx(iv, UEDEN));
   const amrex::Real srcr = srcQ(iv, QRHO);
   const amrex::Real srce = srcQ(iv, QREINT);
   const amrex::Real srcp = srcQ(iv, QPRES);
   const amrex::Real rrr = qyp(iv, QRHO);
-  const amrex::Real rrl = qym(ivp1, QRHO);
+  const amrex::Real rrl = qym(ivpn, QRHO);
   const amrex::Real c = qa(iv, QGAMC);
 
   // Update passive variables
 #if AMREX_SPACEDIM == 2
   pc_transd_passive(
-    iv, ivp0, ivp1, 0, UMZ, QW, cdtdx, hdt, flxrho, rrr, rrl, srcQ, qyp, qym,
+    iv, ivpt, ivpn, 0, UMZ, QW, cdtdx, hdt, flxrho, rrr, rrl, srcQ, qyp, qym,
     flxx, qp, qm);
 #endif
   for (int n = 0; n < NUM_ADV; n++) {
     pc_transd_passive(
-      iv, ivp0, ivp1, n, UFA, QFA, cdtdx, hdt, flxrho, rrr, rrl, srcQ, qyp, qym,
+      iv, ivpt, ivpn, n, UFA, QFA, cdtdx, hdt, flxrho, rrr, rrl, srcQ, qyp, qym,
       flxx, qp, qm);
   }
   for (int n = 0; n < NUM_SPECIES; n++) {
     pc_transd_passive(
-      iv, ivp0, ivp1, n, UFS, QFS, cdtdx, hdt, flxrho, rrr, rrl, srcQ, qyp, qym,
+      iv, ivpt, ivpn, n, UFS, QFS, cdtdx, hdt, flxrho, rrr, rrl, srcQ, qyp, qym,
       flxx, qp, qm);
   }
   for (int n = 0; n < NUM_AUX; n++) {
     pc_transd_passive(
-      iv, ivp0, ivp1, n, UFX, QFX, cdtdx, hdt, flxrho, rrr, rrl, srcQ, qyp, qym,
+      iv, ivpt, ivpn, n, UFX, QFX, cdtdx, hdt, flxrho, rrr, rrl, srcQ, qyp, qym,
       flxx, qp, qm);
   }
   for (int n = 0; n < NUM_LIN; n++) {
     pc_transd_passive(
-      iv, ivp0, ivp1, n, ULIN, QLIN, cdtdx, hdt, 0., 1., 1., srcQ, qyp, qym,
+      iv, ivpt, ivpn, n, ULIN, QLIN, cdtdx, hdt, 0., 1., 1., srcQ, qyp, qym,
       flxx, qp, qm);
   }
-  const amrex::Real pggp = qint(ivp0, GDPRES);
+  const amrex::Real pggp = qint(ivpt, GDPRES);
   const amrex::Real pggm = qint(iv, GDPRES);
-  const amrex::Real ugp = qint(ivp0, qvidx);
+  const amrex::Real ugp = qint(ivpt, qvidx);
   const amrex::Real ugm = qint(iv, qvidx);
 
   const amrex::Real dAup = pggp * ugp - pggm * ugm;
@@ -746,12 +750,12 @@ pc_transd(
   // QM
 
   // Conversion to Conservative
-  amrex::Real rul = qym(ivp1, QU);
-  amrex::Real rvl = qym(ivp1, QV);
+  amrex::Real rul = qym(ivpn, QU);
+  amrex::Real rvl = qym(ivpn, QV);
   const amrex::Real ekinl = 0.5 * rrl * (rul * rul + rvl * rvl);
   rul *= rrl;
   rvl *= rrl;
-  const amrex::Real rel = qym(ivp1, QREINT) + ekinl;
+  const amrex::Real rel = qym(ivpn, QREINT) + ekinl;
 
   // Transverse fluxes
   const amrex::Real rrnewl = rrl - flxrho;
@@ -759,16 +763,16 @@ pc_transd(
   const amrex::Real rvnewl = rvl - flxv;
   const amrex::Real renewl = rel - flxe;
 
-  qm(ivp1, QRHO) = rrnewl + hdt * srcr;
-  qm(ivp1, QU) = runewl / rrnewl + hdt * srcQ(iv, QU);
-  qm(ivp1, QV) = rvnewl / rrnewl + hdt * srcQ(iv, QV);
+  qm(ivpn, QRHO) = rrnewl + hdt * srcr;
+  qm(ivpn, QU) = runewl / rrnewl + hdt * srcQ(iv, QU);
+  qm(ivpn, QV) = rvnewl / rrnewl + hdt * srcQ(iv, QV);
   const amrex::Real rhoekinl =
     0.5 * (runewl * runewl + rvnewl * rvnewl) / rrnewl;
 
-  qm(ivp1, QREINT) = renewl - rhoekinl + hdt * srce;
+  qm(ivpn, QREINT) = renewl - rhoekinl + hdt * srce;
   const amrex::Real pnewl =
-    qym(ivp1, QPRES) - cdtdx * (dAup + pav * dAu * (c - 1.));
-  qm(ivp1, QPRES) = amrex::max<amrex::Real>(
+    qym(ivpn, QPRES) - cdtdx * (dAup + pav * dAu * (c - 1.));
+  qm(ivpn, QPRES) = amrex::max<amrex::Real>(
     pnewl + hdt * srcp, std::numeric_limits<amrex::Real>::min());
 }
 

--- a/Source/MOL.H
+++ b/Source/MOL.H
@@ -125,7 +125,7 @@ void pc_compute_hyp_mol_flux(
   const amrex::GpuArray<amrex::Array4<amrex::Real>, AMREX_SPACEDIM>& flx,
   const amrex::GpuArray<const amrex::Array4<const amrex::Real>, AMREX_SPACEDIM>&
     area,
-  const int plm_iorder,
+  const int mol_iorder,
   const bool use_laxf_flux,
   const amrex::Array4<amrex::EBCellFlag const>& flags);
 

--- a/Source/MOL.cpp
+++ b/Source/MOL.cpp
@@ -9,7 +9,7 @@ pc_compute_hyp_mol_flux(
   const amrex::GpuArray<amrex::Array4<amrex::Real>, AMREX_SPACEDIM>& flx,
   const amrex::GpuArray<const amrex::Array4<const amrex::Real>, AMREX_SPACEDIM>&
     area,
-  const int plm_iorder,
+  const int mol_iorder,
   const bool use_laxf_flux,
   const amrex::Array4<amrex::EBCellFlag const>& flags)
 {
@@ -41,7 +41,7 @@ pc_compute_hyp_mol_flux(
        bdim[0] * UMY + bdim[1] * UMX + bdim[2] * UMX,
        bdim[0] * UMZ + bdim[1] * UMZ + bdim[2] * UMY}};
 
-    if (plm_iorder != 1) {
+    if (mol_iorder != 1) {
       amrex::ParallelFor(
         cbox, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
           mol_slope(i, j, k, dir, q_idx, q, qaux, dq, flags);

--- a/Source/Params/_cpp_parameters
+++ b/Source/Params/_cpp_parameters
@@ -107,6 +107,9 @@ ppm_trace_sources           bool           false
 # for piecewise linear, reconstruction order to use
 plm_iorder                   int           4
 
+# for mol, reconstruction order to use
+mol_iorder                   int           2
+
 # Lax Friedrich's flux
 use_laxf_flux               bool           false
 

--- a/Source/Params/param_includes/pelec_defaults.H
+++ b/Source/Params/param_includes/pelec_defaults.H
@@ -34,6 +34,7 @@ amrex::Real PeleC::forcing_force = 0.0;
 int PeleC::ppm_type = 0;
 bool PeleC::ppm_trace_sources = false;
 int PeleC::plm_iorder = 4;
+int PeleC::mol_iorder = 2;
 bool PeleC::use_laxf_flux = false;
 bool PeleC::use_flattening = true;
 bool PeleC::dual_energy_update_E_from_e = true;

--- a/Source/Params/param_includes/pelec_params.H
+++ b/Source/Params/param_includes/pelec_params.H
@@ -34,6 +34,7 @@ static amrex::Real forcing_force;
 static int ppm_type;
 static bool ppm_trace_sources;
 static int plm_iorder;
+static int mol_iorder;
 static bool use_laxf_flux;
 static bool use_flattening;
 static bool dual_energy_update_E_from_e;

--- a/Source/Params/param_includes/pelec_queries.H
+++ b/Source/Params/param_includes/pelec_queries.H
@@ -40,6 +40,7 @@ pp.query("forcing_force", forcing_force);
 pp.query("ppm_type", ppm_type);
 pp.query("ppm_trace_sources", ppm_trace_sources);
 pp.query("plm_iorder", plm_iorder);
+pp.query("mol_iorder", mol_iorder);
 pp.query("use_laxf_flux", use_laxf_flux);
 pp.query("use_flattening", use_flattening);
 pp.query("dual_energy_update_E_from_e", dual_energy_update_E_from_e);

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -338,14 +338,12 @@ PeleC::read_params()
 
   if (do_hydro) {
     if (do_mol) {
-      if ((plm_iorder != 1) && (plm_iorder != 2)) {
-        amrex::Warning(
-          "PeleC::plm_iorder for MOL must be 1, or 2. Setting it to 2.");
-        plm_iorder = 2;
+      if ((mol_iorder != 1) && (mol_iorder != 2)) {
+        amrex::Error("PeleC::mol_iorder must be 1, or 2.");
       }
     } else if (ppm_type == 0) {
       if ((plm_iorder != 1) && (plm_iorder != 2) && (plm_iorder != 4)) {
-        amrex::Error("PeleC::plm_iorder for ppm_type = 0 must be 1, 2, or 4");
+        amrex::Error("PeleC::plm_iorder must be 1, 2, or 4");
       }
     }
   }


### PR DESCRIPTION
This is better than overloading the `plm_iorder` flag to reuse in MOL (I think). 