### PR TITLE
eb-converging-nozzle: turn on diffusion so sponge layers work

### DIFF
--- a/Exec/RegTests/EB-ConvergingNozzle/eb-converging-nozzle-hdf5-zfp.inp
+++ b/Exec/RegTests/EB-ConvergingNozzle/eb-converging-nozzle-hdf5-zfp.inp
@@ -20,9 +20,9 @@ pelec.hi_bc       =  "Hard"  "FOExtrap"  "FOExtrap"
 # WHICH PHYSICS
 pelec.do_hydro = 1
 pelec.do_mol = 1
-pelec.diffuse_vel = 0
-pelec.diffuse_temp = 0
-pelec.diffuse_spec = 0
+pelec.diffuse_vel = 1
+pelec.diffuse_temp = 1
+pelec.diffuse_spec = 1
 pelec.do_react = 0
 pelec.chem_integrator = "ReactorNull"
 pelec.diffuse_enth = 0

--- a/Exec/RegTests/EB-ConvergingNozzle/eb-converging-nozzle-hdf5.inp
+++ b/Exec/RegTests/EB-ConvergingNozzle/eb-converging-nozzle-hdf5.inp
@@ -20,9 +20,9 @@ pelec.hi_bc       =  "Hard"  "FOExtrap"  "FOExtrap"
 # WHICH PHYSICS
 pelec.do_hydro = 1
 pelec.do_mol = 1
-pelec.diffuse_vel = 0
-pelec.diffuse_temp = 0
-pelec.diffuse_spec = 0
+pelec.diffuse_vel = 1
+pelec.diffuse_temp = 1
+pelec.diffuse_spec = 1
 pelec.do_react = 0
 pelec.chem_integrator = "ReactorNull"
 pelec.diffuse_enth = 0

--- a/Exec/RegTests/EB-ConvergingNozzle/eb-converging-nozzle.inp
+++ b/Exec/RegTests/EB-ConvergingNozzle/eb-converging-nozzle.inp
@@ -20,9 +20,9 @@ pelec.hi_bc       =  "Hard"  "FOExtrap"  "FOExtrap"
 # WHICH PHYSICS
 pelec.do_hydro = 1
 pelec.do_mol = 1
-pelec.diffuse_vel = 0
-pelec.diffuse_temp = 0
-pelec.diffuse_spec = 0
+pelec.diffuse_vel = 1
+pelec.diffuse_temp = 1
+pelec.diffuse_spec = 1
 pelec.do_react = 0
 pelec.chem_integrator = "ReactorNull"
 pelec.diffuse_enth = 0


### PR DESCRIPTION
To avoid confusion because the sponge zones just use the regular diffusion operators to if diffusion is off they don't do anything. Closes #825 