### PR TITLE
Reproducibility for EB covered state

### DIFF
--- a/Source/InitEB.cpp
+++ b/Source/InitEB.cpp
@@ -239,22 +239,32 @@ PeleC::define_body_state()
 
   // Scan over data and find a point in the fluid to use to
   // set computable values in cells outside the domain
+  // We look for the lexicographically first valid point
   if (!body_state_set) {
-    bool foundPt = false;
     const amrex::MultiFab& S = get_new_data(State_Type);
     auto const& fact =
       dynamic_cast<amrex::EBFArrayBoxFactory const&>(Factory());
     auto const& flags = fact.getMultiEBCellFlagFab();
+    amrex::Vector<int> h_minvec(AMREX_SPACEDIM, 0);
+    AMREX_D_TERM(h_minvec[0] = geom.Domain().bigEnd(0);
+                 , h_minvec[1] = geom.Domain().bigEnd(1);
+                 , h_minvec[2] = geom.Domain().bigEnd(2);)
 
-    for (amrex::MFIter mfi(S, false); mfi.isValid() && !foundPt; ++mfi) {
+    amrex::Gpu::DeviceVector<amrex::Real> local_body_state(NVAR, -1);
+    amrex::Gpu::DeviceVector<int> d_minvec(AMREX_SPACEDIM, 0);
+    amrex::Gpu::copy(
+      amrex::Gpu::hostToDevice, h_minvec.begin(), h_minvec.end(),
+      d_minvec.begin());
+
+    for (amrex::MFIter mfi(S, false); mfi.isValid(); ++mfi) {
       const amrex::Box vbox = mfi.validbox();
       auto const& farr = S.const_array(mfi);
       auto const& flag_arr = flags.const_array(mfi);
 
       const auto lo = amrex::lbound(vbox);
       const auto hi = amrex::ubound(vbox);
-      amrex::Gpu::DeviceVector<amrex::Real> local_body_state(NVAR, -1);
       amrex::Real* p_body_state = local_body_state.begin();
+      int* p_minvec = d_minvec.begin();
       amrex::ParallelFor(1, [=] AMREX_GPU_DEVICE(int /*dummy*/) noexcept {
         bool found = false;
         for (int i = lo.x; i <= hi.x && !found; ++i) {
@@ -263,32 +273,53 @@ PeleC::define_body_state()
               const amrex::IntVect iv(AMREX_D_DECL(i, j, k));
               if (flag_arr(iv).isRegular()) {
                 found = true;
-                for (int n = 0; n < NVAR; ++n) {
-                  p_body_state[n] = farr(iv, n);
+                const amrex::IntVect iv_min_loc(p_minvec);
+                if (iv < iv_min_loc) {
+                  for (int n = 0; n < NVAR; ++n) {
+                    p_body_state[n] = farr(iv, n);
+                  }
+                  AMREX_D_TERM(p_minvec[0] = iv[0];, p_minvec[1] = iv[1];
+                               , p_minvec[2] = iv[2];)
                 }
               }
             }
           }
         }
       });
-      amrex::Gpu::copy(
-        amrex::Gpu::deviceToHost, local_body_state.begin(),
-        local_body_state.end(), body_state.begin());
-      foundPt = body_state[0] != -1;
     }
+    amrex::Gpu::copy(
+      amrex::Gpu::deviceToHost, local_body_state.begin(),
+      local_body_state.end(), body_state.begin());
+    amrex::Gpu::copy(
+      amrex::Gpu::deviceToHost, d_minvec.begin(), d_minvec.end(),
+      h_minvec.begin());
 
-    // Find proc with lowest rank to find valid point, use that for all
-    amrex::Vector<int> found(amrex::ParallelDescriptor::NProcs(), 0);
-    found[amrex::ParallelDescriptor::MyProc()] = (int)foundPt;
+    // Find proc with lexicographically first valid point, use that for all
+    amrex::Vector<int> found(
+      AMREX_SPACEDIM * amrex::ParallelDescriptor::NProcs(), 0);
+    AMREX_D_TERM(
+      found[AMREX_SPACEDIM * amrex::ParallelDescriptor::MyProc()] = h_minvec[0];
+      , found[AMREX_SPACEDIM * amrex::ParallelDescriptor::MyProc() + 1] =
+          h_minvec[1];
+      , found[AMREX_SPACEDIM * amrex::ParallelDescriptor::MyProc() + 2] =
+          h_minvec[2];)
     amrex::ParallelDescriptor::ReduceIntSum(
       found.data(), static_cast<int>(found.size()));
     int body_rank = -1;
-    for (int i = 0; i < found.size(); ++i) {
-      if (found[i] == 1) {
+    amrex::IntVect iv_min(geom.Domain().bigEnd());
+    for (int i = 0; i < amrex::ParallelDescriptor::NProcs(); ++i) {
+      const int offset = AMREX_SPACEDIM * i;
+      amrex::IntVect iv_test(
+        AMREX_D_DECL(found[offset], found[offset + 1], found[offset + 2]));
+      if (iv_test < iv_min) {
         body_rank = i;
+        AMREX_D_TERM(iv_min.setVal(0, iv_test[0]);
+                     , iv_min.setVal(1, iv_test[1]);
+                     , iv_min.setVal(2, iv_test[2]);)
       }
     }
-    AMREX_ASSERT(body_rank >= 0);
+    AMREX_ALWAYS_ASSERT(body_rank >= 0);
+
     amrex::ParallelDescriptor::Bcast(
       &(body_state[0]), body_state.size(), body_rank); // NOLINT
     body_state_set = true;

--- a/Source/InitEB.cpp
+++ b/Source/InitEB.cpp
@@ -252,11 +252,11 @@ PeleC::define_body_state()
     const auto& dbox = geom.Domain();
     const long max_idx = dbox.numPts();
 
-    // function minimized at the uncovered cell
+    // function minimized at the first uncovered cell
     amrex::ParallelFor(
       minIdxTmp, [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) noexcept {
         const amrex::IntVect iv(amrex::IntVect(AMREX_D_DECL(i, j, k)));
-        long idx_masked =
+        const long idx_masked =
           flag_arrays[nbx](iv).isRegular() ? dbox.index(iv) : max_idx;
         tmp_arrays[nbx](iv) = static_cast<amrex::Real>(idx_masked);
       });

--- a/Source/InitEB.cpp
+++ b/Source/InitEB.cpp
@@ -255,6 +255,7 @@ PeleC::define_body_state()
     // function minimized at the first uncovered cell
     amrex::ParallelFor(
       minIdxTmp, [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) noexcept {
+        amrex::ignore_unused(k);
         const amrex::IntVect iv(amrex::IntVect(AMREX_D_DECL(i, j, k)));
         const long idx_masked =
           flag_arrays[nbx](iv).isRegular() ? dbox.index(iv) : max_idx;

--- a/Source/InitEB.cpp
+++ b/Source/InitEB.cpp
@@ -269,6 +269,7 @@ PeleC::define_body_state()
     for (int n = 0; n < NVAR; ++n) {
       body_state[n] = S.min(tgt_box, n);
     }
+    body_state_set = true;
   }
 }
 

--- a/Source/Params/_cpp_parameters
+++ b/Source/Params/_cpp_parameters
@@ -293,7 +293,7 @@ print_energy_diagnostics     bool           (false, true)
 # how often (number of coarse timesteps) to compute integral sums (for runtime diagnostics)
 sum_interval                 int           -1
 
-# record extrema of certain variables along with the intergal sums
+# record extrema of certain variables along with the integral sums
 track_extrema               bool           true
 
 # track the extrema of this species in addition to other quantities


### PR DESCRIPTION
The state in cells covered by the EB is currently is set based on the value of the state in a somewhat arbitrarily selected fluid cell. Right now, the lexicographically first fluid cell in the first FAB containing fluid cells on the highest rank processor with a fluid cell is selected to populate the covered state. 

The identity of this cell depends on the domain decomposition and therefore the covered state may change for a particular case when the number of processors or `amr.max_grid_size` is changed. See below, for EB-C8 in 2D with 1 and 4 processors.

With this PR, the lexicographically first fluid cell in the entire domain is chosen, so it is no longer depends on domain decomposition. As a result, both cases below will now be equivalent and match the `1 proc` version. The code to do this is not very pretty, but I wasn't sure of a better way.

This PR should have no effect on the actual solutions, but may lead to some diffs due to covered cells changing.

`1 proc, current`
![Screen Shot 2023-10-06 at 3 51 37 PM](https://github.com/AMReX-Combustion/PeleC/assets/53018946/c24bf6d0-af52-4352-bd4d-3dd87e3b83c6)

`4 proc, current`
![Screen Shot 2023-10-06 at 3 51 09 PM](https://github.com/AMReX-Combustion/PeleC/assets/53018946/9b6f41aa-d232-4534-9aaa-6b6f615c9541)
