### PR TITLE
Fix bug in indexing for EB-inflow hyperbolics

### DIFF
--- a/Exec/RegTests/EB-InflowBC/prob.H
+++ b/Exec/RegTests/EB-InflowBC/prob.H
@@ -92,12 +92,6 @@ struct MyProblemSpecificFunctions : public DefaultProblemSpecificFunctions
       prob_lo[1] + static_cast<amrex::Real>(iv[1] + 0.5) * dx[1],
       prob_lo[2] + static_cast<amrex::Real>(iv[2] + 0.5) * dx[2])};
 
-    const int R_RHO = 0;
-    const int R_UN = 1;
-    const int R_UT1 = 2;
-    const int R_UT2 = 3;
-    const int R_P = 4;
-
     const amrex::Real max_r = 0.1;
     const amrex::Real radius =
       std::sqrt(AMREX_D_TERM(, x[1] * x[1], +x[2] * x[2]));

--- a/Source/IndexDefines.H
+++ b/Source/IndexDefines.H
@@ -78,6 +78,16 @@
 #define NQAUX 6
 #define NGDNV 6
 
+#define R_RHO 0
+#define R_UN 1
+#define R_UT1 2
+#define R_UT2 3
+#define R_P 4
+#define R_ADV 5
+#define R_Y (R_ADV + NUM_ADV)
+#define R_LIN (R_Y + NUM_SPECIES + NUM_AUX)
+#define R_NUM (5 + NUM_SPECIES + NUM_ADV + NUM_LIN + NUM_AUX)
+
 #if AMREX_SPACEDIM == 1
 // hopefully we won't do EB in 1D
 #define NLSPTS 1

--- a/Source/MOL.cpp
+++ b/Source/MOL.cpp
@@ -123,15 +123,8 @@ pc_compute_hyp_mol_flux(
 
         const amrex::Real cavg = 0.5 * (qaux(iv, QC) + qaux(ivm, QC));
 
-        amrex::Real spl[NUM_SPECIES];
-        for (int n = 0; n < NUM_SPECIES; n++) {
-          spl[n] = qtempl[R_Y + n];
-        }
-
-        amrex::Real spr[NUM_SPECIES];
-        for (int n = 0; n < NUM_SPECIES; n++) {
-          spr[n] = qtempr[R_Y + n];
-        }
+        amrex::Real* spl = &qtempl[R_Y];
+        amrex::Real* spr = &qtempr[R_Y];
 
         amrex::Real flux_tmp[NVAR] = {0.0};
         amrex::Real ustar = 0.0;

--- a/Source/MOL.cpp
+++ b/Source/MOL.cpp
@@ -19,14 +19,6 @@ pc_compute_hyp_mol_flux(
   int axisdir,
   bool do_rf)
 {
-  const int R_RHO = 0;
-  const int R_UN = 1;
-  const int R_UT1 = 2;
-  const int R_UT2 = 3;
-  const int R_P = 4;
-  const int R_ADV = 5;
-  const int R_Y = R_ADV + NUM_ADV;
-  const int R_NUM = 5 + NUM_SPECIES + NUM_ADV + NUM_LIN + NUM_AUX;
   const int bc_test_val = 1;
   const bool using_rotframe = do_rf; // local capture
   const auto geomdata = geom.data();
@@ -114,7 +106,6 @@ pc_compute_hyp_mol_flux(
         }
 #endif
 #if NUM_LIN > 0
-        const int R_LIN = R_Y + NUM_SPECIES + NUM_AUX;
         for (int n = 0; n < NUM_LIN; n++) {
           qtempl[R_LIN + n] = q(ivm, QLIN + n) + 0.5 * dq(ivm, QLIN + n);
           qtempr[R_LIN + n] = q(iv, QLIN + n) - 0.5 * dq(iv, QLIN + n);
@@ -213,14 +204,6 @@ pc_compute_hyp_mol_flux_eb(
 {
 
   const int nextra = 0;
-
-  const int R_RHO = 0;
-  const int R_UN = 1;
-  const int R_UT1 = 2;
-  const int R_UT2 = 3;
-  const int R_P = 4;
-  const int R_ADV = 5;
-  const int R_Y = R_ADV + NUM_ADV;
   const int bc_test_val = 1;
 
   const amrex::Real full_area = AMREX_D_PICK(1.0, dx[0], dx[0] * dx[1]);
@@ -247,8 +230,8 @@ pc_compute_hyp_mol_flux_eb(
                      , flux_tmp[UMZ] = -q(iv, QPRES) * ebnorm[2];)
       } else {
         auto eos = pele::physics::PhysicsType::eos();
-        amrex::Real qtempl[5 + NUM_SPECIES] = {0.0};
-        amrex::Real spl[NUM_SPECIES] = {0.0};
+        amrex::Real qtempl[R_NUM] = {0.0};
+        amrex::Real* spl = &qtempl[R_Y];
         qtempl[R_UN] = -(AMREX_D_TERM(
           q(iv, QU) * ebnorm[0], +q(iv, QV) * ebnorm[1],
           +q(iv, QW) * ebnorm[2]));
@@ -263,14 +246,12 @@ pc_compute_hyp_mol_flux_eb(
 
         // Flip the velocity about the normal for the right state - will use
         // left  state for remainder of right state
-        amrex::Real qtempr[5 + NUM_SPECIES] = {0.0};
+        amrex::Real qtempr[R_NUM] = {0.0};
         qtempr[R_UN] = -1.0 * qtempl[R_UN];
 
         amrex::Real eos_state_rho = qtempl[R_RHO];
         amrex::Real eos_state_p = qtempl[R_P];
-        for (int n = 0; n < NUM_SPECIES; n++) {
-          spl[n] = qtempl[R_Y + n];
-        }
+
         amrex::Real eos_state_T;
         eos.RYP2T(eos_state_rho, spl, eos_state_p, eos_state_T);
         amrex::Real eos_state_e;
@@ -285,10 +266,10 @@ pc_compute_hyp_mol_flux_eb(
         qtempr[R_UT1] = qtempl[R_UT1];
         qtempr[R_UT2] = qtempl[R_UT2];
         qtempr[R_P] = qtempl[R_P];
-        amrex::Real spr[NUM_SPECIES] = {0.0};
-        for (int n = 0; n < NUM_SPECIES; n++) {
-          spr[n] = spl[n];
+        for (int n = R_ADV; n < R_NUM; n++) {
+          qtempr[n] = qtempl[n];
         }
+        amrex::Real* spr = &qtempr[R_Y];
         amrex::Real rhoe_r = rhoe_l;
         amrex::Real gamc_r = gamc_l;
 
@@ -318,7 +299,6 @@ pc_compute_hyp_mol_flux_eb(
             }
 #endif
 #if NUM_LIN > 0
-            const int R_LIN = R_Y + NUM_SPECIES + NUM_AUX;
             for (int n = 0; n < NUM_LIN; n++) {
               pc_cmpflx_passive(
                 ustar, qint_iu, qtempl[R_LIN + n], qtempr[R_LIN + n],
@@ -342,7 +322,6 @@ pc_compute_hyp_mol_flux_eb(
             }
 #endif
 #if NUM_LIN > 0
-            const int R_LIN = R_Y + NUM_SPECIES + NUM_AUX;
             for (int n = 0; n < NUM_LIN; n++) {
               pc_lax_cmpflx_passive(
                 qtempl[R_UN], qtempr[R_UN], 1., 1., qtempl[R_LIN + n],


### PR DESCRIPTION
- Move definition of indices used in MOL hyp flux calculations to be defined as macros in IndexDefines.H. otherwise these must be redefined 3 times, including in a user-specified function, which likely to introduce bugs
- In `pc_compute_hyp_mol_flux`, instead of defining `spr` and `spl` as new arrays that must be allocated and copied into, just point to the appropriate places in `qtempl` and `qtempr`. This cuts down on code and should be a bit more efficient.
- In `pc_compute_hyp_mol_flux_eb` do the same thing. Note that there is currently a bug where the `qtemp` arrays aren't sized to store ADV/AUX/LIN quantities, but the indexing used assumes does account for these quantities. This fortunately seems to not have caused issues, but is now fixed.
- Note that in the function `ProblemSpecificFunctions::problem_eb_state` we pass both `qtemp{l,r}` and `sp{l,r}` as arguments. This is redundant, but shouldn't hurt anything as long as users understand this.

@mjrahimi - can you verify that this updated version of the code works for the oxy-combustor case?