### PR TITLE
fix 'paraview' spelling in the readme file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ To build `PeleC` (using the default submodules for AMReX, PelePhysics, and SUNDI
 
    a. In VisIt, direct the File->Open dialogue to select the file named "Header" that is inside each plotfile folder.
 
-   b. In ParaViuew, navigate to the case directory, open the plotfile folder.
+   b. In ParaView, navigate to the case directory, open the plotfile folder.
 
    c. With Amrvis, `$ amrvis3d plt00030`, for example.
 


### PR DESCRIPTION
This pull request addresses a minor typographical error in the README file. The word "ParaViuew" has been corrected to "ParaView" to ensure accuracy and clarity.

**Changes Made:**
- Corrected the spelling of "ParaViuew" to "ParaView" in the README file.

This change helps maintain the professionalism and accuracy of the project documentation. 

Thank you for considering this correction!
