### PR TITLE
Fix datlog and update amrex

### DIFF
--- a/Exec/RegTests/MassCons/masscons-mol-1.inp
+++ b/Exec/RegTests/MassCons/masscons-mol-1.inp
@@ -42,7 +42,7 @@ pelec.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 pelec.sum_interval   = 1       # timesteps between computing mass
 pelec.v              = 1       # verbosity in PeleC.cpp
 amr.v                = 1       # verbosity in Amr.cpp
-amr.data_log         = datalog
+amr.data_log         = datlog
 
 # REFINEMENT / REGRIDDING
 amr.max_level       = 0       # maximum level number allowed

--- a/Exec/RegTests/MassCons/masscons-mol-2.inp
+++ b/Exec/RegTests/MassCons/masscons-mol-2.inp
@@ -42,7 +42,7 @@ pelec.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 pelec.sum_interval   = 1       # timesteps between computing mass
 pelec.v              = 1       # verbosity in PeleC.cpp
 amr.v                = 1       # verbosity in Amr.cpp
-amr.data_log         = datalog
+amr.data_log         = datlog
 
 # REFINEMENT / REGRIDDING
 amr.max_level       = 0       # maximum level number allowed

--- a/Exec/RegTests/MassCons/masscons-plm.inp
+++ b/Exec/RegTests/MassCons/masscons-plm.inp
@@ -42,7 +42,7 @@ pelec.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 pelec.sum_interval   = 1       # timesteps between computing mass
 pelec.v              = 1       # verbosity in PeleC.cpp
 amr.v                = 1       # verbosity in Amr.cpp
-amr.data_log         = datalog
+amr.data_log         = datlog
 
 # REFINEMENT / REGRIDDING
 amr.max_level       = 0       # maximum level number allowed

--- a/Exec/RegTests/MassCons/masscons-ppm.inp
+++ b/Exec/RegTests/MassCons/masscons-ppm.inp
@@ -42,7 +42,7 @@ pelec.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 pelec.sum_interval   = 1       # timesteps between computing mass
 pelec.v              = 1       # verbosity in PeleC.cpp
 amr.v                = 1       # verbosity in Amr.cpp
-amr.data_log         = datalog
+amr.data_log         = datlog
 
 # REFINEMENT / REGRIDDING
 amr.max_level       = 0       # maximum level number allowed

--- a/Exec/RegTests/MassCons/masscons.py
+++ b/Exec/RegTests/MassCons/masscons.py
@@ -22,7 +22,7 @@ class ConsTestCase(unittest.TestCase):
 
         # Load the data
         fdir = os.path.abspath(".")
-        fname = os.path.join(fdir, "datalog")
+        fname = os.path.join(fdir, "datlog")
         df = pd.read_csv(fname, delim_whitespace=True)
         npt.assert_allclose(df.mass, df.mass[0], rtol=1e-13)
         npt.assert_allclose(df.rho_E, df.rho_E[0], rtol=1e-13)

--- a/Source/Diffusion.cpp
+++ b/Source/Diffusion.cpp
@@ -4,9 +4,9 @@ void
 PeleC::getMOLSrcTerm(
   const amrex::MultiFab& S,
   amrex::MultiFab& MOLSrcTerm,
-  amrex::Real /*time*/,
-  amrex::Real dt,
-  amrex::Real flux_factor)
+  const amrex::Real /*time*/,
+  const amrex::Real dt,
+  const amrex::Real flux_factor)
 {
   BL_PROFILE("PeleC::getMOLSrcTerm()");
   if (
@@ -582,13 +582,14 @@ PeleC::getMOLSrcTerm(
 
         {
           BL_PROFILE("ApplyMLRedistribution()");
+          const amrex::Real fac_for_redist = (do_mol) ? 0.5 : 1.0;
           ApplyMLRedistribution(
             vbox, S.nComp(), Dterm, Dterm_tmp, S.const_array(mfi), scratch,
             flag_arr, AMREX_D_DECL(apx, apy, apz), vfrac.const_array(mfi),
             AMREX_D_DECL(fcx, fcy, fcz), ccc, d_bcs.dataPtr(), geom, dt,
             redistribution_type, as_crse, drho_as_crse->array(),
             rrflag_as_crse->array(), as_fine, dm_as_fine.array(),
-            level_mask.const_array(mfi), level_mask_not_covered,
+            level_mask.const_array(mfi), level_mask_not_covered, fac_for_redist,
             use_wts_in_divnc, 0, eb_srd_max_order);
         }
 

--- a/Source/SumIQ.cpp
+++ b/Source/SumIQ.cpp
@@ -74,11 +74,11 @@ PeleC::sum_integrated_quantities()
       amrex::Print() << "TIME = " << time << " FUEL PROD   = " << fuel_prod
                      << '\n';
 
-      const int log_index = find_datalog_index("datalog");
+      const int log_index = find_datalog_index("datlog");
       if (log_index >= 0) {
         std::ostream& data_log1 = parent->DataLog(log_index);
         if (data_log1.good()) {
-          const int datwidth = 18;
+          const int datwidth = 24;
           if (time == 0.0) {
             data_log1 << std::setw(datwidth) << "          time";
             data_log1 << std::setw(datwidth) << "          mass";
@@ -94,7 +94,7 @@ PeleC::sum_integrated_quantities()
           }
 
           // Write the quantities at this time
-          const int datprecision = 10;
+          const int datprecision = 16;
           data_log1 << std::setw(datwidth) << time;
           data_log1 << std::setw(datwidth) << std::setprecision(datprecision)
                     << mass;

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -97,7 +97,7 @@ endfunction(add_test_r)
 function(add_test_rv TEST_NAME TEST_EXE_DIR)
     setup_test()
     set(RUNTIME_OPTIONS "max_step=10 ${RUNTIME_OPTIONS}")
-    add_test(${TEST_NAME} sh -c "rm -f datalog && ${MPI_COMMANDS} ${CURRENT_TEST_EXE} ${MPIEXEC_POSTFLAGS} ${CURRENT_TEST_BINARY_DIR}/${TEST_NAME}.inp ${RUNTIME_OPTIONS} > ${TEST_NAME}.log ${SAVE_GOLDS_COMMAND} ${FCOMPARE_COMMAND} && nosetests masscons.py")
+    add_test(${TEST_NAME} sh -c "rm -f datlog && ${MPI_COMMANDS} ${CURRENT_TEST_EXE} ${MPIEXEC_POSTFLAGS} ${CURRENT_TEST_BINARY_DIR}/${TEST_NAME}.inp ${RUNTIME_OPTIONS} > ${TEST_NAME}.log ${SAVE_GOLDS_COMMAND} ${FCOMPARE_COMMAND} && nosetests masscons.py")
     set_tests_properties(${TEST_NAME} PROPERTIES TIMEOUT 18000 PROCESSORS ${PELEC_NP} WORKING_DIRECTORY "${CURRENT_TEST_BINARY_DIR}/" LABELS "regression;verification" ATTACHED_FILES_ON_FAIL "${CURRENT_TEST_BINARY_DIR}/${TEST_NAME}.log")
 endfunction(add_test_rv)
 


### PR DESCRIPTION
Something got changed in SumIQ such that it was looking to write to `datalog` (I think this happened here: https://github.com/AMReX-Combustion/PeleC/pull/376) But most input files used `datlog`. So I went back to using `datlog`. We could go the other way too if people prefer. 