### PR TITLE
Fix derive for state variables with ghost cells

### DIFF
--- a/Exec/RegTests/PMF/pmf-lidryer-arkode.inp
+++ b/Exec/RegTests/PMF/pmf-lidryer-arkode.inp
@@ -27,7 +27,7 @@ pelec.v            = 1       # verbosity in PeleC cpp files
 amr.v              = 1       # verbosity in Amr.cpp
 #amr.grid_log       = grdlog  # name of grid logging file
 
-# REFINEMENT / REGRIDDING 
+# REFINEMENT / REGRIDDING
 amr.max_level       = 1       # maximum level number allowed
 amr.ref_ratio       = 2 2 2 2 # refinement ratio
 amr.regrid_int      = 2 2 2 2 # how often to regrid
@@ -49,13 +49,18 @@ pelec.plot_rhoy = 0
 pelec.plot_massfrac = 1
 
 # PROBLEM PARAMETERS
-prob.pamb = 1013250.0  
+prob.pamb = 1013250.0
 prob.phi_in = -0.5
 prob.pertmag = 0.005
 prob.pmf_datafile = "LiDryer_H2_p1_phi0_4000tu0300.dat"
 
 tagging.max_ftracerr_lev = 4
 tagging.ftracerr = 150.e-6
+
+tagging.refinement_indicators = gtemp
+tagging.gtemp.adjacent_difference_greater = 100
+tagging.gtemp.field_name = Temp
+tagging.gtemp.max_level = 1
 
 extern.new_Jacobian_each_cell = 0
 

--- a/Source/BCfill.cpp
+++ b/Source/BCfill.cpp
@@ -30,8 +30,7 @@ struct PCHypFillExtDir
     const int /*orig_comp*/) const
   {
     // We need the whole state to apply physical BCs
-    AMREX_ASSERT(dcomp == 0 and numcomp == NVAR);
-    amrex::ignore_unused(dcomp, numcomp);
+    AMREX_ALWAYS_ASSERT(dcomp == 0 && numcomp == NVAR);
 
     const int* domlo = geom.Domain().loVect();
     const int* domhi = geom.Domain().hiVect();

--- a/Source/BCfill.cpp
+++ b/Source/BCfill.cpp
@@ -21,14 +21,18 @@ struct PCHypFillExtDir
   void operator()(
     const amrex::IntVect& iv,
     amrex::Array4<amrex::Real> const& dest,
-    const int /*dcomp*/,
-    const int /*numcomp*/,
+    const int dcomp,
+    const int numcomp,
     amrex::GeometryData const& geom,
     const amrex::Real time,
     const amrex::BCRec* bcr,
     const int /*bcomp*/,
     const int /*orig_comp*/) const
   {
+    // We need the whole state to apply physical BCs
+    AMREX_ASSERT(dcomp == 0 and numcomp == NVAR);
+    amrex::ignore_unused(dcomp, numcomp);
+
     const int* domlo = geom.Domain().loVect();
     const int* domhi = geom.Domain().hiVect();
     const amrex::Real* prob_lo = geom.ProbLo();

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -1932,29 +1932,21 @@ PeleC::errorEst(
 std::unique_ptr<amrex::MultiFab>
 PeleC::derive(const std::string& name, amrex::Real time, int ngrow)
 {
-  if ((do_les) && (name == "C_s2")) {
+  if ((do_les) && ((name == "C_s2") || (name == "C_I") || (name == "Pr_T"))) {
+    AMREX_ASSERT(ngrow <= LES_Coeffs.nGrow());
     std::unique_ptr<amrex::MultiFab> derive_dat(
-      new amrex::MultiFab(grids, dmap, 1, 0));
-    amrex::MultiFab::Copy(*derive_dat, LES_Coeffs, comp_Cs2, 0, 1, 0);
-    return derive_dat;
-  }
-  if ((do_les) && (name == "C_I")) {
-    std::unique_ptr<amrex::MultiFab> derive_dat(
-      new amrex::MultiFab(grids, dmap, 1, 0));
-    amrex::MultiFab::Copy(*derive_dat, LES_Coeffs, comp_CI, 0, 1, 0);
-    return derive_dat;
-  }
-  if ((do_les) && (les_model != 1) && (name == "Pr_T")) {
-    std::unique_ptr<amrex::MultiFab> derive_dat(
-      new amrex::MultiFab(grids, dmap, 1, 0));
-    amrex::MultiFab::Copy(*derive_dat, LES_Coeffs, comp_PrT, 0, 1, 0);
-    return derive_dat;
-  }
-  if ((do_les) && (les_model == 1) && (name == "Pr_T")) {
-    std::unique_ptr<amrex::MultiFab> derive_dat(
-      new amrex::MultiFab(grids, dmap, 1, 0));
-    amrex::MultiFab::Copy(*derive_dat, LES_Coeffs, comp_Cs2ovPrT, 0, 1, 0);
-    amrex::MultiFab::Divide(*derive_dat, LES_Coeffs, comp_Cs2, 0, 1, 0);
+      new amrex::MultiFab(grids, dmap, 1, ngrow));
+    if (name == "C_s2") {
+      amrex::MultiFab::Copy(*derive_dat, LES_Coeffs, comp_Cs2, 0, 1, ngrow);
+    } else if (name == "C_I") {
+      amrex::MultiFab::Copy(*derive_dat, LES_Coeffs, comp_CI, 0, 1, ngrow);
+    } else if ((les_model != 1) && (name == "Pr_T")) {
+      amrex::MultiFab::Copy(*derive_dat, LES_Coeffs, comp_PrT, 0, 1, ngrow);
+    } else { // Pr_T, les_model==1
+      amrex::MultiFab::Copy(
+        *derive_dat, LES_Coeffs, comp_Cs2ovPrT, 0, 1, ngrow);
+      amrex::MultiFab::Divide(*derive_dat, LES_Coeffs, comp_Cs2, 0, 1, ngrow);
+    }
     return derive_dat;
   }
 
@@ -1966,6 +1958,24 @@ PeleC::derive(const std::string& name, amrex::Real time, int ngrow)
     }
     amrex::MultiFab::Copy(*mf, vfrac, 0, 0, 1, 0);
     return mf;
+  }
+
+  // Can't use the AmrLevel derive for state variables with ghost cells:
+  // That will fillpatch them individually, but we require the full state
+  // for physBCs. Therefore, instead fillpatch the full state and then grab
+  // the component we need.
+  int index, scomp;
+  if (isStateVariable(name, index, scomp) && (ngrow > 0)) {
+    amrex::MultiFab S_data(
+      get_new_data(State_Type).boxArray(),
+      get_new_data(State_Type).DistributionMap(), NVAR, ngrow, amrex::MFInfo(),
+      Factory());
+    FillPatch(
+      *this, S_data, S_data.nGrow(), time, State_Type, Density, NVAR, 0);
+    std::unique_ptr<amrex::MultiFab> derive_dat(
+      new amrex::MultiFab(grids, dmap, 1, ngrow, amrex::MFInfo(), Factory()));
+    amrex::MultiFab::Copy(*derive_dat, S_data, scomp, 0, 1, ngrow);
+    return derive_dat;
   }
 
   // For those using GrowBoxByOne we need this


### PR DESCRIPTION
When deriving a state variable with ghost cells, the derive function in AmrLevel does a FillPatch for the individual state variable. However, in PeleC, the `PCHypFillExtDir` function can only operate on the full state, not individual variables. Therefore, instead of using the AmrLevel derive function in this case, we should manually FillPatch the whole state and then take the component that we need. 

Resolves https://github.com/AMReX-Combustion/PeleC/issues/706 (the only time this problem comes up right now is when using the `adjacent_difference_greater` refinement criterion with a state variable, which requires a ghost cell). Also cleans up the derive for LES variables, adds error checking to `PCHypFillExtDir` to ensure it is only called for the full state, and adds `adjacent_difference_greater` to a test case.