### PR TITLE
remove dependence of Filter on Utilities

### DIFF
--- a/Source/Filter.H
+++ b/Source/Filter.H
@@ -6,7 +6,6 @@
 #include <AMReX_MultiFab.H>
 
 #include "Constants.H"
-#include "Utilities.H"
 
 #ifdef AMREX_USE_OMP
 #include <omp.h>

--- a/Source/Filter.cpp
+++ b/Source/Filter.cpp
@@ -473,8 +473,9 @@ Filter::apply_filter(
   const int /*ncomp*/)
 {
   const auto q = in.const_array();
+  out.setVal(0.0, box, nstart, ncnt);
   auto qh = out.array();
-  setC(box, nstart, ncnt, qh, 0.0);
+
   amrex::Gpu::DeviceVector<amrex::Real> weights(_weights.size());
   amrex::Real* w = weights.data();
   amrex::Gpu::copy(

--- a/Source/Filter.cpp
+++ b/Source/Filter.cpp
@@ -473,7 +473,7 @@ Filter::apply_filter(
   const int /*ncomp*/)
 {
   const auto q = in.const_array();
-  out.setVal(0.0, box, nstart, ncnt);
+  out.setVal<amrex::RunOn::Device>(0.0, box, nstart, ncnt);
   auto qh = out.array();
 
   amrex::Gpu::DeviceVector<amrex::Real> weights(_weights.size());

--- a/Source/PeleC.H
+++ b/Source/PeleC.H
@@ -15,6 +15,7 @@
 #endif
 
 #include "Filter.H"
+#include "Utilities.H"
 #include "Tagging.H"
 #include "IndexDefines.H"
 #include "prob_parm.H"


### PR DESCRIPTION
This basically makes the Filter class independent of the rest of PeleC, so that it can be easily pulled in and used by external tools (PeleAnalysis).