### PR TITLE
Fix some warnings

### DIFF
--- a/Source/LES.cpp
+++ b/Source/LES.cpp
@@ -159,19 +159,23 @@ computeTangentialVelDerivs(
   const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx)
 {
   BL_PROFILE("PeleC::pc_compute_tangential_vel_derivs()");
+#if AMREX_SPACEDIM == 3
   for (int dir = 0; dir < AMREX_SPACEDIM; dir++) {
     tander_ec[dir].resize(
       eboxes[dir], GradUtils::nCompTan, amrex::The_Async_Arena());
     tanders[dir] = tander_ec[dir].array();
     setV(eboxes[dir], GradUtils::nCompTan, tanders[dir], 0);
     const amrex::Real d1 = dir == 0 ? dx[1] : dx[0];
-    const amrex::Real d2 = dir == 2 ? dx[1] : AMREX_ARLIM_3D(dx)[2];
+    const amrex::Real d2 = dir == 2 ? dx[1] : dx[2];
     amrex::ParallelFor(
       eboxes[dir], [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
         pc_compute_tangential_vel_derivs(
           i, j, k, q_ar, dir, d1, d2, tanders[dir]);
       });
   }
+#else
+  amrex::Abort("computeTangentialVelDerivs: only supported in 3D");
+#endif
 }
 
 void

--- a/Source/LES.cpp
+++ b/Source/LES.cpp
@@ -174,6 +174,7 @@ computeTangentialVelDerivs(
       });
   }
 #else
+  amrex::ignore_unused(eboxes, tander_ec, tanders, q_ar, dx);
   amrex::Abort("computeTangentialVelDerivs: only supported in 3D");
 #endif
 }

--- a/Source/LES.cpp
+++ b/Source/LES.cpp
@@ -165,7 +165,7 @@ computeTangentialVelDerivs(
     tanders[dir] = tander_ec[dir].array();
     setV(eboxes[dir], GradUtils::nCompTan, tanders[dir], 0);
     const amrex::Real d1 = dir == 0 ? dx[1] : dx[0];
-    const amrex::Real d2 = dir == 2 ? dx[1] : dx[2];
+    const amrex::Real d2 = dir == 2 ? dx[1] : AMREX_ARLIM_3D(dx)[2];
     amrex::ParallelFor(
       eboxes[dir], [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
         pc_compute_tangential_vel_derivs(

--- a/Source/PeleC.H
+++ b/Source/PeleC.H
@@ -463,9 +463,6 @@ public:
   // Remove data at old time.
   void removeOldData() override;
 
-  // Passes some data about the grid
-  void setGridInfo();
-
   // Print information about energy budget.
   void do_energy_diagnostics();
 

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -615,64 +615,12 @@ PeleC::buildMetrics()
     geom.Domain(), geom.periodicity(), constants::level_mask_covered(),
     constants::level_mask_notcovered(), constants::level_mask_physbnd(),
     constants::level_mask_interior());
-
-  if (level == 0) {
-    setGridInfo();
-  }
 }
 
 void
 PeleC::setTimeLevel(amrex::Real time, amrex::Real dt_old, amrex::Real dt_new)
 {
   AmrLevel::setTimeLevel(time, dt_old, dt_new);
-}
-
-void
-PeleC::setGridInfo()
-{
-  // Send refinement data. We do it here
-  // because now the grids have been initialized and
-  // we need this data for setting up the problem.
-  // Note that this routine will always get called
-  // on level 0, even if we are doing a restart,
-  // so it is safe to put this here.
-  if (level == 0) {
-    const int max_level = parent->maxLevel();
-    const int nlevs = max_level + 1;
-    const int size = 3 * nlevs;
-
-    amrex::Vector<int> domlo_level(size);
-    amrex::Vector<int> domhi_level(size);
-
-    const int* domlo_coarse = geom.Domain().loVect();
-    const int* domhi_coarse = geom.Domain().hiVect();
-
-    for (int dir = 0; dir < 3; dir++) {
-      domlo_level[dir] = (AMREX_ARLIM_3D(domlo_coarse))[dir];
-      domhi_level[dir] = (AMREX_ARLIM_3D(domhi_coarse))[dir];
-    }
-
-    for (int lev = 1; lev <= max_level; lev++) {
-      amrex::IntVect ref_ratio = parent->refRatio(lev - 1);
-
-      // Note that we are explicitly calculating here what the
-      // data would be on refined levels rather than getting the
-      // data directly from those levels, because some potential
-      // refined levels may not exist at the beginning of the simulation.
-
-      for (int dir = 0; dir < 3; dir++) {
-        domlo_level[3 * lev + dir] = 0;
-        domhi_level[3 * lev + dir] = 0;
-      }
-      for (int dir = 0; dir < AMREX_SPACEDIM; dir++) {
-        int ncell = (domhi_level[3 * (lev - 1) + dir] -
-                     domlo_level[3 * (lev - 1) + dir] + 1) *
-                    ref_ratio[dir];
-        domlo_level[3 * lev + dir] = domlo_level[dir];
-        domhi_level[3 * lev + dir] = domlo_level[3 * lev + dir] + ncell - 1;
-      }
-    }
-  }
 }
 
 /*


### PR DESCRIPTION
#914 is failing with some new warnings relating to old code.

It looks like the `setGridInfo` function doesn't actually do anything and is just a holdover from old Fortran days. Unless I'm missing something, it only modifies local variables that fall out of scope at the end of the function. It is now causing a warning so I just deleted the whole thing. 

We only allow LES in 3D but is compiled in 2D as well and we get a warning because `dx[2]`  is referenced, which would be out of bounds. So instead use macros to just abort unless we're 3D. Solution with `AMREX_ARLIM_3D` didn't work because that only supports int arrays.