### PR TITLE
use template to simplify a bunch of derive functions

### DIFF
--- a/Source/Derive.H
+++ b/Source/Derive.H
@@ -54,38 +54,27 @@ get_weight(const int im, const int ip)
   return diff == 0 ? 0.0 : (diff == 1 ? 1.0 : 0.5);
 }
 
-void pc_dervelx(
+template <int state_idx, int num_comp>
+void
+pc_derdividebyrho(
   const amrex::Box& bx,
   amrex::FArrayBox& derfab,
-  int dcomp,
-  int ncomp,
+  int /*dcomp*/,
+  int /*ncomp*/,
   const amrex::FArrayBox& datfab,
-  const amrex::Geometry& geomdata,
-  amrex::Real time,
-  const int* bcrec,
-  const int level);
+  const amrex::Geometry& /*geomdata*/,
+  amrex::Real /*time*/,
+  const int* /*bcrec*/,
+  const int /*level*/)
+{
+  auto const dat = datfab.const_array();
+  auto derived = derfab.array();
 
-void pc_dervely(
-  const amrex::Box& bx,
-  amrex::FArrayBox& derfab,
-  int dcomp,
-  int ncomp,
-  const amrex::FArrayBox& datfab,
-  const amrex::Geometry& geomdata,
-  amrex::Real time,
-  const int* bcrec,
-  const int level);
-
-void pc_dervelz(
-  const amrex::Box& bx,
-  amrex::FArrayBox& derfab,
-  int dcomp,
-  int ncomp,
-  const amrex::FArrayBox& datfab,
-  const amrex::Geometry& geomdata,
-  amrex::Real time,
-  const int* bcrec,
-  const int level);
+  amrex::ParallelFor(
+    bx, num_comp, [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) noexcept {
+      derived(i, j, k, n) = dat(i, j, k, state_idx + n) / dat(i, j, k, URHO);
+    });
+}
 
 void pc_dermagvel(
   const amrex::Box& bx,
@@ -131,51 +120,7 @@ void pc_dereint1(
   const int* bcrec,
   const int level);
 
-void pc_dereint2(
-  const amrex::Box& bx,
-  amrex::FArrayBox& derfab,
-  int dcomp,
-  int ncomp,
-  const amrex::FArrayBox& datfab,
-  const amrex::Geometry& geomdata,
-  amrex::Real time,
-  const int* bcrec,
-  const int level);
-
 void pc_derlogden(
-  const amrex::Box& bx,
-  amrex::FArrayBox& derfab,
-  int dcomp,
-  int ncomp,
-  const amrex::FArrayBox& datfab,
-  const amrex::Geometry& geomdata,
-  amrex::Real time,
-  const int* bcrec,
-  const int level);
-
-void pc_derspec(
-  const amrex::Box& bx,
-  amrex::FArrayBox& derfab,
-  int dcomp,
-  int ncomp,
-  const amrex::FArrayBox& datfab,
-  const amrex::Geometry& geomdata,
-  amrex::Real time,
-  const int* bcrec,
-  const int level);
-
-void pc_deradv(
-  const amrex::Box& bx,
-  amrex::FArrayBox& derfab,
-  int dcomp,
-  int ncomp,
-  const amrex::FArrayBox& datfab,
-  const amrex::Geometry& geomdata,
-  amrex::Real time,
-  const int* bcrec,
-  const int level);
-
-void pc_deraux(
   const amrex::Box& bx,
   amrex::FArrayBox& derfab,
   int dcomp,

--- a/Source/Derive.cpp
+++ b/Source/Derive.cpp
@@ -7,66 +7,6 @@
 #include "TransCoeff.H"
 
 void
-pc_dervelx(
-  const amrex::Box& bx,
-  amrex::FArrayBox& derfab,
-  int /*dcomp*/,
-  int /*ncomp*/,
-  const amrex::FArrayBox& datfab,
-  const amrex::Geometry& /*geomdata*/,
-  amrex::Real /*time*/,
-  const int* /*bcrec*/,
-  const int /*level*/)
-{
-  auto const dat = datfab.const_array();
-  auto velx = derfab.array();
-
-  amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-    velx(i, j, k) = dat(i, j, k, UMX) / dat(i, j, k, URHO);
-  });
-}
-
-void
-pc_dervely(
-  const amrex::Box& bx,
-  amrex::FArrayBox& derfab,
-  int /*dcomp*/,
-  int /*ncomp*/,
-  const amrex::FArrayBox& datfab,
-  const amrex::Geometry& /*geomdata*/,
-  amrex::Real /*time*/,
-  const int* /*bcrec*/,
-  const int /*level*/)
-{
-  auto const dat = datfab.const_array();
-  auto vely = derfab.array();
-
-  amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-    vely(i, j, k) = dat(i, j, k, UMY) / dat(i, j, k, URHO);
-  });
-}
-
-void
-pc_dervelz(
-  const amrex::Box& bx,
-  amrex::FArrayBox& derfab,
-  int /*dcomp*/,
-  int /*ncomp*/,
-  const amrex::FArrayBox& datfab,
-  const amrex::Geometry& /*geomdata*/,
-  amrex::Real /*time*/,
-  const int* /*bcrec*/,
-  const int /*level*/)
-{
-  auto const dat = datfab.const_array();
-  auto velz = derfab.array();
-
-  amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-    velz(i, j, k) = dat(i, j, k, UMZ) / dat(i, j, k, URHO);
-  });
-}
-
-void
 pc_dermagvel(
   const amrex::Box& bx,
   amrex::FArrayBox& derfab,
@@ -163,27 +103,6 @@ pc_dereint1(
 }
 
 void
-pc_dereint2(
-  const amrex::Box& bx,
-  amrex::FArrayBox& derfab,
-  int /*dcomp*/,
-  int /*ncomp*/,
-  const amrex::FArrayBox& datfab,
-  const amrex::Geometry& /*geomdata*/,
-  amrex::Real /*time*/,
-  const int* /*bcrec*/,
-  const int /*level*/)
-{
-  // Compute internal energy from (rho e).
-  auto const dat = datfab.const_array();
-  auto e = derfab.array();
-
-  amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-    e(i, j, k) = dat(i, j, k, UEINT) / dat(i, j, k, URHO);
-  });
-}
-
-void
 pc_derlogden(
   const amrex::Box& bx,
   amrex::FArrayBox& derfab,
@@ -201,69 +120,6 @@ pc_derlogden(
   amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
     logden(i, j, k) = log10(dat(i, j, k));
   });
-}
-
-void
-pc_derspec(
-  const amrex::Box& bx,
-  amrex::FArrayBox& derfab,
-  int /*dcomp*/,
-  int /*ncomp*/,
-  const amrex::FArrayBox& datfab,
-  const amrex::Geometry& /*geomdata*/,
-  amrex::Real /*time*/,
-  const int* /*bcrec*/,
-  const int /*level*/)
-{
-  auto const dat = datfab.const_array();
-  auto spec = derfab.array();
-
-  amrex::ParallelFor(
-    bx, NUM_SPECIES, [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) noexcept {
-      spec(i, j, k, n) = dat(i, j, k, UFS + n) / dat(i, j, k, URHO);
-    });
-}
-
-void
-pc_deradv(
-  const amrex::Box& bx,
-  amrex::FArrayBox& derfab,
-  int /*dcomp*/,
-  int /*ncomp*/,
-  const amrex::FArrayBox& datfab,
-  const amrex::Geometry& /*geomdata*/,
-  amrex::Real /*time*/,
-  const int* /*bcrec*/,
-  const int /*level*/)
-{
-  auto const dat = datfab.const_array();
-  auto adv = derfab.array();
-
-  amrex::ParallelFor(
-    bx, NUM_ADV, [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) noexcept {
-      adv(i, j, k, n) = dat(i, j, k, UFA + n) / dat(i, j, k, URHO);
-    });
-}
-
-void
-pc_deraux(
-  const amrex::Box& bx,
-  amrex::FArrayBox& derfab,
-  int /*dcomp*/,
-  int /*ncomp*/,
-  const amrex::FArrayBox& datfab,
-  const amrex::Geometry& /*geomdata*/,
-  amrex::Real /*time*/,
-  const int* /*bcrec*/,
-  const int /*level*/)
-{
-  auto const dat = datfab.const_array();
-  auto aux = derfab.array();
-
-  amrex::ParallelFor(
-    bx, NUM_AUX, [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) noexcept {
-      aux(i, j, k, n) = dat(i, j, k, UFX + n) / dat(i, j, k, URHO);
-    });
 }
 
 void

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -1693,7 +1693,7 @@ PeleC::errorEst(
 
       // Tagging vel_x
       S_derData.setVal<amrex::RunOn::Device>(0.0, datbox);
-      pc_dervelx(
+      pc_derdividebyrho<UMX, 1>(
         datbox, S_derData, ncp, Sfab.nComp(), S_data[mfi], geom, time, bc,
         level);
       if (level < tagging_parm->max_velerr_lev) {
@@ -1715,7 +1715,7 @@ PeleC::errorEst(
 
       // Tagging vel_y
       S_derData.setVal<amrex::RunOn::Device>(0.0, datbox);
-      pc_dervely(
+      pc_derdividebyrho<UMY, 1>(
         datbox, S_derData, ncp, Sfab.nComp(), S_data[mfi], geom, time, bc,
         level);
       if (level < tagging_parm->max_velerr_lev) {
@@ -1737,7 +1737,7 @@ PeleC::errorEst(
 
       // Tagging vel_z
       S_derData.setVal<amrex::RunOn::Device>(0.0, datbox);
-      pc_dervelz(
+      pc_derdividebyrho<UMZ, 1>(
         datbox, S_derData, ncp, Sfab.nComp(), S_data[mfi], geom, time, bc,
         level);
       if (level < tagging_parm->max_velerr_lev) {

--- a/Source/Setup.cpp
+++ b/Source/Setup.cpp
@@ -466,7 +466,7 @@ PeleC::variableSetUp()
 
   // Internal energy as derived from rho*e, part of the state
   derive_lst.add(
-    "eint_e", amrex::IndexType::TheCellType(), 1, pc_dereint2,
+    "eint_e", amrex::IndexType::TheCellType(), 1, pc_derdividebyrho<UEINT, 1>,
     amrex::DeriveRec::TheSameBox);
   derive_lst.addComponent("eint_e", desc_lst, State_Type, Density, NVAR);
 
@@ -484,17 +484,18 @@ PeleC::variableSetUp()
 
   derive_lst.add(
     "massfrac", amrex::IndexType::TheCellType(), NUM_SPECIES,
-    var_names_massfrac, pc_derspec, amrex::DeriveRec::TheSameBox);
+    var_names_massfrac, pc_derdividebyrho<UFS, NUM_SPECIES>,
+    amrex::DeriveRec::TheSameBox);
   derive_lst.addComponent("massfrac", desc_lst, State_Type, Density, NVAR);
 
   derive_lst.add(
-    "adv", amrex::IndexType::TheCellType(), NUM_ADV, adv_names, pc_deradv,
-    amrex::DeriveRec::TheSameBox);
+    "adv", amrex::IndexType::TheCellType(), NUM_ADV, adv_names,
+    pc_derdividebyrho<UFA, NUM_ADV>, amrex::DeriveRec::TheSameBox);
   derive_lst.addComponent("adv", desc_lst, State_Type, Density, NVAR);
 
   derive_lst.add(
-    "aux", amrex::IndexType::TheCellType(), NUM_AUX, aux_names, pc_deraux,
-    amrex::DeriveRec::TheSameBox);
+    "aux", amrex::IndexType::TheCellType(), NUM_AUX, aux_names,
+    pc_derdividebyrho<UFX, NUM_AUX>, amrex::DeriveRec::TheSameBox);
   derive_lst.addComponent("aux", desc_lst, State_Type, Density, NVAR);
 
   // Species mole fractions
@@ -510,17 +511,17 @@ PeleC::variableSetUp()
 
   // Velocities
   derive_lst.add(
-    "x_velocity", amrex::IndexType::TheCellType(), 1, pc_dervelx,
+    "x_velocity", amrex::IndexType::TheCellType(), 1, pc_derdividebyrho<UMX, 1>,
     amrex::DeriveRec::TheSameBox);
   derive_lst.addComponent("x_velocity", desc_lst, State_Type, Density, NVAR);
 
   derive_lst.add(
-    "y_velocity", amrex::IndexType::TheCellType(), 1, pc_dervely,
+    "y_velocity", amrex::IndexType::TheCellType(), 1, pc_derdividebyrho<UMY, 1>,
     amrex::DeriveRec::TheSameBox);
   derive_lst.addComponent("y_velocity", desc_lst, State_Type, Density, NVAR);
 
   derive_lst.add(
-    "z_velocity", amrex::IndexType::TheCellType(), 1, pc_dervelz,
+    "z_velocity", amrex::IndexType::TheCellType(), 1, pc_derdividebyrho<UMZ, 1>,
     amrex::DeriveRec::TheSameBox);
   derive_lst.addComponent("z_velocity", desc_lst, State_Type, Density, NVAR);
 


### PR DESCRIPTION
No need to have a bunch of repeated code just to divide different variables by density, so let's get rid of some lines of code.