### PR TITLE
Be explicit about amrex max and min for ints

### DIFF
--- a/Source/Advance.cpp
+++ b/Source/Advance.cpp
@@ -91,8 +91,7 @@ PeleC::do_mol_advance(
   int nGrow_FP_border = numGrow() + nGrowF;
 #ifdef PELE_USE_SPRAY
   const int spray_state_ghosts = sprayStateGhosts(amr_ncycle);
-  nGrow_FP_border =
-    amrex::max<amrex::Real>(nGrow_FP_border, spray_state_ghosts);
+  nGrow_FP_border = amrex::max<int>(nGrow_FP_border, spray_state_ghosts);
   AMREX_ASSERT(Sborder.nGrow() >= nGrow_FP_border);
 #endif
 
@@ -267,8 +266,7 @@ PeleC::do_sdc_iteration(
   if (do_spray_particles) {
     const int spray_state_ghosts = sprayStateGhosts(amr_ncycle);
     fill_Sborder = true;
-    nGrow_FP_border =
-      amrex::max<amrex::Real>(nGrow_FP_border, spray_state_ghosts);
+    nGrow_FP_border = amrex::max<int>(nGrow_FP_border, spray_state_ghosts);
     AMREX_ASSERT(Sborder.nGrow() >= nGrow_FP_border);
   }
 #endif
@@ -325,7 +323,7 @@ PeleC::do_sdc_iteration(
   if (do_diffuse || do_spray_particles) {
     int nGrowDiff = numGrow();
     if (do_spray_particles && level > 0) {
-      nGrowDiff = amrex::max<amrex::Real>(nGrowDiff, nGrow_FP_border);
+      nGrowDiff = amrex::max<int>(nGrowDiff, nGrow_FP_border);
     }
     FillPatcherFill(Sborder, 0, NVAR, nGrowDiff, time + dt, State_Type, 0);
   }

--- a/Source/Advance.cpp
+++ b/Source/Advance.cpp
@@ -91,7 +91,8 @@ PeleC::do_mol_advance(
   int nGrow_FP_border = numGrow() + nGrowF;
 #ifdef PELE_USE_SPRAY
   const int spray_state_ghosts = sprayStateGhosts(amr_ncycle);
-  nGrow_FP_border = amrex::max(nGrow_FP_border, spray_state_ghosts);
+  nGrow_FP_border =
+    amrex::max<amrex::Real>(nGrow_FP_border, spray_state_ghosts);
   AMREX_ASSERT(Sborder.nGrow() >= nGrow_FP_border);
 #endif
 
@@ -266,7 +267,8 @@ PeleC::do_sdc_iteration(
   if (do_spray_particles) {
     const int spray_state_ghosts = sprayStateGhosts(amr_ncycle);
     fill_Sborder = true;
-    nGrow_FP_border = amrex::max(nGrow_FP_border, spray_state_ghosts);
+    nGrow_FP_border =
+      amrex::max<amrex::Real>(nGrow_FP_border, spray_state_ghosts);
     AMREX_ASSERT(Sborder.nGrow() >= nGrow_FP_border);
   }
 #endif
@@ -323,7 +325,7 @@ PeleC::do_sdc_iteration(
   if (do_diffuse || do_spray_particles) {
     int nGrowDiff = numGrow();
     if (do_spray_particles && level > 0) {
-      nGrowDiff = amrex::max(nGrowDiff, nGrow_FP_border);
+      nGrowDiff = amrex::max<amrex::Real>(nGrowDiff, nGrow_FP_border);
     }
     FillPatcherFill(Sborder, 0, NVAR, nGrowDiff, time + dt, State_Type, 0);
   }

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -480,7 +480,7 @@ PeleC::PeleC(
 #ifdef PELE_USE_SPRAY
   if (do_spray_particles) {
     if (level > 0) {
-      nGrowS = amrex::max<amrex::Real>(
+      nGrowS = amrex::max<int>(
         nGrowS, sprayStateGhosts(parent->MaxRefRatio(level - 1)));
       defineSpraySource(parent->MaxRefRatio(level - 1));
     } else {

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -480,8 +480,8 @@ PeleC::PeleC(
 #ifdef PELE_USE_SPRAY
   if (do_spray_particles) {
     if (level > 0) {
-      nGrowS =
-        amrex::max(nGrowS, sprayStateGhosts(parent->MaxRefRatio(level - 1)));
+      nGrowS = amrex::max<amrex::Real>(
+        nGrowS, sprayStateGhosts(parent->MaxRefRatio(level - 1)));
       defineSpraySource(parent->MaxRefRatio(level - 1));
     } else {
       defineSpraySource(1);


### PR DESCRIPTION
I think we shouldn't have any `amrex::max` or `amrex::min` without a specialization.