### PR TITLE
remove plt vars with nans from eb-c3

### DIFF
--- a/Exec/RegTests/EB-C3/eb-c3.inp
+++ b/Exec/RegTests/EB-C3/eb-c3.inp
@@ -61,7 +61,8 @@ amr.check_int       = -1       # number of timesteps between checkpoints
 amr.plot_files_output = 1
 amr.plot_file       = plt
 amr.plot_int        = 100
-amr.derive_plot_vars = density xmom ymom zmom rho_E rho_e Temp rho_H2 rho_O2 rho_H2O rho_H rho_O rho_OH rho_HO2 rho_H2O2 rho_N2 rho_omega_H2 rho_omega_O2 rho_omega_H2O rho_omega_H rho_omega_O rho_omega_OH rho_omega_HO2 rho_omega_H2O2 rho_omega_N2 pressure kineng enstrophy soundspeed MachNumber entropy magvort divu eint_E eint_e logden x_velocity y_velocity z_velocity magvel radvel magmom vfrac cp cv viscosity bulk_viscosity conductivity D(H2) D(O2) D(H2O) D(H) D(O) D(OH) D(HO2) D(H2O2) D(N2)
+amr.derive_plot_vars = density xmom ymom zmom rho_E rho_e Temp rho_H2 rho_O2 rho_H2O rho_H rho_O rho_OH rho_HO2 rho_H2O2 rho_N2 magmom vfrac
+pelec.plot_reactions = 0
 
 #extruded triangles lets the user create a maximum of 5 triangles
 #in 2D that will be extruded in the z direction

--- a/Source/IO.cpp
+++ b/Source/IO.cpp
@@ -355,7 +355,7 @@ PeleC::setPlotVariables()
   int plot_reactions = 1;
   pp.query("plot_reactions", plot_reactions);
   if (plot_reactions == 0) {
-    for (int i = 0; i < NUM_SPECIES + 1; i++) {
+    for (int i = 0; i < NUM_SPECIES + 2; i++) {
       amrex::Amr::deleteStatePlotVar(desc_lst[Reactions_Type].name(i));
     }
   }


### PR DESCRIPTION
https://github.com/AMReX-Combustion/PeleC/pull/704 sets the state in covered cells to 0 for EB-C3 for error checking purposes. As a result, derived variables that divide by density become NaN in covered cells. Don't plot those, to allow for plt files to be compared in nightly test.