### PR TITLE
move check on diagnostic variables to it runs after they are initialized

### DIFF
--- a/Exec/RegTests/EB-ConvergingNozzle/example.inp
+++ b/Exec/RegTests/EB-ConvergingNozzle/example.inp
@@ -96,4 +96,4 @@ pelec.zPlane.file = pltzcut
 pelec.zPlane.normal = 2
 pelec.zPlane.center = 0.0
 pelec.zPlane.int = 100
-pelec.zPlane.field_names = vfrac density zmom xmom Temp z_velocity y_velocity x_velocity Y(H2) Y(HO2) pressure MachNumber magvel viscosity conductivity
+pelec.zPlane.field_names = density zmom xmom Temp z_velocity y_velocity x_velocity pressure MachNumber magvel viscosity conductivity

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -2011,6 +2011,22 @@ PeleC::init_diagnostics()
       m_diagnostics[n]->init(diag_prefix, diags[n]);
       m_diagnostics[n]->addVars(m_diagVars);
     }
+    // Remove duplicates from m_diagVars and check that all the variables exists
+    std::sort(m_diagVars.begin(), m_diagVars.end());
+    auto last = std::unique(m_diagVars.begin(), m_diagVars.end());
+    m_diagVars.erase(last, m_diagVars.end());
+    int index = 0;
+    int scomp = 0;
+    for (auto& v : m_diagVars) {
+      const bool itexists =
+        derive_lst.canDerive(v) || isStateVariable(v, index, scomp);
+      amrex::Print() << v << " is a diagvar and it "
+                     << (itexists ? "exists" : "does not exist") << std::endl;
+      if (!itexists) {
+        amrex::Abort(
+          "PeleC::init_diagnostics(): Field " + v + " is not available");
+      }
+    }
   }
 }
 

--- a/Source/PeleC.cpp
+++ b/Source/PeleC.cpp
@@ -2011,17 +2011,15 @@ PeleC::init_diagnostics()
       m_diagnostics[n]->init(diag_prefix, diags[n]);
       m_diagnostics[n]->addVars(m_diagVars);
     }
-    // Remove duplicates from m_diagVars and check that all the variables exists
+    // Remove duplicates from m_diagVars and check that all the variables exist
     std::sort(m_diagVars.begin(), m_diagVars.end());
     auto last = std::unique(m_diagVars.begin(), m_diagVars.end());
     m_diagVars.erase(last, m_diagVars.end());
     int index = 0;
     int scomp = 0;
     for (auto& v : m_diagVars) {
-      const bool itexists =
-        derive_lst.canDerive(v) || isStateVariable(v, index, scomp);
-      amrex::Print() << v << " is a diagvar and it "
-                     << (itexists ? "exists" : "does not exist") << std::endl;
+      const bool itexists = derive_lst.canDerive(v) ||
+                            isStateVariable(v, index, scomp) || v == "vfrac";
       if (!itexists) {
         amrex::Abort(
           "PeleC::init_diagnostics(): Field " + v + " is not available");
@@ -2090,14 +2088,16 @@ PeleC::do_diagnostics()
           1);
         for (int v{0}; v < m_diagVars.size(); ++v) {
           // Already tested: either a derive or a state variable
-          if (derive_lst.canDerive(m_diagVars[v])) {
+          if (derive_lst.canDerive(m_diagVars[v]) || m_diagVars[v] == "vfrac") {
             auto mf = amrlevel.derive(m_diagVars[v], cumtime, 1);
-            const amrex::DeriveRec* rec = derive_lst.get(m_diagVars[v]);
             int varIdx{0};
-            for (int vd{0}; vd < rec->numDerive(); ++vd) {
-              if (m_diagVars[v] == rec->variableName(vd)) {
-                varIdx = vd;
-                break;
+            if (derive_lst.canDerive(m_diagVars[v])) {
+              const amrex::DeriveRec* rec = derive_lst.get(m_diagVars[v]);
+              for (int vd{0}; vd < rec->numDerive(); ++vd) {
+                if (m_diagVars[v] == rec->variableName(vd)) {
+                  varIdx = vd;
+                  break;
+                }
               }
             }
             amrex::MultiFab::Copy(*diagMFVec[lev], *mf, varIdx, v, 1, 1);

--- a/Source/Setup.cpp
+++ b/Source/Setup.cpp
@@ -689,20 +689,6 @@ PeleC::variableSetUp()
 #endif
 
   read_tagging_params();
-
-  // Remove duplicates from m_diagVars and check that all the variables exists
-  std::sort(m_diagVars.begin(), m_diagVars.end());
-  auto last = std::unique(m_diagVars.begin(), m_diagVars.end());
-  m_diagVars.erase(last, m_diagVars.end());
-  int index = 0;
-  int scomp = 0;
-  for (auto& v : m_diagVars) {
-    const bool itexists =
-      derive_lst.canDerive(v) || isStateVariable(v, index, scomp);
-    if (!itexists) {
-      amrex::Abort("Field " + v + " is not available");
-    }
-  }
 }
 
 void


### PR DESCRIPTION
Right now, the vector of diagnositcs variables is checked for duplicates and to ensure all variables exists before the vector is actually populated. Move this check to just after when the vector gets populated.