### PR TITLE
correct index for populating turbfluc on high boundaries

### DIFF
--- a/Source/BCfill.cpp
+++ b/Source/BCfill.cpp
@@ -115,7 +115,7 @@ struct PCHypFillExtDir
         }
 
         // turbulent fluctuations
-        if (m_do_turb_inflow && (iv[idir] == domlo[idir] - 1)) {
+        if (m_do_turb_inflow && (iv[idir] == domhi[idir] + 1)) {
           for (int n = 0; n < AMREX_SPACEDIM; n++) {
             turb_fluc[n] = dest(iv, UMX + n);
           }


### PR DESCRIPTION
It appears there was an uncaught copy/paste error in #665. When populating turbulent fluctuations from the TurbInflow utility on high boundaries, we do an index check that for the low boundary instead. This fixes that.

@Alex-jian522 please confirm this resolves the turbulent inflow issue that you were seeing.

Closes #973 

