### PR TITLE
CI Updates - Include reference comparison

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,39 +332,42 @@ jobs:
           cd ${{runner.workspace}}/build-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}}; \
           ctest ${{matrix.ctest_args}} -VV --output-on-failure; \
           if [ $? -ne 0 ]; then exit 1; fi \
-      - name: Compare to Reference Case
+      - name: Checkout Reference Version
+        if: matrix.reference_comparison == 'ON'
         run : |
-          if [ "${{matrix.reference_comparison}}" == "ON" ]; then
-            printf "\n-------- Checking out Reference --------\n"; \
-            git remote add amrexcomb https://github.com/AMReX-Combustion/PeleC.git
-            git fetch amrexcomb development
-            git checkout amrexcomb/development
-            git submodule update --recursive
-            printf "\n-------- Confguring Reference --------\n"; \
-            cmake -B${{runner.workspace}}/build-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}}-reference \
-            -DCMAKE_INSTALL_PREFIX:PATH=${{runner.workspace}}/install-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}}-reference  \
-            -DCMAKE_BUILD_TYPE:STRING=${{matrix.build_type}} \
-            -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
-            -DPELE_DIM:STRING=${{matrix.dim}} \
-            -DPELE_ENABLE_MPI:BOOL=ON \
-            -DMPIEXEC_PREFLAGS:STRING=--oversubscribe \
-            -DPELE_ENABLE_FCOMPARE:BOOL=ON \
-            -DPELE_ENABLE_FCOMPARE_FOR_TESTS:BOOL=ON \
-            -DPELE_REFERENCE_GOLDS_DIRECTORY:STRING=${{runner.workspace}}/build-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}} \
-            -DPELE_ENABLE_MASA:BOOL=ON \
-            -DPELE_EXCLUDE_BUILD_IN_CI:BOOL=ON \
-            -DMASA_ROOT:PATH=${{runner.workspace}}/deps/install/MASA \
-            -DCMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache \
-            ${{github.workspace}}; \
-            if [ $? -ne 0 ]; then exit 1; fi; \
-            printf "\n-------- Building Reference --------\n"; \
-            cmake --build ${{runner.workspace}}/build-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}}-reference \
-            --parallel ${{env.NPROCS}}; \
-            printf "\n-------- Running Reference and Comparing--------\n"; \
-            cd ${{runner.workspace}}/build-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}}-reference; \
-            ctest ${{matrix.ctest_args}} -VV --output-on-failure; \
-            if [ $? -ne 0 ]; then exit 1; fi; \
-          fi
+          git remote add amrexcomb https://github.com/AMReX-Combustion/PeleC.git
+          git fetch amrexcomb development
+          git checkout amrexcomb/development
+          git submodule update --recursive
+      - name: Configure Reference Version
+        if: matrix.reference_comparison == 'ON'
+        run : |
+          cmake -B${{runner.workspace}}/build-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}}-reference \
+          -DCMAKE_INSTALL_PREFIX:PATH=${{runner.workspace}}/install-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}}-reference  \
+          -DCMAKE_BUILD_TYPE:STRING=${{matrix.build_type}} \
+          -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+          -DPELE_DIM:STRING=${{matrix.dim}} \
+          -DPELE_ENABLE_MPI:BOOL=ON \
+          -DMPIEXEC_PREFLAGS:STRING=--oversubscribe \
+          -DPELE_ENABLE_FCOMPARE:BOOL=ON \
+          -DPELE_ENABLE_FCOMPARE_FOR_TESTS:BOOL=ON \
+          -DPELE_REFERENCE_GOLDS_DIRECTORY:STRING=${{runner.workspace}}/build-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}} \
+          -DPELE_ENABLE_MASA:BOOL=ON \
+          -DPELE_EXCLUDE_BUILD_IN_CI:BOOL=ON \
+          -DMASA_ROOT:PATH=${{runner.workspace}}/deps/install/MASA \
+          -DCMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache \
+          ${{github.workspace}}; \
+          if [ $? -ne 0 ]; then exit 1; fi; \
+      - name: Build Reference Version
+        if: matrix.reference_comparison == 'ON'
+        run : |
+          cmake --build ${{runner.workspace}}/build-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}}-reference \
+          --parallel ${{env.NPROCS}}; \
+      - name: Run Reference Version and Compare Output
+        if: matrix.reference_comparison == 'ON'
+        run : |
+          ctest ${{matrix.ctest_args}} -VV --output-on-failure; \
+          if [ $? -ne 0 ]; then exit 1; fi; \
 
   GPU-Nvidia:
     name: GPU-CUDA

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,8 @@ jobs:
         exclude:
           - os: macos-latest
             build_type: Debug
+    env:
+      DO_REF_COMPARE: ${{matrix.reference_comparison == 'ON' && github.event_name != 'push'}}
     steps:
       - name: Clone
         uses: actions/checkout@v4
@@ -333,14 +335,14 @@ jobs:
           ctest ${{matrix.ctest_args}} -VV --output-on-failure; \
           if [ $? -ne 0 ]; then exit 1; fi \
       - name: Checkout Reference Version
-        if: matrix.reference_comparison == 'ON'
+        if: env.DO_REF_COMPARE == 'true'
         run : |
           git remote add amrexcomb https://github.com/AMReX-Combustion/PeleC.git
           git fetch amrexcomb development
           git checkout amrexcomb/development
           git submodule update --recursive
       - name: Configure Reference Version
-        if: matrix.reference_comparison == 'ON'
+        if: env.DO_REF_COMPARE == 'true'
         run : |
           cmake -B${{runner.workspace}}/build-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}}-reference \
           -DCMAKE_INSTALL_PREFIX:PATH=${{runner.workspace}}/install-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}}-reference  \
@@ -359,7 +361,7 @@ jobs:
           ${{github.workspace}}; \
           if [ $? -ne 0 ]; then exit 1; fi; \
       - name: Build Reference Version
-        if: matrix.reference_comparison == 'ON'
+        if: env.DO_REF_COMPARE == 'true'
         run : |
           ccache -z
             cmake --build ${{runner.workspace}}/build-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}}-reference \
@@ -368,7 +370,7 @@ jobs:
           ccache -s
           du -hs ${{matrix.ccache_cache}}
       - name: Test Reference and Compare
-        if: matrix.reference_comparison == 'ON'
+        if: env.DO_REF_COMPARE == 'true'
         run : |
           cd ${{runner.workspace}}/build-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}}-reference; \
           ctest ${{matrix.ctest_args}} -VV --output-on-failure; \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,11 +212,13 @@ jobs:
             comp: llvm
             procs: $(sysctl -n hw.ncpu)
             ccache_cache: /Users/runner/Library/Caches/ccache
+            reference_comparison: ON
           - os: ubuntu-24.04
             install_deps: sudo apt-get install -y libopenmpi-dev openmpi-bin libtool-bin
             comp: gnu
             procs: $(nproc)
             ccache_cache: ~/.cache/ccache
+            reference_comparison: OFF
           - build_type: Release
             ctest_args: -LE no-ci
             ccache_size: 250M
@@ -299,6 +301,8 @@ jobs:
           -DMPIEXEC_PREFLAGS:STRING=--oversubscribe \
           -DPELE_ENABLE_FCOMPARE_FOR_TESTS:BOOL=OFF \
           -DPELE_ENABLE_MASA:BOOL=ON \
+          -DPELE_SAVE_GOLDS:BOOL=${{matrix.reference_comparison}} \
+          -DPELE_SAVED_GOLDS_DIRECTORY=${{runner.workspace}}/build-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}} \
           -DPELE_EXCLUDE_BUILD_IN_CI:BOOL=ON \
           -DMASA_ROOT:PATH=${{runner.workspace}}/deps/install/MASA \
           -DCMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache \
@@ -331,6 +335,40 @@ jobs:
           cd ${{runner.workspace}}/build-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}}; \
           ctest ${{matrix.ctest_args}} -VV --output-on-failure; \
           if [ $? -ne 0 ]; then exit 1; fi \
+      - name: Compare to Reference Case
+        run : |
+          if [ "${{matrix.reference_comparison}}" == "ON" ]; then
+            printf "\n-------- Checking out Reference --------\n"; \
+            git remote add amrexcomb https://github.com/AMReX-Combustion/PeleC.git
+            git fetch amrexcomb development
+            git checkout amrexcomb/development
+            git submodule update --recursive
+            printf "\n-------- Confguring Reference --------\n"; \
+            cmake -B${{runner.workspace}}/build-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}}-reference \
+            -DCMAKE_INSTALL_PREFIX:PATH=${{runner.workspace}}/install-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}}-reference  \
+            -DCMAKE_BUILD_TYPE:STRING=${{matrix.build_type}} \
+            -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+            -DPELE_DIM:STRING=${{matrix.dim}} \
+            -DPELE_ENABLE_MPI:BOOL=ON \
+            -DMPIEXEC_PREFLAGS:STRING=--oversubscribe \
+            -DPELE_ENABLE_FCOMPARE:BOOL=ON \
+            -DPELE_ENABLE_FCOMPARE_FOR_TESTS:BOOL=ON \
+            -DPELE_REFERENCE_GOLDS_DIRECTORY:STRING=${{runner.workspace}}/build-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}} \
+            -DPELE_ENABLE_MASA:BOOL=ON \
+            -DPELE_EXCLUDE_BUILD_IN_CI:BOOL=ON \
+            -DMASA_ROOT:PATH=${{runner.workspace}}/deps/install/MASA \
+            -DCMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache \
+            ${{github.workspace}}; \
+            if [ $? -ne 0 ]; then exit 1; fi; \
+            printf "\n-------- Building Reference --------\n"; \
+            cmake --build ${{runner.workspace}}/build-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}}-reference \
+            --parallel ${{env.NPROCS}}; \
+            printf "\n-------- Running Reference and Comparing--------\n"; \
+            cd ${{runner.workspace}}/build-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}}-reference; \
+            ctest ${{matrix.ctest_args}} -VV --output-on-failure; \
+            if [ $? -ne 0 ]; then exit 1; fi; \
+          fi
+
   GPU-Nvidia:
     name: GPU-CUDA
     needs: [Formatting, CPU-GNUmake]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,7 +367,7 @@ jobs:
           if [ ${PIPESTATUS[0]} -ne 0 ]; then exit 1; fi; \
           ccache -s
           du -hs ${{matrix.ccache_cache}}
-      - name: Run Reference Version and Compare Output
+      - name: Test Reference and Compare
         if: matrix.reference_comparison == 'ON'
         run : |
           cd ${{runner.workspace}}/build-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}}-reference; \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,7 +291,6 @@ jobs:
           make install
       - name: Configure
         run: |
-          printf "\n-------- Configuring --------\n"; \
           cmake -B${{runner.workspace}}/build-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}} \
           -DCMAKE_INSTALL_PREFIX:PATH=${{runner.workspace}}/install-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}} \
           -DCMAKE_BUILD_TYPE:STRING=${{matrix.build_type}} \
@@ -311,7 +310,6 @@ jobs:
       - name: Build
         run: |
           ccache -z
-          printf "\n-------- Building --------\n"; \
             cmake --build ${{runner.workspace}}/build-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}} \
             --parallel ${{env.NPROCS}} 2>&1 | tee -a ${{runner.workspace}}/build-output.txt; \
           if [ ${PIPESTATUS[0]} -ne 0 ]; then exit 1; fi \
@@ -331,7 +329,6 @@ jobs:
           exit ${return}
       - name: Test
         run: |
-          printf "\n-------- Testing --------\n"; \
           cd ${{runner.workspace}}/build-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}}; \
           ctest ${{matrix.ctest_args}} -VV --output-on-failure; \
           if [ $? -ne 0 ]; then exit 1; fi \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04, macos-latest]
         build_type: [Release, Debug]
+        dim: [2, 3]
         include:
           - os: macos-latest
             install_deps: brew install open-mpi libtool automake ccache
@@ -288,32 +289,28 @@ jobs:
           make install
       - name: Configure
         run: |
-          (for DIM in 2 3; do \
-            printf "\n-------- Configuring ${DIM}D --------\n"; \
-            cmake -B${{runner.workspace}}/build-${DIM}d-${{matrix.os}}-${{matrix.build_type}} \
-            -DCMAKE_INSTALL_PREFIX:PATH=${{runner.workspace}}/install-${DIM}d-${{matrix.os}}-${{matrix.build_type}} \
-            -DCMAKE_BUILD_TYPE:STRING=${{matrix.build_type}} \
-            -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
-            -DPELE_DIM:STRING=${DIM} \
-            -DPELE_ENABLE_MPI:BOOL=ON \
-            -DMPIEXEC_PREFLAGS:STRING=--oversubscribe \
-            -DPELE_ENABLE_FCOMPARE_FOR_TESTS:BOOL=OFF \
-            -DPELE_ENABLE_MASA:BOOL=ON \
-            -DPELE_EXCLUDE_BUILD_IN_CI:BOOL=ON \
-            -DMASA_ROOT:PATH=${{runner.workspace}}/deps/install/MASA \
-            -DCMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache \
-            ${{github.workspace}}; \
-            if [ $? -ne 0 ]; then exit 1; fi \
-          done)
+          printf "\n-------- Configuring --------\n"; \
+          cmake -B${{runner.workspace}}/build-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}} \
+          -DCMAKE_INSTALL_PREFIX:PATH=${{runner.workspace}}/install-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}} \
+          -DCMAKE_BUILD_TYPE:STRING=${{matrix.build_type}} \
+          -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+          -DPELE_DIM:STRING=${{matrix.dim}} \
+          -DPELE_ENABLE_MPI:BOOL=ON \
+          -DMPIEXEC_PREFLAGS:STRING=--oversubscribe \
+          -DPELE_ENABLE_FCOMPARE_FOR_TESTS:BOOL=OFF \
+          -DPELE_ENABLE_MASA:BOOL=ON \
+          -DPELE_EXCLUDE_BUILD_IN_CI:BOOL=ON \
+          -DMASA_ROOT:PATH=${{runner.workspace}}/deps/install/MASA \
+          -DCMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache \
+          ${{github.workspace}}; \
+          if [ $? -ne 0 ]; then exit 1; fi \
       - name: Build
         run: |
           ccache -z
-          (for DIM in 2 3; do \
-            printf "\n-------- Building ${DIM}D --------\n"; \
-              cmake --build ${{runner.workspace}}/build-${DIM}d-${{matrix.os}}-${{matrix.build_type}} \
-              --parallel ${{env.NPROCS}} 2>&1 | tee -a ${{runner.workspace}}/build-output.txt; \
-            if [ ${PIPESTATUS[0]} -ne 0 ]; then exit 1; fi \
-          done)
+          printf "\n-------- Building --------\n"; \
+            cmake --build ${{runner.workspace}}/build-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}} \
+            --parallel ${{env.NPROCS}} 2>&1 | tee -a ${{runner.workspace}}/build-output.txt; \
+          if [ ${PIPESTATUS[0]} -ne 0 ]; then exit 1; fi \
       - name: Ccache Report
         run: |
           ccache -s
@@ -330,12 +327,10 @@ jobs:
           exit ${return}
       - name: Test
         run: |
-          (for DIM in 2 3; do \
-            printf "\n-------- Testing ${DIM}D --------\n"; \
-            cd ${{runner.workspace}}/build-${DIM}d-${{matrix.os}}-${{matrix.build_type}}; \
-            ctest ${{matrix.ctest_args}} -VV --output-on-failure; \
-            if [ $? -ne 0 ]; then exit 1; fi \
-          done)
+          printf "\n-------- Testing --------\n"; \
+          cd ${{runner.workspace}}/build-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}}; \
+          ctest ${{matrix.ctest_args}} -VV --output-on-failure; \
+          if [ $? -ne 0 ]; then exit 1; fi \
   GPU-Nvidia:
     name: GPU-CUDA
     needs: [Formatting, CPU-GNUmake]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,6 +366,7 @@ jobs:
       - name: Run Reference Version and Compare Output
         if: matrix.reference_comparison == 'ON'
         run : |
+          cd ${{runner.workspace}}/build-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}}-reference; \
           ctest ${{matrix.ctest_args}} -VV --output-on-failure; \
           if [ $? -ne 0 ]; then exit 1; fi; \
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,9 +266,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{matrix.ccache_cache}}
-          key: ccache-${{github.workflow}}-${{github.job}}-${{matrix.os}}-${{matrix.build_type}}-git-${{github.sha}}
+          key: ccache-${{github.workflow}}-${{github.job}}-${{matrix.os}}-${{matrix.dim}}-${{matrix.build_type}}-git-${{github.sha}}
           restore-keys: |
-               ccache-${{github.workflow}}-${{github.job}}-${{matrix.os}}-${{matrix.build_type}}-git-
+               ccache-${{github.workflow}}-${{github.job}}-${{matrix.os}}-${{matrix.dim}}-${{matrix.build_type}}-git-
       - name: MASA
         run: |
           # Install MetaPhysicL
@@ -361,8 +361,12 @@ jobs:
       - name: Build Reference Version
         if: matrix.reference_comparison == 'ON'
         run : |
-          cmake --build ${{runner.workspace}}/build-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}}-reference \
-          --parallel ${{env.NPROCS}}; \
+          ccache -z
+            cmake --build ${{runner.workspace}}/build-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}}-reference \
+            --parallel ${{env.NPROCS}}; \
+          if [ ${PIPESTATUS[0]} -ne 0 ]; then exit 1; fi \
+          ccache -s
+          du -hs ${{matrix.ccache_cache}}
       - name: Run Reference Version and Compare Output
         if: matrix.reference_comparison == 'ON'
         run : |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,7 +364,7 @@ jobs:
           ccache -z
             cmake --build ${{runner.workspace}}/build-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}}-reference \
             --parallel ${{env.NPROCS}}; \
-          if [ ${PIPESTATUS[0]} -ne 0 ]; then exit 1; fi \
+          if [ ${PIPESTATUS[0]} -ne 0 ]; then exit 1; fi; \
           ccache -s
           du -hs ${{matrix.ccache_cache}}
       - name: Run Reference Version and Compare Output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,8 +307,7 @@ jobs:
           -DPELE_EXCLUDE_BUILD_IN_CI:BOOL=ON \
           -DMASA_ROOT:PATH=${{runner.workspace}}/deps/install/MASA \
           -DCMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache \
-          ${{github.workspace}}; \
-          if [ $? -ne 0 ]; then exit 1; fi \
+          ${{github.workspace}}
       - name: Build
         run: |
           ccache -z
@@ -330,17 +329,16 @@ jobs:
           export return=$(tail -n 1 ${{runner.workspace}}/build-output-warnings.txt | awk '{print $2}')
           exit ${return}
       - name: Test
+        working-directory: ${{runner.workspace}}/build-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}}
         run: |
-          cd ${{runner.workspace}}/build-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}}; \
-          ctest ${{matrix.ctest_args}} -VV --output-on-failure; \
-          if [ $? -ne 0 ]; then exit 1; fi \
+          ctest ${{matrix.ctest_args}} -VV --output-on-failure
       - name: Checkout Reference Version
         if: env.DO_REF_COMPARE == 'true'
         run : |
           git remote add amrexcomb https://github.com/AMReX-Combustion/PeleC.git
-          git fetch amrexcomb development
+          git fetch amrexcomb development --depth=1
           git checkout amrexcomb/development
-          git submodule update --recursive
+          git submodule update --recursive --depth=1
       - name: Configure Reference Version
         if: env.DO_REF_COMPARE == 'true'
         run : |
@@ -358,23 +356,20 @@ jobs:
           -DPELE_EXCLUDE_BUILD_IN_CI:BOOL=ON \
           -DMASA_ROOT:PATH=${{runner.workspace}}/deps/install/MASA \
           -DCMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache \
-          ${{github.workspace}}; \
-          if [ $? -ne 0 ]; then exit 1; fi; \
+          ${{github.workspace}}
       - name: Build Reference Version
         if: env.DO_REF_COMPARE == 'true'
         run : |
           ccache -z
             cmake --build ${{runner.workspace}}/build-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}}-reference \
-            --parallel ${{env.NPROCS}}; \
-          if [ ${PIPESTATUS[0]} -ne 0 ]; then exit 1; fi; \
+            --parallel ${{env.NPROCS}}
           ccache -s
           du -hs ${{matrix.ccache_cache}}
       - name: Test Reference and Compare
         if: env.DO_REF_COMPARE == 'true'
+        working-directory: ${{runner.workspace}}/build-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}}-reference
         run : |
-          cd ${{runner.workspace}}/build-${{matrix.dim}}d-${{matrix.os}}-${{matrix.build_type}}-reference; \
-          ctest ${{matrix.ctest_args}} -VV --output-on-failure; \
-          if [ $? -ne 0 ]; then exit 1; fi; \
+          ctest ${{matrix.ctest_args}} -VV --output-on-failure
 
   GPU-Nvidia:
     name: GPU-CUDA

--- a/Exec/RegTests/PMF/pmf-lidryer-arkode.inp
+++ b/Exec/RegTests/PMF/pmf-lidryer-arkode.inp
@@ -51,7 +51,7 @@ pelec.plot_massfrac = 1
 # PROBLEM PARAMETERS
 prob.pamb = 1013250.0
 prob.phi_in = -0.5
-prob.pertmag = 0.01
+prob.pertmag = 0.005
 prob.pmf_datafile = "LiDryer_H2_p1_phi0_4000tu0300.dat"
 
 tagging.max_ftracerr_lev = 4

--- a/Exec/RegTests/PMF/pmf-lidryer-arkode.inp
+++ b/Exec/RegTests/PMF/pmf-lidryer-arkode.inp
@@ -51,7 +51,7 @@ pelec.plot_massfrac = 1
 # PROBLEM PARAMETERS
 prob.pamb = 1013250.0
 prob.phi_in = -0.5
-prob.pertmag = 0.005
+prob.pertmag = 0.01
 prob.pmf_datafile = "LiDryer_H2_p1_phi0_4000tu0300.dat"
 
 tagging.max_ftracerr_lev = 4

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -57,7 +57,7 @@ macro(setup_test)
 
     # Set some default runtime options for all tests
     set(RUNTIME_OPTIONS "amr.checkpoint_files_output=0 amrex.the_arena_is_managed=0")
-    if(PELE_ENABLE_FCOMPARE_FOR_TESTS)
+    if(PELE_ENABLE_FCOMPARE_FOR_TESTS OR PELE_SAVE_GOLDS)
       set(RUNTIME_OPTIONS "${RUNTIME_OPTIONS} amr.plot_files_output=1 amr.plot_int=10 amr.plot_file=plt")
     else()
       set(RUNTIME_OPTIONS "${RUNTIME_OPTIONS} amr.plot_files_output=0")


### PR DESCRIPTION
With nightly tests not running regularly, it's possible new PRs could be changing behavior without us realizing. The goal here is to add a comparison of simulation output to the current development branch as part of the CI. 

This is done in a similar manner to the PeleLMeX unit tests: by checking out and building a reference copy of PeleLMeX and re-running reference cases for comparison as part of the CI. But here, we use CMake and the capability for comparison to gold files. This definitely isn't the most computationally efficient approach relative to storing gold files, but it is easy to implement and isn't horrible. It is only done for the macos-release test run.

To keep overall time for testing down, I split the 2D and 3D tests accross different runners so that they can go in parallel.

@jrood-nrel: I ignored ccache stuff in this implementation because I don't really understand how it works, but maybe that could help accelerate this?

The second to last commit in this PR has a change that causes the reference plotfile test to fail as a demonstration. That change is reverted in the final commit, showing the expected behavior where all comparisons pass.