### PR TITLE
fixes for AMReX changing mpi namespaces around

### DIFF
--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -15,6 +15,8 @@
 #include "PeleC.H"
 #include "PeleCAmr.H"
 
+using namespace amrex::mpidatatypes;
+
 std::string inputs_name;
 
 void initialize_EB2(


### PR DESCRIPTION
Updates PelePhysics to get the newer AMReX and makes necessary modification due to AMReX MPI namespace changes