### PR TITLE
included reset functions for ghost and virtual particle containers

### DIFF
--- a/Source/Setup.cpp
+++ b/Source/Setup.cpp
@@ -710,6 +710,8 @@ PeleC::variableCleanUp()
 #ifdef PELE_USE_SPRAY
   SprayParticleContainer::SprayCleanUp();
   SprayPC.reset();
+  GhostPC.reset();
+  VirtPC.reset();
 #endif
 #ifdef PELE_USE_SOOT
   soot_model.cleanup();


### PR DESCRIPTION
Problem: I get the following warning after PeleLMeX run is complete (signalled by AMReX finalize call)
```pure virtual method called```
```terminate called without an active exception```
Dependency: Should be used with PelePhysics PR#650, PeleLMeX PR#621
Issue: For some reason, on HIP, the spray particle containers are called by process exit handlers after AMreX finalize call, which results in double freeing and hence the error message
Solution: Enforcing all spray particle containers are destroyed before the AMReX finalize call