### PR TITLE
Fix bug in LES coefficient calculation.

### DIFF
--- a/Source/LES.H
+++ b/Source/LES.H
@@ -417,7 +417,7 @@ pc_dynamic_smagorinsky_coeffs(
 
   // "resolved turbulent stresses" and others
   for (int dir = 0; dir < AMREX_SPACEDIM * AMREX_SPACEDIM; dir++) {
-    M[dir] = betaij[dir] * alphaij(i, j, k, dir);
+    M[dir] = betaij[dir] - alphaij(i, j, k, dir);
   }
 
   L[i00] = Kij(i, j, k, 0) - q(i, j, k, QRHO) * q(i, j, k, QU) * q(i, j, k, QU);


### PR DESCRIPTION
See Formula 17 on page 365 in Martín, M. Pino, U. Piomelli, and G. V. Candler. "Subgrid-Scale Models for Compressible Large-Eddy Simulations." Theoretical and Computational Fluid Dynamics 13, no. 5 (2000):
361–76. https://link.springer.com/article/10.1007/PL00020896

Thanks to @bronise777 for finding this. Discussed in #845 